### PR TITLE
Benchmark tooling for quantitative evaluation of code changes

### DIFF
--- a/sw/.gitignore
+++ b/sw/.gitignore
@@ -51,6 +51,7 @@ coverage.xml
 .pytest_cache/
 cover/
 /tests/output/
+/output/
 
 # Translations
 *.mo

--- a/sw/README.md
+++ b/sw/README.md
@@ -146,6 +146,18 @@ been time-synced:
 They expect a dataset folder containing `raw_videos/` and a `time sync/` subfolder. See
 [`evaluation/README.md`](evaluation/README.md) for the dataset layout and the full argument list.
 
+## Benchmarking
+`rocsync/benchmark/` measures the vision pipeline against a folder of validation images:
+
+| Tool | Purpose |
+| --- | --- |
+| `annotate.py` | Interactive GUI for building a `ground_truth.json` from validation images |
+| `validate.py` | Run the pipeline over every image and record what it decoded, with per-step timings |
+| `evaluate.py` | Score a validation run against the ground truth and report where it fails |
+
+See [`rocsync/benchmark/README.md`](rocsync/benchmark/README.md) for the annotation shortcuts and
+the full argument list.
+
 ## Development
 Everyone works against the same pinned environment, described by `pyproject.toml` and locked in
 `uv.lock`. Create it with:

--- a/sw/README.md
+++ b/sw/README.md
@@ -154,8 +154,8 @@ every frame of a video counting as one benchmark frame:
 | Tool | Purpose |
 | --- | --- |
 | `annotate.py` | Interactive GUI for building a `ground_truth.json` from validation frames |
-| `validate.py` | Run the pipeline over every frame and record what it decoded, with per-step timings |
-| `evaluate.py` | Score a validation run against the ground truth and report where it fails |
+| `validate.py` | Run the pipeline over every frame and record what it decoded, with per-step timings, then fit each video's clock |
+| `evaluate.py` | Score a validation run against the ground truth and report where it fails, per frame and per fitted clock |
 
 See [`rocsync/benchmark/README.md`](rocsync/benchmark/README.md) for the annotation shortcuts and
 the full argument list.

--- a/sw/README.md
+++ b/sw/README.md
@@ -19,7 +19,8 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 Then install RocSync as a tool, which puts the `rocsync` and `rocsync-align` commands on your
-`PATH` in their own isolated environment:
+`PATH` in their own isolated environment (the `rocsync-annotate`, `rocsync-validate`, and
+`rocsync-evaluate` benchmark tools come along with them):
 
 ```bash
 git clone https://github.com/jaromeyer/RocSync.git

--- a/sw/README.md
+++ b/sw/README.md
@@ -154,6 +154,7 @@ every frame of a video counting as one benchmark frame:
 | Tool | Purpose |
 | --- | --- |
 | `annotate.py` | Interactive GUI for building a `ground_truth.json` from validation frames |
+| `retime.py` | Remux a clip onto a clock built from its annotations, so the timing a benchmark run has to recover is known exactly rather than fitted |
 | `validate.py` | Run the pipeline over every frame and record what it decoded, with per-step timings, then fit each video's clock |
 | `evaluate.py` | Score a validation run against the ground truth and report where it fails, per frame and per fitted clock |
 

--- a/sw/README.md
+++ b/sw/README.md
@@ -148,12 +148,13 @@ They expect a dataset folder containing `raw_videos/` and a `time sync/` subfold
 [`evaluation/README.md`](evaluation/README.md) for the dataset layout and the full argument list.
 
 ## Benchmarking
-`rocsync/benchmark/` measures the vision pipeline against a folder of validation images:
+`rocsync/benchmark/` measures the vision pipeline against a folder of validation images and videos,
+every frame of a video counting as one benchmark frame:
 
 | Tool | Purpose |
 | --- | --- |
-| `annotate.py` | Interactive GUI for building a `ground_truth.json` from validation images |
-| `validate.py` | Run the pipeline over every image and record what it decoded, with per-step timings |
+| `annotate.py` | Interactive GUI for building a `ground_truth.json` from validation frames |
+| `validate.py` | Run the pipeline over every frame and record what it decoded, with per-step timings |
 | `evaluate.py` | Score a validation run against the ground truth and report where it fails |
 
 See [`rocsync/benchmark/README.md`](rocsync/benchmark/README.md) for the annotation shortcuts and

--- a/sw/pyproject.toml
+++ b/sw/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
 [project.scripts]
 rocsync = "rocsync.main:main"
 rocsync-align = "rocsync.helpers.align:main"
+rocsync-annotate = "rocsync.benchmark.annotate:main"
+rocsync-validate = "rocsync.benchmark.validate:main"
+rocsync-evaluate = "rocsync.benchmark.evaluate:main"
 
 [dependency-groups]
 dev = ["basedpyright>=1.39", "pytest>=9.1.1", "ruff>=0.16.3"]

--- a/sw/pyproject.toml
+++ b/sw/pyproject.toml
@@ -28,11 +28,13 @@ dependencies = [
 rocsync = "rocsync.main:main"
 rocsync-align = "rocsync.helpers.align:main"
 rocsync-annotate = "rocsync.benchmark.annotate:main"
+rocsync-retime = "rocsync.benchmark.retime:main"
 rocsync-validate = "rocsync.benchmark.validate:main"
 rocsync-evaluate = "rocsync.benchmark.evaluate:main"
 
 [dependency-groups]
-dev = ["basedpyright>=1.39", "pytest>=9.1.1", "ruff>=0.16.3"]
+# av only powers rocsync-retime, which authors benchmark datasets from a checkout
+dev = ["av>=12", "basedpyright>=1.39", "pytest>=9.1.1", "ruff>=0.16.3"]
 
 [tool.setuptools]
 # Only the library ships; tests/ and evaluation/ stay out of site-packages

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -6,7 +6,9 @@ videos.
 Inputs are collected recursively: images (`.png`, `.jpg`, `.jpeg`) and videos (`.mp4`, `.mov`,
 `.avi`, `.mkv`). **Every frame of a video is a benchmark frame** — video frames are decoded on
 demand, so nothing is extracted to disk. A dataset should hold a video *or* its extracted frames,
-not both, or the same content is benchmarked twice under two sets of keys.
+not both, or the same content is benchmarked twice under two sets of keys. A
+[retimed clip](#retimed-videos) is the one exception: it sits beside its source and shadows it,
+so validation and scoring see one of the two and annotation the other.
 
 These are development tools: they run against a checkout, not an installed copy. Create the
 environment once with `uv sync` from `RocSync/sw`, then prefix each command with `uv run` to use
@@ -48,7 +50,7 @@ fit 54 frames  RMSE 0.21  max 0.63 ms
 ```
 
 `dt` is how far the annotated timestamp sits from where the rest of the video puts this
-frame, green within the 2 ms tolerance and red beyond it. The clock behind it is fitted
+frame, green within [the video's tolerance](#ground-truth-format) and red beyond it. The clock behind it is fitted
 over the video's *other* annotated frames and asked to predict this one, so a frame cannot
 drag the line towards itself and hide half its own error. It reads the annotation on screen
 rather than the saved one, so a correction shows in the number before it is accepted.
@@ -125,6 +127,7 @@ presentation time to board time that the video's annotations agree on:
   "images": {"...": "..."},
   "videos": {
     "subdir/clip.mp4": {
+      "timeline": "measured",
       "clock_rate": 1.0000743,
       "clock_offset_ms": -4333.21,
       "pts_min_ms": 0.0,
@@ -132,8 +135,18 @@ presentation time to board time that the video's annotations agree on:
       "n_frames_fitted": 54,
       "rmse_ms": 0.21,
       "max_residual_ms": 0.63,
-      "residual_threshold_ms": 2.0,
+      "residual_threshold_ms": 11.111,
+      "source_frame_period_ms": 33.333,
       "derived_at": "2026-08-18T09:12:00+00:00"
+    },
+    "subdir/clip.retimed.mp4": {
+      "timeline": "synthesized",
+      "source": "subdir/clip.mp4",
+      "source_frame_offset": 0,
+      "anchors_digest": "sha256:9f2c1a4b7d3e5068",
+      "n_frames": 72,
+      "residual_threshold_ms": 2.0,
+      "...": "same clock fields as above"
     }
   }
 }
@@ -150,19 +163,113 @@ Fields:
   it are separate things to be right about, and the benchmark scores them separately.
 - `videos[path]`: `board_ms = clock_rate * pts_ms + clock_offset_ms`, with `pts_min_ms` and
   `pts_max_ms` spanning the *annotated* frames rather than the file, so scoring never
-  extrapolates past the frames the reference was built from.
+  extrapolates past the frames the reference was built from. Timestamps are as a decoder
+  reports them, relative to the stream's start time, which is also what the pipeline reads.
+- `videos[path].timeline`: `measured` for a recording, whose clock is fitted over its
+  annotations, or `synthesized` for a [retimed clip](#retimed-videos), whose clock was drawn
+  and whose timestamps were built to match it.
+- `videos[path].residual_threshold_ms`: How far an annotated frame may sit from the clock. A
+  synthesized timeline gets 2 ms, one ring LED at each end of the arc, because it is built from
+  the annotations themselves. A measured one gets a third of a source frame, clamped to
+  [2, 50] ms — tighter than the board itself resolves is meaningless, and a tolerance
+  approaching the 100 ms ring period would stop flagging a whole counter step. The stored number is what the reference was checked
+  against and what scoring reports, so a frozen reference stays valid under the rule it was
+  frozen by.
+- `videos[path].source_frame_period_ms`: Frame period of the recording, read from the packet
+  duration rather than the timestamp spacing. A clip holding every 16th frame of a 30 fps
+  recording still says 33.3 ms per packet while its timestamps sit 533 ms apart, and it is the
+  camera's own rate that the tolerance has to scale from.
+- `videos[path].source` / `source_frame_offset` / `anchors_digest` / `n_frames`: Present on a
+  retimed clip only. Frame *j* of the clip is frame *j + source_frame_offset* of `source`, which
+  is where its annotations live. The digest covers the annotations it was built from and
+  `n_frames` what it ended up spanning, which together tell `rocsync-retime` when it has gone
+  stale.
 
 The reference clock is plain least squares over the annotated timestamps, not the RANSAC
 fit `rocsync` uses on decoded ones. `rocsync-evaluate` measures fitted clocks against these
 numbers, so they have to be a pure function of the annotations: derived with the production
 fitter, a change to that fitter would move the ground truth and every error measured against
 it at the same time. No outlier is tolerated either, which is all RANSAC would have bought —
-an annotated frame more than `residual_threshold_ms` (one board LED is 1 ms) off the line is
-a bad annotation, and refusing to store a reference is how it gets found.
+an annotated frame further than `residual_threshold_ms` off the line is a bad annotation, and
+refusing to store a reference is how it gets found. The annotator shows each frame's
+leave-one-out residual against that same tolerance while you work.
 
 The annotator derives a video's reference when it has at least 5 timestamp annotations and no
 reference yet, or when one of its annotations was added, edited or cleared. A video nobody
 touched keeps the exact number it had.
+
+## Retimed Videos
+
+A recording's container timestamps are not a record of when the camera exposed. The phone clips in
+the dataset write a near-nominal grid while the sensor wanders ±7 ms around it, which puts a floor
+under any clock fitted against them: fitting the undecimated original over 650 frames gives the
+same 3.2 ms as the decimated copy, so the information was never written rather than lost in
+processing.
+
+That floor is the honest answer to how well a phone can be synchronized, and far too coarse to
+catch a regression in decoding or fitting — a 3 ms error and a correct answer look alike.
+`rocsync-retime` produces the other kind of benchmark video: the annotated board times become the
+timeline, so the clock the pipeline should recover is known exactly instead of fitted. Both kinds
+coexist in a dataset, labelled `measured` and `synthesized`, because each answers a question the
+other cannot.
+
+```bash
+uv run rocsync-retime [data_dir] [-o ground_truth.json] [--jitter-ms 0] [--force]
+```
+
+- `data_dir`: Directory containing validation images and videos (default: `validation_data/`).
+- `-o`: Ground truth JSON to read and update (default: `<data_dir>/ground_truth.json`).
+- `--jitter-ms`: Gaussian noise on frames without an annotation. Anchors stay exact — perturbing
+  them would put back the noise the retiming exists to remove (default: 0).
+- `--force`: Rebuild clips already up to date.
+
+This needs PyAV, which is in the `dev` dependency group: the tool authors datasets rather than
+reading them, so a checkout has it after `uv sync` and an installed copy does not.
+
+### What it writes
+
+`clip.retimed.mp4` beside `clip.mp4`, a **stream copy** with rewritten packet timestamps. Pixels
+stay bit-identical, which is what lets every existing corner, homography and LED annotation carry
+over — they are what the clip is built from. Non-video streams are dropped and the output uses a
+1/90000 time base, fine enough that rounding is negligible against the 2 ms tolerance.
+
+Each clip's `clock_rate` is drawn from `U(1 ± 0.05)` — the widest deviation that stays inside
+`process_video`'s own sanity warning — seeded on the source's relative path, so the target is never
+trivially `1.0` and a regenerated clip reproduces. The offset follows from where the timeline
+lands, in the tens of seconds. Anchors satisfy `clock_rate · pts + clock_offset_ms == board_time`
+by construction, and the tool verifies that by reading the written file back before recording it.
+
+### What it spans
+
+The clip is trimmed to `[first annotated frame, last annotated frame]`, so no timestamp is ever
+extrapolated and the strict tolerance holds across the whole file. A stream copy cannot start
+mid-GOP, so the output actually starts at the last keyframe at or before the first anchor and may
+carry a few frames past the last one; those continue the adjacent segment's slope and are not
+anchors, so nothing checks them. The tool refuses a clip needing more than five such margin frames.
+
+Every frame inside the window is kept, annotated or not — partially visible boards, wrapping ring
+arcs, frames with no board at all. A clip of only cleanly decodable frames would stop exercising
+the rejection paths that matter. Only frames with a reconstructable annotated timestamp anchor the
+timeline; the rest are interpolated between anchors and still carry their real capture jitter,
+which is the point.
+
+### Where the annotations live
+
+With the source, always. A retimed clip is a derived artifact that can be regenerated or deleted
+without touching them, and its ground truth entry records `source` and `source_frame_offset` so a
+prediction about its frame *j* resolves back to frame *j + offset* of the recording.
+
+That is also why **the annotator walks the recordings and never a retimed clip**: the sources are
+untrimmed, so frames outside the current window stay annotatable, which is how a window grows.
+`rocsync-validate` and `rocsync-evaluate` do the opposite — a recording with a retimed clip beside
+it is skipped in favour of it, so the same footage is never benchmarked twice.
+
+### Re-running
+
+Safe after every annotation session. Each entry stores an `anchors_digest` over the annotations it
+was built from; a clip whose digest still matches and whose file is intact is reported as up to
+date and left alone. Only clips whose annotations actually moved get rewritten, and `--force`
+overrides that.
 
 ## Validation Benchmark
 
@@ -214,7 +321,8 @@ Metrics are computed per pipeline step:
   over the frames a timestamp actually follows from
 - **Clock fit** (per video, when the ground truth has a reference clock): clock rate error in
   ppm, clock offset error, sync error, residuals against the annotations, and whether the
-  fit's own outlier rejection agrees with them
+  fit's own outlier rejection agrees with them. A recording whose retimed clip the run scored
+  is not reported separately
 
 Corner positions are compared against the annotated coordinates. Board space is derived by mapping
 both sides through the annotated homography, which normalises the threshold to LED sample radii —
@@ -236,11 +344,15 @@ for the overall timestamp step — the pipeline is right to refuse it — and it
 every clock fit, the reference included. Annotations are unaffected: record what is on screen
 and the scoring sorts out what is decodable.
 
-The clock-fit block reads the reference out of the ground truth and never re-fits it. Its
-rows:
+The clock-fit block reads the reference out of the ground truth and never re-fits it. Read a
+sync error against the `reference tolerance` on the same block: a 0.5 ms error against a
+synthesized timeline is a real measurement, while against a measured one it is inside the
+camera's own noise. Its rows:
 
 | Row | Meaning |
 | --- | --- |
+| `timeline` | `measured` for a recording, `synthesized` for a [retimed clip](#retimed-videos) |
+| `reference tolerance [ms]` | how far an annotation may sit from the reference, which is what makes those two comparable |
 | `clock rate error [ppm]` | fitted rate minus reference rate; the raw difference is ~1e-5 and unreadable otherwise |
 | `clock offset error [ms]` | fitted board time at `pts == 0` minus the reference's |
 | `sync error, first/last/worst [ms]` | how far the two clocks disagree at either end of the annotated span |
@@ -283,9 +395,11 @@ uv run rocsync-evaluate output/benchmark/other.json output/benchmark/current.jso
 Running a checkout under the benchmark needs `rocsync/benchmark/{__init__,common,validate}.py`,
 `rocsync/dataset.py` for the suffix sets `common.py` collects inputs by, `rocsync/timeline.py` and
 `rocsync/video_statistics.py` for the clock fit, the `stats` hooks in `vision.py` — including
-`ring_window`, which carries the decoded arc — and a `rocsync-validate` entry point. None of those three modules imports anything from `rocsync`
-except each other, so an older checkout only needs the files copied in. `annotate.py` and `evaluate.py` need geometry that
-older checkouts lack, so they are not portable and are not needed there.
+`ring_window`, which carries the decoded arc — and a `rocsync-validate` entry point. Beyond those,
+the benchmark modules reach only for `board_profiles.py` and `camera.py`, which every checkout
+already has, so an older one needs nothing but the files above copied in. `annotate.py`,
+`retime.py` and `evaluate.py` need geometry that older checkouts lack, so they are not portable
+and are not needed there.
 
 `rocsync-evaluate` prints how many ground truth frames each column actually scores. A column that
 scores fewer was run over a different set of inputs, and its rates describe that subset — a

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -319,10 +319,13 @@ Metrics are computed per pipeline step:
 - **Ring**: detection rates + start/end value accuracy, wrapping arcs included
 - **Overall**: timestamp detection + exact match accuracy + start/end/exposure error statistics,
   over the frames a timestamp actually follows from
-- **Clock fit** (per video, when the ground truth has a reference clock): clock rate error in
-  ppm, clock offset error, sync error, residuals against the annotations, and whether the
-  fit's own outlier rejection agrees with them. A recording whose retimed clip the run scored
-  is not reported separately
+- **Clock fit** (when the ground truth has a reference clock): clock rate error in ppm, clock
+  offset error, sync error, residuals against the annotations, and whether the fit's own
+  outlier rejection agrees with them. Reported per group of videos rather than per video —
+  measured and retimed timelines are summarized separately, because a measured one also
+  carries the camera's own timestamp error. Fit errors are the mean and the worst over the
+  group's videos, frame counters their totals, residuals pooled over every frame the group
+  scored. A recording whose retimed clip the run scored is not reported separately
 
 Corner positions are compared against the annotated coordinates. Board space is derived by mapping
 both sides through the annotated homography, which normalises the threshold to LED sample radii —

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -69,7 +69,7 @@ rather than the saved one, so a correction shows in the number before it is acce
 
 | Key | Action |
 |-----|--------|
-| Enter / Space | Accept annotation, save, advance to next frame |
+| Enter / Space | Accept annotation, save, advance to the next unannotated frame |
 | D / Right arrow | Skip to next frame without saving |
 | A / Left arrow | Go back to previous frame |
 | N | Jump to next unannotated frame |

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -87,7 +87,7 @@ Annotations are saved to a JSON file with the following structure:
 
 Fields:
 - `aruco.visible` / `aruco.id`: Whether the ArUco marker is visible and its detected ID (omitted when not visible).
-- `corners[i].visible` / `corners[i].position`: Per-corner-LED visibility and position in original image coordinates (position omitted when not visible).
+- `corners[i].visible` / `corners[i].position`: Per-corner-LED visibility and position in original image coordinates (position omitted when not visible). Benchmark results use the same space, so the two are directly comparable.
 - `homography`: 3×3 matrix mapping original image → rectified board coordinates.
 - `counter.visible` / `counter.value`: Whether the binary counter is readable and its decoded value (omitted when not visible).
 - `ring.start` / `ring.end`: First ON and first OFF LED indices (0–99), half-open interval `[start, end)`. `start == end` means the ring is undecodable.
@@ -104,7 +104,9 @@ uv run rocsync-validate [data_dir] [-o results.json] [--debug DIR]
 - `-o`: Output JSON file (default: `benchmark_results.json`).
 - `--debug`: Directory for debug images.
 
-Results JSON contains a `config` section and an `images` section with per-image aruco, corners, counter, ring, timestamp, success flag, and timing breakdown.
+Results JSON contains a `config` section and an `images` section with per-image aruco, corners, counter, ring, timestamp, success flag, and timing breakdown. Corner positions are in original image coordinates, matching the ground truth: the pipeline detects them in the rough-rectified grid, whose scale is a property of the checkout being measured, so they are un-warped through that grid's own homography before being stored.
+
+`config` records which checkout produced the file — branch, commit, whether the tree was dirty, run time, and the OpenCV and NumPy versions — because `rocsync-evaluate` labels its columns by filename alone.
 
 ## Benchmark Evaluation
 
@@ -124,3 +126,46 @@ Metrics are computed per pipeline step:
 - **Counter**: detection rates + value accuracy
 - **Ring**: detection rates + start/end value accuracy
 - **Overall**: timestamp detection + exact match accuracy + start/end/exposure error statistics
+
+Corner positions are compared against the annotated coordinates. Board space is derived by mapping
+both sides through the annotated homography, which normalises the threshold to LED sample radii —
+a fixed pixel threshold in image space means different things depending on how large the board
+appears in the frame.
+
+Reading position errors: the annotator pre-fills each image from a pipeline run, so on every frame
+accepted without correction the annotation *is* that pipeline's output. Position error therefore
+reads as zero for whichever checkout produced the annotations, and a non-zero error for another
+checkout measures divergence from it rather than distance from truth. Detection rates do not suffer
+this — the ground truth's positives include everything annotated by hand on frames where the
+pipeline failed.
+
+## Comparing branches
+
+`rocsync-evaluate` takes several result files and prints one column per file, named after the file,
+which is how two checkouts are compared. Only `rocsync-validate` has to run inside the checkout
+under test; annotation and scoring stay here, against one reference geometry.
+
+Every branch installs as `rocsync` at the same version, so they cannot share an environment — give
+each one a worktree with its own venv:
+
+```bash
+git worktree add ../RocSync-other <branch>
+cd ../RocSync-other/sw && uv sync
+```
+
+Then produce a column per checkout and compare:
+
+```bash
+mkdir -p output/benchmark
+../RocSync-other/sw/.venv/bin/rocsync-validate <data_dir> -o output/benchmark/other.json
+uv run rocsync-validate <data_dir> -o output/benchmark/current.json
+uv run rocsync-evaluate output/benchmark/other.json output/benchmark/current.json \
+    -g <data_dir>/ground_truth.json -t
+```
+
+Running a checkout under the benchmark needs `rocsync/benchmark/{__init__,common,validate}.py`, the
+`stats` hooks in `vision.py`, and a `rocsync-validate` entry point. `annotate.py` and `evaluate.py`
+need geometry that older checkouts lack, so they are not portable and are not needed there.
+
+Timing columns are only comparable when the environments agree — check the OpenCV and NumPy
+versions that `rocsync-evaluate` prints per column before reading `-t` output.

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -40,7 +40,10 @@ The window shows two panels side-by-side:
 - **Left**: Original image
 - **Right**: Rectified 640×640 board with color-coded LED overlays
   - Red circle = ON, Blue circle = OFF, Gray circle = not visible
-  - If the pipeline failed (e.g., no ArUco detected), a black image is shown with LED positions at their expected locations.
+  - When the pipeline found the ArUco marker but failed to detect the corner LEDs, the board is
+    rectified from the marker alone and the counter and ring are read off that coarse view. It is
+    an estimate to correct, not an annotation: refine the corner LEDs and the fit tightens.
+  - If no ArUco marker was detected, a black image is shown with LED positions at their expected locations.
 
 On a video frame the top right also carries the frame's timing residual:
 
@@ -81,6 +84,11 @@ rather than the saved one, so a correction shows in the number before it is acce
 ### Mouse Interactions (right panel)
 
 **Corner LEDs** — Click on a corner LED circle to toggle visible/hidden. Drag a corner LED to refine its position.
+
+Every corner edit re-fits the homography from the visible corner LEDs and, on a frame whose
+counter and ring you have not yet annotated by hand, re-reads both off the new fit. Toggling a
+counter LED or setting the ring hands that reading over to you, and the auto-decode leaves it
+alone from then on; so does opening a frame that was already annotated.
 
 **Counter LEDs** — Click on a counter LED circle to toggle ON/OFF. Click the counter bounding box (outside individual LEDs) to toggle counter visibility.
 

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -44,6 +44,8 @@ The window shows two panels side-by-side:
   - When the pipeline found the ArUco marker but failed to detect the corner LEDs, the board is
     rectified from the marker alone and the counter and ring are read off that coarse view. It is
     an estimate to correct, not an annotation: refine the corner LEDs and the fit tightens.
+  - The pipeline's minimum marker-area gate is off here, so a board held far from the camera is
+    still offered for annotation; whether the benchmark run rejects it is measured separately.
   - If no ArUco marker was detected, a black image is shown with LED positions at their expected locations.
 
 On a video frame the top right also carries the frame's timing residual:

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -1,6 +1,12 @@
 # Benchmark Tools
 
-Tools for evaluating and annotating the RocSync vision pipeline against validation images.
+Tools for evaluating and annotating the RocSync vision pipeline against validation images and
+videos.
+
+Inputs are collected recursively: images (`.png`, `.jpg`, `.jpeg`) and videos (`.mp4`, `.mov`,
+`.avi`, `.mkv`). **Every frame of a video is a benchmark frame** — video frames are decoded on
+demand, so nothing is extracted to disk. A dataset should hold a video *or* its extracted frames,
+not both, or the same content is benchmarked twice under two sets of keys.
 
 These are development tools: they run against a checkout, not an installed copy. Create the
 environment once with `uv sync` from `RocSync/sw`, then prefix each command with `uv run` to use
@@ -9,7 +15,7 @@ main README.
 
 ## Annotation Tool
 
-Interactive GUI for creating ground truth annotations. Runs the pipeline on each image, displays the result with LED overlays, and lets you verify or correct the decoded values. Produces a `ground_truth.json` file for benchmark evaluation.
+Interactive GUI for creating ground truth annotations. Runs the pipeline on each frame, displays the result with LED overlays, and lets you verify or correct the decoded values. Produces a `ground_truth.json` file for benchmark evaluation.
 
 ### Usage
 
@@ -17,10 +23,10 @@ Interactive GUI for creating ground truth annotations. Runs the pipeline on each
 uv run rocsync-annotate [data_dir] [-o ground_truth.json]
 ```
 
-- `data_dir`: Directory containing validation images (default: `validation_data/`). Images are collected recursively (`.png`, `.jpg`, `.jpeg`).
+- `data_dir`: Directory containing validation images and videos (default: `validation_data/`).
 - `-o`: Output file (default: `<data_dir>/ground_truth.json`).
 
-The tool resumes from the first unannotated image on restart.
+The tool resumes from the first unannotated frame on restart.
 
 ### Display
 
@@ -35,12 +41,14 @@ The window shows two panels side-by-side:
 
 | Key | Action |
 |-----|--------|
-| Enter / Space | Accept annotation, save, advance to next image |
-| D / Right arrow | Skip to next image without saving |
-| A / Left arrow | Go back to previous image |
-| N | Jump to next unannotated image |
-| B | Jump to previous unannotated image |
-| C / Backspace | Clear annotation for current image (deletes from ground truth, re-runs pipeline) |
+| Enter / Space | Accept annotation, save, advance to next frame |
+| D / Right arrow | Skip to next frame without saving |
+| A / Left arrow | Go back to previous frame |
+| N | Jump to next unannotated frame |
+| B | Jump to previous unannotated frame |
+| . | Jump to the first frame of the next input file |
+| , | Jump to the first frame of the previous input file |
+| C / Backspace | Clear annotation for current frame (deletes from ground truth, re-runs pipeline) |
 | Q | Quit |
 | H | Toggle help overlay |
 | 0-9 | Select which corner the next left-panel click places |
@@ -66,6 +74,11 @@ The window shows two panels side-by-side:
 
 Annotations are saved to a JSON file with the following structure:
 
+Each key under `images` names one benchmark frame. A still image is keyed by its path relative to
+`data_dir`; a video frame adds `#` and its absolute frame index, zero-padded to six digits, so a
+video's frames sort in playback order next to the file itself. The index is the frame's position in
+the file rather than a presentation timestamp, which would shift with the decoder.
+
 ```json
 {
   "images": {
@@ -80,6 +93,9 @@ Annotations are saved to a JSON file with the following structure:
       "homography": [[...], [...], [...]],
       "counter": {"visible": true, "value": 42},
       "ring": {"start": 10, "end": 55}
+    },
+    "subdir/clip.mp4#000042": {
+      "...": "same fields; frame 42 of subdir/clip.mp4"
     }
   }
 }
@@ -94,19 +110,21 @@ Fields:
 
 ## Validation Benchmark
 
-Runs the pipeline on all images in a directory and saves per-image results in a structure mirroring the ground truth format, plus per-step timing.
+Runs the pipeline on every frame in a directory and saves per-frame results in a structure mirroring the ground truth format, plus per-step timing.
 
 ```bash
 uv run rocsync-validate [data_dir] [-o results.json] [--debug DIR]
 ```
 
-- `data_dir`: Directory containing validation images (default: `validation_data/`).
+- `data_dir`: Directory containing validation images and videos (default: `validation_data/`).
 - `-o`: Output JSON file (default: `benchmark_results.json`).
 - `--debug`: Directory for debug images.
 
-Results JSON contains a `config` section and an `images` section with per-image aruco, corners, counter, ring, timestamp, success flag, and timing breakdown. Corner positions are in original image coordinates, matching the ground truth: the pipeline detects them in the rough-rectified grid, whose scale is a property of the checkout being measured, so they are un-warped through that grid's own homography before being stored.
+Results JSON contains a `config` section and an `images` section with per-frame aruco, corners, counter, ring, timestamp, success flag, and timing breakdown. Keys match the ground truth's, so `n_images` in `config` counts benchmark frames rather than files. Corner positions are in original image coordinates, matching the ground truth: the pipeline detects them in the rough-rectified grid, whose scale is a property of the checkout being measured, so they are un-warped through that grid's own homography before being stored.
 
 `config` records which checkout produced the file — branch, commit, whether the tree was dirty, run time, and the OpenCV and NumPy versions — because `rocsync-evaluate` labels its columns by filename alone.
+
+Video frames are decoded in the order they are walked, so a run never seeks backwards through a file.
 
 ## Benchmark Evaluation
 
@@ -163,9 +181,17 @@ uv run rocsync-evaluate output/benchmark/other.json output/benchmark/current.jso
     -g <data_dir>/ground_truth.json -t
 ```
 
-Running a checkout under the benchmark needs `rocsync/benchmark/{__init__,common,validate}.py`, the
-`stats` hooks in `vision.py`, and a `rocsync-validate` entry point. `annotate.py` and `evaluate.py`
-need geometry that older checkouts lack, so they are not portable and are not needed there.
+Running a checkout under the benchmark needs `rocsync/benchmark/{__init__,common,validate}.py`,
+`rocsync/dataset.py` for the suffix sets `common.py` collects inputs by, the `stats` hooks in
+`vision.py`, and a `rocsync-validate` entry point. `dataset.py` imports nothing from `rocsync`, so
+an older checkout only needs the file copied in. `annotate.py` and `evaluate.py` need geometry that
+older checkouts lack, so they are not portable and are not needed there.
+
+`rocsync-evaluate` prints how many ground truth frames each column actually scores. A column that
+scores fewer was run over a different set of inputs, and its rates describe that subset — a
+prediction the run never made is skipped rather than counted as a miss.
 
 Timing columns are only comparable when the environments agree — check the OpenCV and NumPy
-versions that `rocsync-evaluate` prints per column before reading `-t` output.
+versions that `rocsync-evaluate` prints per column before reading `-t` output. Video decoding is
+part of that: annotations are in decoded coordinates, and OpenCV applies a container's rotation
+metadata itself, so a backend that did not would put every position in a transposed frame.

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -144,7 +144,10 @@ Fields:
 - `corners[i].visible` / `corners[i].position`: Per-corner-LED visibility and position in original image coordinates (position omitted when not visible). Benchmark results use the same space, so the two are directly comparable.
 - `homography`: 3×3 matrix mapping original image → rectified board coordinates.
 - `counter.visible` / `counter.value`: Whether the binary counter is readable and its decoded value (omitted when not visible).
-- `ring.start` / `ring.end`: First ON and first OFF LED indices (0–99), half-open interval `[start, end)`. `start == end` means the ring is undecodable.
+- `ring.start` / `ring.end`: First ON and first OFF LED indices (0–99), half-open interval
+  `[start, end)`. `start == end` means no arc was readable. Annotate the arc as it appears,
+  including one that wraps the end of the period (`start > end`) — reading the arc and timing
+  it are separate things to be right about, and the benchmark scores them separately.
 - `videos[path]`: `board_ms = clock_rate * pts_ms + clock_offset_ms`, with `pts_min_ms` and
   `pts_max_ms` spanning the *annotated* frames rather than the file, so scoring never
   extrapolates past the frames the reference was built from.
@@ -206,8 +209,9 @@ Metrics are computed per pipeline step:
 - **ArUco**: detection rates + corner pixel error in image space
 - **Corners**: detection rates in image space and board space + pixel errors in both spaces
 - **Counter**: detection rates + value accuracy
-- **Ring**: detection rates + start/end value accuracy
-- **Overall**: timestamp detection + exact match accuracy + start/end/exposure error statistics
+- **Ring**: detection rates + start/end value accuracy, wrapping arcs included
+- **Overall**: timestamp detection + exact match accuracy + start/end/exposure error statistics,
+  over the frames a timestamp actually follows from
 - **Clock fit** (per video, when the ground truth has a reference clock): clock rate error in
   ppm, clock offset error, sync error, residuals against the annotations, and whether the
   fit's own outlier rejection agrees with them
@@ -223,6 +227,14 @@ reads as zero for whichever checkout produced the annotations, and a non-zero er
 checkout measures divergence from it rather than distance from truth. Detection rates do not suffer
 this — the ground truth's positives include everything annotated by hand on frames where the
 pipeline failed.
+
+A ring arc that wraps the end of the period was exposed across a counter increment, so the
+counter no longer says which period the arc belongs to and no timestamp follows from it. The
+board decides this, in `board_time_from_ring`; the benchmark asks rather than reimplementing.
+Such a frame is still scored on whether the arc was read correctly, but it is not a positive
+for the overall timestamp step — the pipeline is right to refuse it — and it is kept out of
+every clock fit, the reference included. Annotations are unaffected: record what is on screen
+and the scoring sorts out what is decodable.
 
 The clock-fit block reads the reference out of the ground truth and never re-fits it. Its
 rows:
@@ -270,8 +282,8 @@ uv run rocsync-evaluate output/benchmark/other.json output/benchmark/current.jso
 
 Running a checkout under the benchmark needs `rocsync/benchmark/{__init__,common,validate}.py`,
 `rocsync/dataset.py` for the suffix sets `common.py` collects inputs by, `rocsync/timeline.py` and
-`rocsync/video_statistics.py` for the clock fit, the `stats` hooks in `vision.py`, and a
-`rocsync-validate` entry point. None of those three modules imports anything from `rocsync`
+`rocsync/video_statistics.py` for the clock fit, the `stats` hooks in `vision.py` — including
+`ring_window`, which carries the decoded arc — and a `rocsync-validate` entry point. None of those three modules imports anything from `rocsync`
 except each other, so an older checkout only needs the files copied in. `annotate.py` and `evaluate.py` need geometry that
 older checkouts lack, so they are not portable and are not needed there.
 

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -22,7 +22,7 @@ Interactive GUI for creating ground truth annotations. Runs the pipeline on each
 ### Usage
 
 ```bash
-uv run rocsync-annotate [data_dir] [-o ground_truth.json] [--fit-clocks]
+uv run rocsync-annotate [data_dir] [-o ground_truth.json] [--fit-clocks] [--prune [--dry-run]]
 ```
 
 - `data_dir`: Directory containing validation images and videos (default: `validation_data/`).
@@ -30,8 +30,12 @@ uv run rocsync-annotate [data_dir] [-o ground_truth.json] [--fit-clocks]
 - `--fit-clocks`: Re-derive every video's reference clock and exit, without opening the GUI.
   Run it after editing a ground truth file by hand. It exits non-zero, naming the offending
   frames, when a video's annotations do not agree on a single clock.
+- `--prune`: Remove entries whose input is gone and exit, without opening the GUI. See
+  [Removing inputs from the benchmark](#removing-inputs-from-the-benchmark).
+- `--dry-run`: With `--prune`, list what would go without writing anything.
 
-The tool resumes from the first unannotated frame on restart.
+The tool resumes from the first unannotated frame on restart, and names on startup any entry
+whose image or video it no longer finds.
 
 ### Display
 
@@ -316,12 +320,14 @@ Video frames are decoded in the order they are walked, so a run never seeks back
 Compares benchmark results against ground truth annotations. Reports per-step detection metrics (TPR, FPR, precision, F1), value accuracy, and position errors.
 
 ```bash
-uv run rocsync-evaluate [paths...] [-g ground_truth.json] [-t]
+uv run rocsync-evaluate [paths...] [-g ground_truth.json] [-t] [--allow-partial]
 ```
 
 - `paths`: Directory with benchmark `.json` files, or one or more explicit `.json` filepaths (default: `output/benchmark/`).
 - `-g`: Path to ground truth JSON (default: `validation_data/ground_truth.json`).
 - `-t`: Include per-step timing statistics (all/positive/negative subsets).
+- `--allow-partial`: Report instead of refusing when the columns cover different frames — see
+  [Comparing branches](#comparing-branches).
 
 Metrics are computed per pipeline step:
 - **ArUco**: detection rates + corner pixel error in image space
@@ -415,9 +421,14 @@ already has, so an older one needs nothing but the files above copied in. `annot
 `retime.py` and `evaluate.py` need geometry that older checkouts lack, so they are not portable
 and are not needed there.
 
-`rocsync-evaluate` prints how many ground truth frames each column actually scores. A column that
-scores fewer was run over a different set of inputs, and its rates describe that subset — a
-prediction the run never made is skipped rather than counted as a miss.
+`rocsync-evaluate` prints how many ground truth frames each column actually scores, and refuses to
+print a report when the columns do not cover the same frames: a prediction the run never made is
+skipped by every metric rather than counted as a miss, so columns over different frame sets are
+different populations and the counts, rates and green winner mark between them mean nothing. It
+names the files behind the difference; re-run `rocsync-validate` for the column that lags, or pass
+`--allow-partial` to score each column over its own coverage anyway. Frames no column scores are
+reported separately as a stale ground truth, which
+[pruning](#removing-inputs-from-the-benchmark) clears.
 
 Timing columns are only comparable when the environments agree — check the OpenCV and NumPy
 versions that `rocsync-evaluate` prints per column before reading `-t` output. Video decoding is
@@ -434,3 +445,26 @@ The following command subsamples videos to approximately 0.9 fps, while preservi
 
 When selecting the output framerate, avoid multiples of 100ms to collect frames with different ring arcs.
 I recommend 0.9 - 1.9 fps to minimize annotation cost.
+
+## Removing inputs from the benchmark
+
+Delete the file, then clean up what described it:
+
+```bash
+rm <data_dir>/<subset>/clip.mp4
+uv run rocsync-annotate <data_dir> --prune
+```
+
+`--prune` removes the annotations and the reference clock of every input that is no longer there,
+and nothing else. It leaves alone a file that is present but would not decode — a truncated copy,
+a codec this machine lacks — because that is a reason to fix the file, not to lose the annotation
+work behind it; those are listed and make the exit code non-zero. `--dry-run` prints the same list
+without writing. A retimed clip is cut again on demand, so its entry survives the clip being
+deleted and goes only when the recording it was cut from does.
+
+Annotations whose video was re-encoded shorter are pruned too, by index; re-derive that video's
+clock afterwards with `--fit-clocks`, since its reference was fitted over frames that are now gone.
+
+Result files in `output/benchmark/` still hold predictions for the removed frames, so re-run
+`rocsync-validate` for every column you want to keep comparing — until then `rocsync-evaluate`
+refuses to put an old column next to a fresh one.

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -20,11 +20,14 @@ Interactive GUI for creating ground truth annotations. Runs the pipeline on each
 ### Usage
 
 ```bash
-uv run rocsync-annotate [data_dir] [-o ground_truth.json]
+uv run rocsync-annotate [data_dir] [-o ground_truth.json] [--fit-clocks]
 ```
 
 - `data_dir`: Directory containing validation images and videos (default: `validation_data/`).
 - `-o`: Output file (default: `<data_dir>/ground_truth.json`).
+- `--fit-clocks`: Re-derive every video's reference clock and exit, without opening the GUI.
+  Run it after editing a ground truth file by hand. It exits non-zero, naming the offending
+  frames, when a video's annotations do not agree on a single clock.
 
 The tool resumes from the first unannotated frame on restart.
 
@@ -36,6 +39,19 @@ The window shows two panels side-by-side:
 - **Right**: Rectified 640×640 board with color-coded LED overlays
   - Red circle = ON, Blue circle = OFF, Gray circle = not visible
   - If the pipeline failed (e.g., no ArUco detected), a black image is shown with LED positions at their expected locations.
+
+On a video frame the top right also carries the frame's timing residual:
+
+```
+dt +0.31 ms
+fit 54 frames  RMSE 0.21  max 0.63 ms
+```
+
+`dt` is how far the annotated timestamp sits from where the rest of the video puts this
+frame, green within the 2 ms tolerance and red beyond it. The clock behind it is fitted
+over the video's *other* annotated frames and asked to predict this one, so a frame cannot
+drag the line towards itself and hide half its own error. It reads the annotation on screen
+rather than the saved one, so a correction shows in the number before it is accepted.
 
 ### Keyboard Shortcuts
 
@@ -101,12 +117,49 @@ the file rather than a presentation timestamp, which would shift with the decode
 }
 ```
 
+A `videos` section holds one reference clock per video, the affine map from container
+presentation time to board time that the video's annotations agree on:
+
+```json
+{
+  "images": {"...": "..."},
+  "videos": {
+    "subdir/clip.mp4": {
+      "clock_rate": 1.0000743,
+      "clock_offset_ms": -4333.21,
+      "pts_min_ms": 0.0,
+      "pts_max_ms": 38500.0,
+      "n_frames_fitted": 54,
+      "rmse_ms": 0.21,
+      "max_residual_ms": 0.63,
+      "residual_threshold_ms": 2.0,
+      "derived_at": "2026-08-18T09:12:00+00:00"
+    }
+  }
+}
+```
+
 Fields:
 - `aruco.visible` / `aruco.id`: Whether the ArUco marker is visible and its detected ID (omitted when not visible).
 - `corners[i].visible` / `corners[i].position`: Per-corner-LED visibility and position in original image coordinates (position omitted when not visible). Benchmark results use the same space, so the two are directly comparable.
 - `homography`: 3×3 matrix mapping original image → rectified board coordinates.
 - `counter.visible` / `counter.value`: Whether the binary counter is readable and its decoded value (omitted when not visible).
 - `ring.start` / `ring.end`: First ON and first OFF LED indices (0–99), half-open interval `[start, end)`. `start == end` means the ring is undecodable.
+- `videos[path]`: `board_ms = clock_rate * pts_ms + clock_offset_ms`, with `pts_min_ms` and
+  `pts_max_ms` spanning the *annotated* frames rather than the file, so scoring never
+  extrapolates past the frames the reference was built from.
+
+The reference clock is plain least squares over the annotated timestamps, not the RANSAC
+fit `rocsync` uses on decoded ones. `rocsync-evaluate` measures fitted clocks against these
+numbers, so they have to be a pure function of the annotations: derived with the production
+fitter, a change to that fitter would move the ground truth and every error measured against
+it at the same time. No outlier is tolerated either, which is all RANSAC would have bought —
+an annotated frame more than `residual_threshold_ms` (one board LED is 1 ms) off the line is
+a bad annotation, and refusing to store a reference is how it gets found.
+
+The annotator derives a video's reference when it has at least 5 timestamp annotations and no
+reference yet, or when one of its annotations was added, edited or cleared. A video nobody
+touched keeps the exact number it had.
 
 ## Validation Benchmark
 
@@ -121,6 +174,17 @@ uv run rocsync-validate [data_dir] [-o results.json] [--debug DIR]
 - `--debug`: Directory for debug images.
 
 Results JSON contains a `config` section and an `images` section with per-frame aruco, corners, counter, ring, timestamp, success flag, and timing breakdown. Keys match the ground truth's, so `n_images` in `config` counts benchmark frames rather than files. Corner positions are in original image coordinates, matching the ground truth: the pipeline detects them in the rough-rectified grid, whose scale is a property of the checkout being measured, so they are un-warped through that grid's own homography before being stored.
+
+Every video additionally gets its clock fitted, by the same code a `rocsync` run uses, and a
+`videos` section records the resulting `VideoStatistics` — clock rate and offset, R²/RMSE
+before and after outlier rejection, frame period, dropouts and exposure. A video whose
+timeline could not be fitted carries an `error` instead of the fit. Each frame of a video
+gains its presentation timestamp as `pts_ms` and, once fitted, a `fit` of
+`{"residual_ms", "inlier"}`, so the per-frame outcome stays next to the frame it belongs to.
+
+Unlike a real run, which analyzes roughly one frame per second, every frame that decoded
+feeds the fit: the benchmark has already paid to decode them all, and using all of them keeps
+fit quality separate from the sampling policy.
 
 `config` records which checkout produced the file — branch, commit, whether the tree was dirty, run time, and the OpenCV and NumPy versions — because `rocsync-evaluate` labels its columns by filename alone.
 
@@ -144,6 +208,9 @@ Metrics are computed per pipeline step:
 - **Counter**: detection rates + value accuracy
 - **Ring**: detection rates + start/end value accuracy
 - **Overall**: timestamp detection + exact match accuracy + start/end/exposure error statistics
+- **Clock fit** (per video, when the ground truth has a reference clock): clock rate error in
+  ppm, clock offset error, sync error, residuals against the annotations, and whether the
+  fit's own outlier rejection agrees with them
 
 Corner positions are compared against the annotated coordinates. Board space is derived by mapping
 both sides through the annotated homography, which normalises the threshold to LED sample radii —
@@ -156,6 +223,26 @@ reads as zero for whichever checkout produced the annotations, and a non-zero er
 checkout measures divergence from it rather than distance from truth. Detection rates do not suffer
 this — the ground truth's positives include everything annotated by hand on frames where the
 pipeline failed.
+
+The clock-fit block reads the reference out of the ground truth and never re-fits it. Its
+rows:
+
+| Row | Meaning |
+| --- | --- |
+| `clock rate error [ppm]` | fitted rate minus reference rate; the raw difference is ~1e-5 and unreadable otherwise |
+| `clock offset error [ms]` | fitted board time at `pts == 0` minus the reference's |
+| `sync error, first/last/worst [ms]` | how far the two clocks disagree at either end of the annotated span |
+| `outliers rejected in error` | frames the fit threw out whose decode the annotation confirms |
+| `misdecodes kept as inliers` | frames the fit kept whose decode the annotation contradicts |
+| `residual vs annotations` | fitted board time minus annotated board time, per frame |
+
+Read `sync error` first. Rate and offset trade off against each other — they cancel at
+`pts == 0` and diverge everywhere else — so either one alone can look bad while the clock is
+fine, or look fine while the clock is not. The sync error is what actually lands on a frame.
+
+Unlike the position errors above, this block does not favour whichever checkout pre-filled
+the annotations: the reference is fitted over annotated *values*, not copied from a pipeline's
+output. A decoding bias present in both annotations and predictions still cancels.
 
 ## Comparing branches
 
@@ -182,9 +269,10 @@ uv run rocsync-evaluate output/benchmark/other.json output/benchmark/current.jso
 ```
 
 Running a checkout under the benchmark needs `rocsync/benchmark/{__init__,common,validate}.py`,
-`rocsync/dataset.py` for the suffix sets `common.py` collects inputs by, the `stats` hooks in
-`vision.py`, and a `rocsync-validate` entry point. `dataset.py` imports nothing from `rocsync`, so
-an older checkout only needs the file copied in. `annotate.py` and `evaluate.py` need geometry that
+`rocsync/dataset.py` for the suffix sets `common.py` collects inputs by, `rocsync/timeline.py` and
+`rocsync/video_statistics.py` for the clock fit, the `stats` hooks in `vision.py`, and a
+`rocsync-validate` entry point. None of those three modules imports anything from `rocsync`
+except each other, so an older checkout only needs the files copied in. `annotate.py` and `evaluate.py` need geometry that
 older checkouts lack, so they are not portable and are not needed there.
 
 `rocsync-evaluate` prints how many ground truth frames each column actually scores. A column that

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -43,9 +43,16 @@ The window shows two panels side-by-side:
 | C / Backspace | Clear annotation for current image (deletes from ground truth, re-runs pipeline) |
 | Q | Quit |
 | H | Toggle help overlay |
+| 0-9 | Select which corner the next left-panel click places |
 | Esc | Cancel ring LED selection |
 
-### Mouse Interactions (right panel only)
+### Mouse Interactions (left panel)
+
+**Placing corners** — Click a corner directly in the image to place the pending corner there. The click marks that corner visible and advances the pending corner to the next one, so clicking the corners in order (0, 1, 2, …) annotates them in one pass and then wraps back to corner 0. Press `0`-`9` to jump to a specific corner. The pending corner is ringed in green and named in the top-left of the panel. A zoom inset follows the cursor so clicks stay accurate despite the downscaled display.
+
+**Corner LEDs** — Drag a corner LED circle to refine its position.
+
+### Mouse Interactions (right panel)
 
 **Corner LEDs** — Click on a corner LED circle to toggle visible/hidden. Drag a corner LED to refine its position.
 

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -1,0 +1,114 @@
+# Benchmark Tools
+
+Tools for evaluating and annotating the RocSync vision pipeline against validation images.
+
+## Annotation Tool
+
+Interactive GUI for creating ground truth annotations. Runs the pipeline on each image, displays the result with LED overlays, and lets you verify or correct the decoded values. Produces a `ground_truth.json` file for benchmark evaluation.
+
+### Usage
+
+```bash
+python -m rocsync.benchmark.annotate [data_dir] [-o ground_truth.json]
+```
+
+- `data_dir`: Directory containing validation images (default: `validation_data/`). Images are collected recursively (`.png`, `.jpg`, `.jpeg`).
+- `-o`: Output file (default: `<data_dir>/ground_truth.json`).
+
+The tool resumes from the first unannotated image on restart.
+
+### Display
+
+The window shows two panels side-by-side:
+
+- **Left**: Original image
+- **Right**: Rectified 640×640 board with color-coded LED overlays
+  - Red circle = ON, Blue circle = OFF, Gray circle = not visible
+  - If the pipeline failed (e.g., no ArUco detected), a black image is shown with LED positions at their expected locations.
+
+### Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| Enter / Space | Accept annotation, save, advance to next image |
+| D / Right arrow | Skip to next image without saving |
+| A / Left arrow | Go back to previous image |
+| N | Jump to next unannotated image |
+| B | Jump to previous unannotated image |
+| C / Backspace | Clear annotation for current image (deletes from ground truth, re-runs pipeline) |
+| Q | Quit |
+| H | Toggle help overlay |
+| Esc | Cancel ring LED selection |
+
+### Mouse Interactions (right panel only)
+
+**Corner LEDs** — Click on a corner LED circle to toggle visible/hidden. Drag a corner LED to refine its position.
+
+**Counter LEDs** — Click on a counter LED circle to toggle ON/OFF. Click the counter bounding box (outside individual LEDs) to toggle counter visibility.
+
+**ArUco area** — Click the ArUco region to cycle through marker IDs (0 → 21 → none).
+
+**Ring LEDs** — Two-click protocol: click a ring LED to set the first ON LED (arc start), then click another to set the first OFF LED (arc end). Clicking the same LED for both sets the ring as undecodable. Press `Esc` to cancel after the first click.
+
+### Ground Truth Format
+
+Annotations are saved to a JSON file with the following structure:
+
+```json
+{
+  "images": {
+    "subdir/image.png": {
+      "aruco": {"visible": true, "id": 0},
+      "corners": [
+        {"visible": true, "position": [123.4, 567.8]},
+        {"visible": true, "position": [890.1, 567.8]},
+        {"visible": false},
+        {"visible": true, "position": [123.4, 890.1]}
+      ],
+      "homography": [[...], [...], [...]],
+      "counter": {"visible": true, "value": 42},
+      "ring": {"start": 10, "end": 55}
+    }
+  }
+}
+```
+
+Fields:
+- `aruco.visible` / `aruco.id`: Whether the ArUco marker is visible and its detected ID (omitted when not visible).
+- `corners[i].visible` / `corners[i].position`: Per-corner-LED visibility and position in original image coordinates (position omitted when not visible).
+- `homography`: 3×3 matrix mapping original image → rectified board coordinates.
+- `counter.visible` / `counter.value`: Whether the binary counter is readable and its decoded value (omitted when not visible).
+- `ring.start` / `ring.end`: First ON and first OFF LED indices (0–99), half-open interval `[start, end)`. `start == end` means the ring is undecodable.
+
+## Validation Benchmark
+
+Runs the pipeline on all images in a directory and saves per-image results in a structure mirroring the ground truth format, plus per-step timing.
+
+```bash
+python -m rocsync.benchmark.validate [data_dir] [-o results.json] [--debug DIR]
+```
+
+- `data_dir`: Directory containing validation images (default: `validation_data/`).
+- `-o`: Output JSON file (default: `benchmark_results.json`).
+- `--debug`: Directory for debug images.
+
+Results JSON contains a `config` section and an `images` section with per-image aruco, corners, counter, ring, timestamp, success flag, and timing breakdown.
+
+## Benchmark Evaluation
+
+Compares benchmark results against ground truth annotations. Reports per-step detection metrics (TPR, FPR, precision, F1), value accuracy, and position errors.
+
+```bash
+python -m rocsync.benchmark.evaluate [paths...] [-g ground_truth.json] [-t]
+```
+
+- `paths`: Directory with benchmark `.json` files, or one or more explicit `.json` filepaths (default: `output/benchmark/`).
+- `-g`: Path to ground truth JSON (default: `validation_data/ground_truth.json`).
+- `-t`: Include per-step timing statistics (all/positive/negative subsets).
+
+Metrics are computed per pipeline step:
+- **ArUco**: detection rates + corner pixel error in image space
+- **Corners**: detection rates in image space and board space + pixel errors in both spaces
+- **Counter**: detection rates + value accuracy
+- **Ring**: detection rates + start/end value accuracy
+- **Overall**: timestamp detection + exact match accuracy + start/end/exposure error statistics

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -423,3 +423,14 @@ Timing columns are only comparable when the environments agree — check the Ope
 versions that `rocsync-evaluate` prints per column before reading `-t` output. Video decoding is
 part of that: annotations are in decoded coordinates, and OpenCV applies a container's rotation
 metadata itself, so a backend that did not would put every position in a transposed frame.
+
+## Adding videos to the benchmark
+
+I recommend to subsample videos to 1-2 fps to obtain 
+
+The following command subsamples videos to approximately 0.9 fps, while preserving exact frame timestamps:
+
+`ffmpeg -i input_video.mp4 -vf "select='isnan(prev_selected_t)+gte(t-prev_selected_t,1/0.9)'" -fps_mode passthrough -c:v libx264 -crf 18 -preset slow -an rocsync_benchmark/<subset>/output_video.mp4`
+
+When selecting the output framerate, avoid multiples of 100ms to collect frames with different ring arcs.
+I recommend 0.9 - 1.9 fps to minimize annotation cost.

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -38,7 +38,8 @@ The tool resumes from the first unannotated frame on restart.
 The window shows two panels side-by-side:
 
 - **Left**: Original image
-- **Right**: Rectified 640×640 board with color-coded LED overlays
+- **Right**: Rectified 640×640 board with color-coded LED overlays, drawn inside a 10 px margin
+  so LEDs that a loose fit pushes past the board edge stay visible and draggable
   - Red circle = ON, Blue circle = OFF, Gray circle = not visible
   - When the pipeline found the ArUco marker but failed to detect the corner LEDs, the board is
     rectified from the marker alone and the counter and ring are read off that coarse view. It is

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -2,6 +2,11 @@
 
 Tools for evaluating and annotating the RocSync vision pipeline against validation images.
 
+These are development tools: they run against a checkout, not an installed copy. Create the
+environment once with `uv sync` from `RocSync/sw`, then prefix each command with `uv run` to use
+it without activating anything. See the [Development section](../../README.md#development) of the
+main README.
+
 ## Annotation Tool
 
 Interactive GUI for creating ground truth annotations. Runs the pipeline on each image, displays the result with LED overlays, and lets you verify or correct the decoded values. Produces a `ground_truth.json` file for benchmark evaluation.
@@ -9,7 +14,7 @@ Interactive GUI for creating ground truth annotations. Runs the pipeline on each
 ### Usage
 
 ```bash
-python -m rocsync.benchmark.annotate [data_dir] [-o ground_truth.json]
+uv run rocsync-annotate [data_dir] [-o ground_truth.json]
 ```
 
 - `data_dir`: Directory containing validation images (default: `validation_data/`). Images are collected recursively (`.png`, `.jpg`, `.jpeg`).
@@ -85,7 +90,7 @@ Fields:
 Runs the pipeline on all images in a directory and saves per-image results in a structure mirroring the ground truth format, plus per-step timing.
 
 ```bash
-python -m rocsync.benchmark.validate [data_dir] [-o results.json] [--debug DIR]
+uv run rocsync-validate [data_dir] [-o results.json] [--debug DIR]
 ```
 
 - `data_dir`: Directory containing validation images (default: `validation_data/`).
@@ -99,7 +104,7 @@ Results JSON contains a `config` section and an `images` section with per-image 
 Compares benchmark results against ground truth annotations. Reports per-step detection metrics (TPR, FPR, precision, F1), value accuracy, and position errors.
 
 ```bash
-python -m rocsync.benchmark.evaluate [paths...] [-g ground_truth.json] [-t]
+uv run rocsync-evaluate [paths...] [-g ground_truth.json] [-t]
 ```
 
 - `paths`: Directory with benchmark `.json` files, or one or more explicit `.json` filepaths (default: `output/benchmark/`).

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -371,7 +371,9 @@ class AnnotationTool:
         cv2.namedWindow(WINDOW_NAME, cv2.WINDOW_NORMAL)
         cv2.setMouseCallback(WINDOW_NAME, self._mouse_callback)
 
-        while 0 <= self.current_idx < len(self.images):
+        n_images = len(self.images)
+        unreadable = 0  # consecutive read failures; bail out rather than spin forever
+        while True:
             image_path = self.images[self.current_idx]
             rel_path = str(image_path.relative_to(self.data_dir))
 
@@ -379,8 +381,13 @@ class AnnotationTool:
             if image is None:
                 print(f"Cannot read {image_path}", file=sys.stderr)
                 self._pump()
-                self.current_idx += 1
+                unreadable += 1
+                if unreadable >= n_images:
+                    print("No readable images.", file=sys.stderr)
+                    break
+                self.current_idx = (self.current_idx + 1) % n_images
                 continue
+            unreadable = 0
             self._pump()
 
             # Run pipeline
@@ -463,11 +470,11 @@ class AnnotationTool:
             if action == "accept":
                 self.ground_truth["images"][rel_path] = self.annotation.to_dict()
                 self._save_ground_truth()
-                self.current_idx += 1
+                self.current_idx = (self.current_idx + 1) % n_images
             elif action == "skip":
-                self.current_idx += 1
+                self.current_idx = (self.current_idx + 1) % n_images
             elif action == "back":
-                self.current_idx = max(0, self.current_idx - 1)
+                self.current_idx = (self.current_idx - 1) % n_images
             elif action == "next_unannotated":
                 self.current_idx = self._find_unannotated(self.current_idx, forward=True)
             elif action == "prev_unannotated":
@@ -1198,14 +1205,17 @@ class AnnotationTool:
             json.dump(self.ground_truth, f, indent=2)
 
     def _find_unannotated(self, from_idx, forward=True):
-        """Find the next/previous unannotated image index. Returns from_idx if none found."""
+        """Find the next/previous unannotated image index, wrapping around the list.
+
+        Returns from_idx if every image is annotated.
+        """
+        n = len(self.images)
         step = 1 if forward else -1
-        idx = from_idx + step
-        while 0 <= idx < len(self.images):
+        for k in range(1, n + 1):
+            idx = (from_idx + k * step) % n
             rel = str(self.images[idx].relative_to(self.data_dir))
             if rel not in self.ground_truth["images"]:
                 return idx
-            idx += step
         return from_idx
 
 

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -39,7 +39,7 @@ from rocsync.benchmark.common import (
 from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO, RectifiedBoard
 from rocsync.camera import CameraType
 from rocsync.timeline import frame_pts
-from rocsync.vision import ARUCO_DICTIONARY, process_frame
+from rocsync.vision import ARUCO_DICTIONARY, process_frame, read_counter, read_ring
 
 # Every board rectifies to the same pixel grid, so one radius serves the whole GUI.
 LED_RADIUS_PX = BOARD_V1.rectify().led_sample_radius
@@ -130,6 +130,40 @@ def fit_corner_homography(corners, board):
     return H
 
 
+def coarse_homography_from_aruco(stats, board):
+    """Fit original image → rectified board from the ArUco marker alone, or None.
+
+    Recomputed rather than taken from the pipeline's `rough_homography`: the annotator may
+    have resolved a different board profile, whose marker sits elsewhere in board coords.
+    """
+    corners = stats.get("aruco_corners")
+    if corners is None:
+        return None
+    src = np.array(corners, dtype=np.float32).reshape(4, 2)
+    try:
+        H = cv2.getPerspectiveTransform(src, board.aruco_corners_coords)
+    except cv2.error:
+        return None
+    if H is None or not np.isfinite(H).all():
+        return None
+    return H
+
+
+def decode_clock(rectified, board):
+    """(counter_leds, counter_value, ring_start, ring_end) read off a rectified board.
+
+    The ring is returned in the annotation's half-open ascending form; start == end means
+    no arc was found.
+    """
+    stats = {"steps": {}}
+    counter = read_counter(rectified, CameraType.RGB, board, stats=stats)
+    ring = read_ring(rectified, CameraType.RGB, board, stats=stats)
+    leds = [bool(v) for v in stats["counter_leds"]]
+    if ring is None:
+        return leds, counter, 0, 0
+    return leds, counter, int(ring[0]), int(ring[1] + 1) % board.period
+
+
 # Known ArUco marker IDs to cycle through
 ARUCO_IDS = [p.aruco_marker_id for p in PROFILES_BY_ARUCO.values()]
 
@@ -211,18 +245,13 @@ class ImageAnnotation:
             n = board.counter_bits
             ann.counter_value = sum(2 ** (n - 1 - i) for i in range(n) if counter_leds[i])
 
-        # Ring — read_ring returns inclusive (first ON, last ON).
-        # Convert to half-open [start, end) in ascending index order.
-        steps = stats.get("steps", {})
-        ring_step = steps.get("ring_reading", {})
-        if ring_step.get("success") and stats.get("timestamp"):
-            ts = stats["timestamp"]
-            counter_val = steps.get("counter_reading", {}).get("value", 0)
-            ann.ring_start = (ts[0] - counter_val * board.period) % board.period
-            ann.ring_end = (ts[1] - counter_val * board.period + 1) % board.period
-        elif stats.get("ring_leds") is not None:
-            ann.ring_start = 0
-            ann.ring_end = 0
+        # Ring — the decoded arc is inclusive (first ON, last ON). Convert to half-open
+        # [start, end) in ascending index order. An arc wrapping the period end is kept as
+        # seen; whether it yields a timestamp is reconstruct_timestamp's call, not ours.
+        ring = stats.get("ring_window")
+        if ring is not None:
+            ann.ring_start = int(ring[0])
+            ann.ring_end = int(ring[1] + 1) % board.period
 
         return ann
 
@@ -424,7 +453,9 @@ HELP_TEXT = [
     ". / ,             : Next / previous input file",
     "=== Rectified view ===",
     "Any corner edit re-fits the board view,",
-    "from 4 or more visible corner LEDs",
+    "from 4 or more visible corner LEDs, and",
+    "re-reads counter and ring off the new fit",
+    "until you annotate either by hand",
 ]
 
 
@@ -490,6 +521,9 @@ class AnnotationTool:
         # Corner the next left-panel click places; advances with each placement.
         self.placing_idx = 0
         self._cursor_left: tuple[float, float] | None = None
+        # Whether the user took over the clock / ring, which stops the auto re-decode
+        self._counter_edited = False
+        self._ring_edited = False
         self._needs_redraw = True
         self._window_sized = False
         # (annotation, board) before board-changing ArUco cycle
@@ -571,14 +605,22 @@ class AnnotationTool:
             self._set_board(board)
 
             # Load existing annotation or create from pipeline
-            if frame_key in self.ground_truth["images"]:
+            coarse_fit = False
+            saved = frame_key in self.ground_truth["images"]
+            if saved:
                 self.annotation = ImageAnnotation.from_dict(
                     self.ground_truth["images"][frame_key], board
                 )
             else:
                 self.annotation = ImageAnnotation.from_stats(self.stats, board)
-                # Use the pipeline homography for new annotations
+                # Use the pipeline homography for new annotations, falling back to the
+                # marker alone when corner detection failed — a coarse view to refine
+                # beats a black panel and corners parked at a guess.
                 H = self.stats.get("homography")
+                if H is None:
+                    H = coarse_homography_from_aruco(self.stats, board)
+                    if H is not None:
+                        coarse_fit = True
                 if H is not None:
                     self.annotation.homography = np.array(H, dtype=np.float64).tolist()
 
@@ -621,8 +663,18 @@ class AnnotationTool:
             self._cursor_left = None
             self.status_msg = ""
             self._needs_redraw = True
+            # A stored annotation was accepted as it stands, so it counts as hand-made:
+            # a corner nudge must not silently overwrite the reading it was accepted with.
+            self._counter_edited = saved
+            self._ring_edited = saved
 
             self._current_image = image
+
+            if coarse_fit:
+                # The pipeline stopped before reading anything, so seed the reading off
+                # the coarse view — wrong in detail, but a starting point to correct.
+                self._redecode_clock()
+                self.status_msg = "Coarse fit from ArUco marker — refine the corner LEDs"
             action = self._image_loop(image, frame_key)
 
             if action == "accept":
@@ -876,6 +928,7 @@ class AnnotationTool:
                 # CW first OFF → ascending start
                 self.annotation.ring_start = (idx + 1) % self.board.period
                 self.annotation.ring_end = (self._ring_start_candidate + 1) % self.board.period
+                self._ring_edited = True
                 self.mode = Mode.IDLE
                 self._ring_start_candidate = None
                 self.status_msg = ""
@@ -952,6 +1005,7 @@ class AnnotationTool:
         self._needs_redraw = True
 
     def _toggle_counter_led(self, idx):
+        self._counter_edited = True
         if self.annotation.counter_visible:
             self.annotation.counter_leds[idx] = not self.annotation.counter_leds[idx]
             self.annotation.recompute_counter()
@@ -960,6 +1014,7 @@ class AnnotationTool:
         self._needs_redraw = True
 
     def _toggle_counter_visibility(self):
+        self._counter_edited = True
         self.annotation.counter_visible = not self.annotation.counter_visible
         self._needs_redraw = True
 
@@ -1077,7 +1132,27 @@ class AnnotationTool:
         mask = original[:, :, 2]  # red channel
         bs = board.board_size
         self.stats["rectified"] = cv2.warpPerspective(mask, H, (bs, bs))
+        self._redecode_clock()
         return True
+
+    def _redecode_clock(self):
+        """Re-read counter and ring off the current rectified view.
+
+        Skips whichever the user has annotated by hand, so the auto-decode only ever fills
+        in what nobody has decided yet.
+        """
+        rectified = self.stats.get("rectified")
+        if rectified is None or (self._counter_edited and self._ring_edited):
+            return
+        leds, value, start, end = decode_clock(rectified, self.board)
+        ann = self.annotation
+        if not self._counter_edited:
+            ann.counter_visible = True
+            ann.counter_leds = leds
+            ann.counter_value = value
+        if not self._ring_edited:
+            ann.ring_start = start
+            ann.ring_end = end
 
     def _handle_ring_first_click(self, idx):
         """First ring click (CW first ON LED), then wait for CW first OFF LED."""

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -798,7 +798,9 @@ class AnnotationTool:
                 self.ground_truth["images"][frame_key] = self.annotation.to_dict()
                 self._mark_video_dirty(frame_key)
                 self._save_ground_truth()
-                self.current_idx = (self.current_idx + 1) % n_frames
+                # Show next unannotated frame, or next frame if no unannoted exists
+                nxt = self._find_unannotated(self.current_idx, forward=True)
+                self.current_idx = nxt if nxt != self.current_idx else (self.current_idx + 1) % n_frames
             elif action == "skip":
                 self.current_idx = (self.current_idx + 1) % n_frames
             elif action == "back":
@@ -1441,7 +1443,7 @@ class AnnotationTool:
 
         # Row 2: keyboard shortcuts, shrunk if they would reach past the panel split
         shortcuts = (
-            "Enter=Accept  Left/Right=Prev/Next  N/B=Skip to unannotated  "
+            "Enter/Space=Accept  Left/Right=Prev/Next  N/B=Skip to unannotated  "
             ",/.=Prev/Next file  0-N=Pick corner  C=Clear  Q=Quit  H=Help"
         )
         draw_text(

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -276,7 +276,17 @@ COLOR_BOARD_TEXT = (255, 255, 255)  # white text on dark board
 WINDOW_NAME = "RocSync Annotation"
 TARGET_HEIGHT = 800
 
+# Zoom inset shown while placing corners in the left panel.
+LOUPE_SIZE = 220  # on-screen size of the inset (px)
+LOUPE_SOURCE_PX = 70  # side of the original-image region it magnifies
+LOUPE_MARGIN = 12
+
 HELP_TEXT = [
+    "=== Mouse (left panel) ===",
+    "Click anywhere    : Place the pending corner,",
+    "                    then advance to the next",
+    "Drag corner LED   : Refine position",
+    "                    (zoom inset follows cursor)",
     "=== Mouse (right panel) ===",
     "Click corner LED  : Toggle visible / hidden",
     "Drag corner LED   : Refine position",
@@ -285,6 +295,8 @@ HELP_TEXT = [
     "Click ArUco area  : Cycle ID 0 / ID 21 / none",
     "Click ring LED    : Set first ON, then first OFF",
     "                    (same LED = undecodable)",
+    "=== Keys ===",
+    "0-N               : Place that corner next",
 ]
 
 
@@ -327,6 +339,9 @@ class AnnotationTool:
         self._drag_started = False
         self._drag_on_left = False
         self._ring_start_candidate: int | None = None
+        # Corner the next left-panel click places; advances with each placement.
+        self.placing_idx = 0
+        self._cursor_left: tuple[float, float] | None = None
         self._needs_redraw = True
         self._window_sized = False
         # (annotation, board) before board-changing ArUco cycle
@@ -442,6 +457,8 @@ class AnnotationTool:
 
             self.mode = Mode.IDLE
             self._ring_start_candidate = None
+            self.placing_idx = 0
+            self._cursor_left = None
             self.status_msg = ""
             self._needs_redraw = True
 
@@ -520,6 +537,8 @@ class AnnotationTool:
         elif key in (ord("h"), ord("H")):
             self.show_help = not self.show_help
             self._needs_redraw = True
+        elif ord("0") <= key <= ord("9"):
+            self._select_placing_corner(key - ord("0"))
         elif key == 27:  # Escape
             if self.mode == Mode.ARUCO_CONFIRM:
                 self._revert_aruco_change()
@@ -600,14 +619,20 @@ class AnnotationTool:
         # Try left panel (original image) — corners only
         ox, oy = self._display_to_original(x, y)
         if ox is not None and oy is not None:
+            self._cursor_left = (ox, oy)
+            if event == cv2.EVENT_MOUSEMOVE:
+                self._needs_redraw = True
             if event == cv2.EVENT_LBUTTONDOWN:
                 self._commit_aruco_change()
                 idx = self._hit_test_corner_original(ox, oy)
                 if idx is not None:
+                    # On a corner overlay: hold for a drag, release without one to place.
                     self._drag_idx = idx
                     self._drag_start_original = (ox, oy)
                     self._drag_started = False
                     self._drag_on_left = True
+                else:
+                    self._place_corner(ox, oy)
             elif event == cv2.EVENT_MOUSEMOVE and self._drag_on_left:
                 if (
                     self._drag_idx is not None
@@ -626,10 +651,11 @@ class AnnotationTool:
                         self._needs_redraw = True
             elif event == cv2.EVENT_LBUTTONUP and self._drag_on_left:
                 if self._drag_idx is not None:
-                    if not self._drag_started:
-                        self._cycle_corner_state(self._drag_idx)
-                    if all(c["visible"] for c in self.annotation.corners):
-                        self._recompute_homography(self._current_image)
+                    if self._drag_started:
+                        if all(c["visible"] for c in self.annotation.corners):
+                            self._recompute_homography(self._current_image)
+                    else:
+                        self._place_corner(ox, oy)
                     self._drag_idx = None
                     self._drag_started = False
                     self._drag_on_left = False
@@ -638,6 +664,10 @@ class AnnotationTool:
             return
 
         # Right panel (rectified board)
+        if self._cursor_left is not None:
+            self._cursor_left = None  # cursor left the loupe's panel
+            self._needs_redraw = True
+
         bx, by = self._display_to_board(x, y)
         if bx is None:
             return
@@ -711,6 +741,25 @@ class AnnotationTool:
             self._drag_started = False
             self.mode = Mode.IDLE
             self._needs_redraw = True
+
+    # ── Direct corner placement (left panel) ────────────────────────────
+
+    def _select_placing_corner(self, idx):
+        """Choose which corner the next left-panel click places."""
+        if not 0 <= idx < len(self.annotation.corners):
+            return
+        self.placing_idx = idx
+        self._needs_redraw = True
+
+    def _place_corner(self, ox, oy):
+        """Set the pending corner to the clicked point and advance to the next one."""
+        corner = self.annotation.corners[self.placing_idx]
+        corner["position"] = [ox, oy]
+        corner["visible"] = True
+        if all(c["visible"] for c in self.annotation.corners):
+            self._recompute_homography(self._current_image)
+        self.placing_idx = (self.placing_idx + 1) % len(self.annotation.corners)
+        self._needs_redraw = True
 
     def _cycle_corner_state(self, idx):
         c = self.annotation.corners[idx]
@@ -857,18 +906,33 @@ class AnnotationTool:
         font = cv2.FONT_HERSHEY_SIMPLEX
         ann = self.annotation
 
-        # Left panel: original image with corner LEDs
-        left = original.copy()
+        # Left panel: original image, downscaled first so the overlays are drawn
+        # at display resolution — sharp labels, and no full-res copies per redraw.
+        h = TARGET_HEIGHT
+        orig_h, orig_w = original.shape[:2]
+        self.left_scale = h / orig_h
+        left = cv2.resize(original, (round(orig_w * self.left_scale), h))
         left_h, left_w = left.shape[:2]
         corner_radius = int(max(0.01 * min(left_w, left_h), 2))
         overlay = left.copy()
         for i, c in enumerate(ann.corners):
-            cx, cy = round(c["position"][0]), round(c["position"][1])
+            cx = round(c["position"][0] * self.left_scale)
+            cy = round(c["position"][1] * self.left_scale)
             color = COLOR_ON if c["visible"] else COLOR_NOT_VIS
             cv2.circle(overlay, (cx, cy), corner_radius, (0, 255, 255), -1)
             cv2.circle(left, (cx, cy), corner_radius, color, 2)
+            if i == self.placing_idx:  # the corner the next click places
+                cv2.circle(left, (cx, cy), corner_radius + 5, COLOR_RING_SEL, 2)
             cv2.putText(left, str(i), (cx + corner_radius + 4, cy + 5), font, 0.5, color, 1)
         cv2.addWeighted(overlay, 0.35, left, 0.65, 0, dst=left)
+
+        # Which corner the next click places, and how to pick another. On a darkened
+        # strip so it stays readable over whatever the image happens to show.
+        hint = f"Click places corner {self.placing_idx}   (keys 0-{len(ann.corners) - 1})"
+        (tw, th), _ = cv2.getTextSize(hint, font, 0.55, 1)
+        strip = left[0 : th + 18, 0 : tw + 20]
+        cv2.addWeighted(strip, 0.25, np.zeros_like(strip), 0.75, 0, dst=strip)
+        cv2.putText(left, hint, (10, th + 8), font, 0.55, COLOR_RING_SEL, 1)
 
         # Right panel: rectified board with overlays
         bs = self.board.board_size
@@ -951,15 +1015,14 @@ class AnnotationTool:
             board_img, annotation_label, (tx, ty), font, font_scale, annotation_color, thickness
         )
 
-        # Scale both to common height
-        h = TARGET_HEIGHT
-        left_h, left_w = left.shape[:2]
-        left_scaled = cv2.resize(left, (int(left_w * h / left_h), h))
-        board_scaled = cv2.resize(board_img, (int(bs * h / bs), h))
+        # The left panel is already at the common height; scale the board to match.
+        left_scaled = left
+        board_scaled = cv2.resize(board_img, (h, h))
 
         self.left_panel_w = left_scaled.shape[1]
-        self.left_scale = h / left_h
         self.board_scale = h / bs
+
+        self._draw_loupe(left_scaled, original)
 
         # Status bar (3 rows: info, shortcuts, legend)
         row_h = 22
@@ -986,7 +1049,8 @@ class AnnotationTool:
 
         # Row 2: keyboard shortcuts
         shortcuts = (
-            "Enter=Accept  Left/Right=Prev/Next  N/B=Skip to unannotated  C=Clear  Q=Quit  H=Help"
+            "Enter=Accept  Left/Right=Prev/Next  N/B=Skip to unannotated  "
+            "0-N=Pick corner  C=Clear  Q=Quit  H=Help"
         )
         cv2.putText(
             status_bar,
@@ -1026,6 +1090,47 @@ class AnnotationTool:
 
         return composite
 
+    def _draw_loupe(self, panel, original):
+        """Overlay a magnified inset of the region under the cursor on the scaled left panel."""
+        if self._cursor_left is None:
+            return
+        ph, pw = panel.shape[:2]
+        if pw < LOUPE_SIZE + 2 * LOUPE_MARGIN or ph < LOUPE_SIZE + 2 * LOUPE_MARGIN:
+            return
+
+        font = cv2.FONT_HERSHEY_SIMPLEX
+        cx, cy = self._cursor_left
+        # getRectSubPix replicates the border, so cursors near the edge still work.
+        patch = cv2.getRectSubPix(
+            original, (LOUPE_SOURCE_PX, LOUPE_SOURCE_PX), (float(cx), float(cy))
+        )
+        loupe = cv2.resize(patch, (LOUPE_SIZE, LOUPE_SIZE), interpolation=cv2.INTER_NEAREST)
+        zoom = LOUPE_SIZE / LOUPE_SOURCE_PX
+        mid = LOUPE_SIZE // 2
+
+        # Corner markers falling inside the magnified region
+        for i, c in enumerate(self.annotation.corners):
+            px = round((c["position"][0] - cx) * zoom + mid)
+            py = round((c["position"][1] - cy) * zoom + mid)
+            if 0 <= px < LOUPE_SIZE and 0 <= py < LOUPE_SIZE:
+                color = COLOR_ON if c["visible"] else COLOR_NOT_VIS
+                cv2.circle(loupe, (px, py), 8, color, 1)
+                if i == self.placing_idx:
+                    cv2.circle(loupe, (px, py), 12, COLOR_RING_SEL, 1)
+                cv2.putText(loupe, str(i), (px + 14, py + 4), font, 0.4, color, 1)
+
+        # Crosshair marking the exact click point, with a gap so the pixel stays visible
+        for dx0, dy0, dx1, dy1 in ((-16, 0, -4, 0), (4, 0, 16, 0), (0, -16, 0, -4), (0, 4, 0, 16)):
+            cv2.line(loupe, (mid + dx0, mid + dy0), (mid + dx1, mid + dy1), COLOR_RING_SEL, 1)
+        cv2.rectangle(loupe, (0, 0), (LOUPE_SIZE - 1, LOUPE_SIZE - 1), COLOR_RING_SEL, 2)
+
+        # Park the inset opposite the cursor so it never hides the target
+        dx = cx * self.left_scale
+        dy = cy * self.left_scale
+        x0 = LOUPE_MARGIN if dx > pw / 2 else pw - LOUPE_SIZE - LOUPE_MARGIN
+        y0 = LOUPE_MARGIN if dy > ph / 2 else ph - LOUPE_SIZE - LOUPE_MARGIN
+        panel[y0 : y0 + LOUPE_SIZE, x0 : x0 + LOUPE_SIZE] = loupe
+
     @staticmethod
     def _led_in_ring_arc(idx, start, end):
         """Check if LED idx is ON in the half-open arc [start, end).
@@ -1048,7 +1153,10 @@ class AnnotationTool:
         overlay = img.copy()
         h, w = img.shape[:2]
         pad = 20
-        box_w, box_h = 380, len(HELP_TEXT) * 22 + 2 * pad
+        text_w = max(
+            cv2.getTextSize(line, cv2.FONT_HERSHEY_SIMPLEX, 0.45, 1)[0][0] for line in HELP_TEXT
+        )
+        box_w, box_h = text_w + 2 * pad, len(HELP_TEXT) * 22 + 2 * pad
         x0 = (w - box_w) // 2
         y0 = (h - box_h) // 2
         cv2.rectangle(overlay, (x0, y0), (x0 + box_w, y0 + box_h), (30, 30, 30), -1)

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -1,0 +1,1063 @@
+#!/usr/bin/env python3
+"""Interactive annotation and verification tool for RocSync benchmark images.
+
+Runs the rocsync pipeline on validation images, displays results with LED
+overlays, and lets the user verify or correct the decoded values. Produces
+a ground_truth.json file for benchmark evaluation.
+
+Usage:
+    python -m rocsync.benchmark.annotate [data_dir] [-o ground_truth.json]
+"""
+
+import argparse
+import copy
+import json
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from rocsync.vision import ARUCO_DICTIONARY, process_frame
+from rocsync.camera import CameraType
+from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO
+from rocsync.benchmark.common import collect_images
+
+# Every board rectifies to the same pixel grid, so one radius serves the whole GUI.
+LED_RADIUS_PX = BOARD_V1.rectify().led_sample_radius
+
+
+# ── Board geometry helpers ──────────────────────────────────────────────────
+
+def ring_led_positions(board):
+    """Return list of (x, y) tuples for ring LEDs in rectified board coords."""
+    return [(int(x), int(y)) for x, y in board.ring_led_coords(CameraType.RGB)]
+
+
+def counter_led_positions(board):
+    """Return list of (x, y) tuples for counter LEDs in rectified board coords."""
+    coords = board.counter_led_coords[CameraType.RGB]
+    return [(int(p[0]), int(p[1])) for p in coords]
+
+
+def corner_led_positions(board):
+    """Return list of (x, y) tuples for corner LEDs in rectified board coords."""
+    return [(int(p[0]), int(p[1])) for p in board.always_on_leds[CameraType.RGB]]
+
+
+def counter_bbox(counter_pos):
+    """Compute counter bounding box (x1, y1, x2, y2) with margin around LEDs."""
+    cx = [p[0] for p in counter_pos]
+    cy = [p[1] for p in counter_pos]
+    return (
+        min(cx) - LED_RADIUS_PX - 10,
+        min(cy) - LED_RADIUS_PX - 10,
+        max(cx) + LED_RADIUS_PX + 10,
+        max(cy) + LED_RADIUS_PX + 10,
+    )
+
+
+# Known ArUco marker IDs to cycle through
+ARUCO_IDS = [p.aruco_marker_id for p in PROFILES_BY_ARUCO.values()]
+
+# Hit-test radii (in board coordinates)
+HIT_CORNER = 20
+HIT_COUNTER = LED_RADIUS_PX
+HIT_RING = 25
+DRAG_THRESHOLD = 3  # px before a click becomes a drag
+
+
+# ── Annotation data ────────────────────────────────────────────────────────
+
+@dataclass
+class ImageAnnotation:
+    """Mutable annotation state for a single image.
+
+    Corner LED positions are stored in original image coordinates (float).
+    The homography maps original image → rectified board space and is needed
+    to display / edit positions on the rectified view.
+
+    Ring uses half-open semantics: ring_start = first ON LED,
+    ring_end = first OFF LED.  ring_start == ring_end means undecodable.
+    """
+    board: object = None  # BoardProfile (not serialized)
+
+    aruco_visible: bool = False
+    aruco_id: int = 0
+
+    # Each corner: {"visible": bool, "position": [x, y]}
+    # position is in *original image* coordinates (float)
+    corners: list = field(default_factory=list)
+
+    # Homography: original image → rectified board (3×3, stored as list-of-lists)
+    homography: list | None = None
+
+    counter_visible: bool = False
+    counter_leds: list = field(default_factory=list)
+    counter_value: int = 0
+
+    ring_start: int = 0  # first ON LED index
+    ring_end: int = 0    # first OFF LED index (exclusive); == start → undecodable
+
+    def __post_init__(self):
+        if not self.corners and self.board is not None:
+            corner_pos = corner_led_positions(self.board)
+            self.corners = [
+                {"visible": False, "position": list(p)} for p in corner_pos
+            ]
+        if not self.counter_leds and self.board is not None:
+            self.counter_leds = [False] * self.board.counter_bits
+
+    @classmethod
+    def from_stats(cls, stats, board):
+        """Pre-populate annotation from pipeline stats dict."""
+        ann = cls(board=board)
+
+        # Homography (original → rectified)
+        H = stats.get("homography")
+        if H is not None:
+            H = np.array(H, dtype=np.float64)
+            ann.homography = H.tolist()
+
+        # ArUco
+        aruco_id = stats.get("aruco_id")
+        ann.aruco_visible = aruco_id is not None
+        ann.aruco_id = aruco_id if aruco_id is not None else 0
+
+        # Corner LEDs — stats positions are in rough-rectified space,
+        # convert to original image space via the rough homography inverse.
+        corner_positions = stats.get("corner_positions")
+        aruco_corners = stats.get("aruco_corners")
+        if corner_positions is not None and aruco_corners is not None:
+            rough_H = cv2.getPerspectiveTransform(
+                np.array(aruco_corners, dtype=np.float32),
+                board.aruco_corners_coords,
+            )
+            inv_rough = np.linalg.inv(rough_H)
+            for i, pos in enumerate(corner_positions):
+                if i < len(ann.corners) and pos is not None:
+                    pt = np.array([[pos]], dtype=np.float64)
+                    orig_pt = cv2.perspectiveTransform(pt, inv_rough).reshape(2)
+                    ann.corners[i]["visible"] = True
+                    ann.corners[i]["position"] = [float(orig_pt[0]), float(orig_pt[1])]
+
+        # Counter
+        counter_leds = stats.get("counter_leds")
+        if counter_leds is not None:
+            ann.counter_visible = True
+            ann.counter_leds = list(counter_leds)
+            n = board.counter_bits
+            ann.counter_value = sum(2 ** (n - 1 - i) for i in range(n) if counter_leds[i])
+
+        # Ring — read_ring returns inclusive (first ON, last ON).
+        # Convert to half-open [start, end) in ascending index order.
+        steps = stats.get("steps", {})
+        ring_step = steps.get("ring_reading", {})
+        if ring_step.get("success") and stats.get("timestamp"):
+            ts = stats["timestamp"]
+            counter_val = steps.get("counter_reading", {}).get("value", 0)
+            ann.ring_start = (ts[0] - counter_val * board.period) % board.period
+            ann.ring_end = (ts[1] - counter_val * board.period + 1) % board.period
+        elif stats.get("ring_leds") is not None:
+            ann.ring_start = 0
+            ann.ring_end = 0
+
+        return ann
+
+    def recompute_counter(self):
+        n = self.board.counter_bits
+        self.counter_value = sum(2 ** (n - 1 - i) for i in range(n) if self.counter_leds[i])
+
+    def to_original(self, board_x, board_y):
+        """Transform a point from rectified board coords to original image coords."""
+        if self.homography is None:
+            return [float(board_x), float(board_y)]
+        inv_H = np.linalg.inv(np.array(self.homography, dtype=np.float64))
+        pt = np.array([[[board_x, board_y]]], dtype=np.float64)
+        orig = cv2.perspectiveTransform(pt, inv_H).reshape(2)
+        return [float(orig[0]), float(orig[1])]
+
+    def to_board(self, orig_x, orig_y):
+        """Transform a point from original image coords to rectified board coords."""
+        if self.homography is None:
+            return int(round(orig_x)), int(round(orig_y))
+        H = np.array(self.homography, dtype=np.float64)
+        pt = np.array([[[orig_x, orig_y]]], dtype=np.float64)
+        board = cv2.perspectiveTransform(pt, H).reshape(2)
+        return int(round(board[0])), int(round(board[1]))
+
+    def to_dict(self):
+        """Serialize annotation. Invisible components are stripped to visibility only."""
+        corners = []
+        for c in self.corners:
+            if c["visible"]:
+                corners.append({"visible": True, "position": c["position"]})
+            else:
+                corners.append({"visible": False})
+
+        result = {
+            "aruco": {"visible": self.aruco_visible},
+            "corners": corners,
+            "homography": self.homography,
+            "counter": {"visible": self.counter_visible},
+            "ring": {},
+        }
+
+        if self.aruco_visible:
+            result["aruco"]["id"] = self.aruco_id
+        if self.counter_visible:
+            result["counter"]["value"] = self.counter_value
+        if self.ring_start == self.ring_end:
+            self.ring_start = 0
+            self.ring_end = 0
+        result["ring"]["start"] = self.ring_start
+        result["ring"]["end"] = self.ring_end
+
+        return result
+
+    @classmethod
+    def from_dict(cls, data, board):
+        ann = cls(board=board)
+        aruco = data.get("aruco", {})
+        ann.aruco_visible = aruco.get("visible", False)
+        ann.aruco_id = aruco.get("id", 0)
+
+        ann.homography = data.get("homography")
+
+        corner_pos = corner_led_positions(board)
+        for i, c in enumerate(data.get("corners", [])):
+            if i < len(ann.corners):
+                if "position" in c:
+                    pos = list(c["position"])
+                elif ann.homography is not None:
+                    pos = ann.to_original(*corner_pos[i])
+                else:
+                    pos = list(corner_pos[i])
+                ann.corners[i] = {
+                    "visible": c.get("visible", False),
+                    "position": pos,
+                }
+
+        counter = data.get("counter", {})
+        ann.counter_visible = counter.get("visible", False)
+        ann.counter_value = counter.get("value", 0)
+        n = board.counter_bits
+        ann.counter_leds = [
+            bool(ann.counter_value & (2 ** (n - 1 - i))) for i in range(n)
+        ]
+
+        ring = data.get("ring", {})
+        ann.ring_start = ring.get("start", 0)
+        ann.ring_end = ring.get("end", 0)
+        return ann
+
+
+# ── Interaction state ───────────────────────────────────────────────────────
+
+class Mode(Enum):
+    IDLE = "idle"
+    DRAGGING_CORNER = "dragging"
+    RING_AWAITING_END = "ring_end"
+    ARUCO_CONFIRM = "aruco_confirm"  # board profile changed, Esc to revert
+
+
+# ── Display and interaction ─────────────────────────────────────────────────
+
+COLOR_ON = (0, 0, 255)           # red  — LED is ON
+COLOR_OFF = (255, 0, 0)          # blue — LED is OFF
+COLOR_NOT_VIS = (128, 128, 128)  # gray — component hidden/undecodable
+COLOR_RING_SEL = (0, 255, 0)     # green — ring selection highlight
+COLOR_TEXT = (0, 0, 0)           # black text on bright bg
+COLOR_STATUS_BG = (220, 220, 220)  # light gray
+COLOR_BOARD_TEXT = (255, 255, 255)  # white text on dark board
+
+WINDOW_NAME = "RocSync Annotation"
+TARGET_HEIGHT = 800
+
+HELP_TEXT = [
+    "=== Mouse (right panel) ===",
+    "Click corner LED  : Toggle visible / hidden",
+    "Drag corner LED   : Refine position",
+    "Click counter LED : Toggle ON / OFF",
+    "Click counter box : Toggle counter visibility",
+    "Click ArUco area  : Cycle ID 0 / ID 21 / none",
+    "Click ring LED    : Set first ON, then first OFF",
+    "                    (same LED = undecodable)",
+]
+
+
+class AnnotationTool:
+    def __init__(self, data_dir, output_path=None):
+        self.data_dir = Path(data_dir)
+        self.output_path = Path(output_path) if output_path else self.data_dir / "ground_truth.json"
+        self.ground_truth = {"images": {}}
+        self.images = []
+        self.current_idx = 0
+
+        # Board profile and derived geometry (set per-image)
+        self.board = BOARD_V1.rectify()
+        self.ring_pos = ring_led_positions(self.board)
+        self.counter_pos = counter_led_positions(self.board)
+        self.corner_pos = corner_led_positions(self.board)
+        self.counter_box = counter_bbox(self.counter_pos)
+        self.aruco_x1 = int(self.board.aruco_corners_coords[0][0])
+        self.aruco_y1 = int(self.board.aruco_corners_coords[0][1])
+        self.aruco_x2 = int(self.board.aruco_corners_coords[2][0])
+        self.aruco_y2 = int(self.board.aruco_corners_coords[2][1])
+
+        # Display state
+        self.show_help = False
+        self.left_panel_w = 0
+        self.left_scale = 1.0
+        self.board_scale = 1.0
+        self.status_msg = ""
+
+        # Interaction state
+        self.mode = Mode.IDLE
+        self.annotation = None
+        self.stats = None
+        self._current_image = None
+        self._drag_idx = None
+        self._drag_start = None
+        self._drag_start_original = None
+        self._drag_started = False
+        self._drag_on_left = False
+        self._ring_start_candidate = None
+        self._needs_redraw = True
+        self._window_sized = False
+        self._aruco_snapshot = None   # (annotation, board) before board-changing ArUco cycle
+
+    def _set_board(self, board):
+        """Update board profile and recompute derived geometry."""
+        self.board = board
+        self.ring_pos = ring_led_positions(board)
+        self.counter_pos = counter_led_positions(board)
+        self.corner_pos = corner_led_positions(board)
+        self.counter_box = counter_bbox(self.counter_pos)
+        self.aruco_x1 = int(board.aruco_corners_coords[0][0])
+        self.aruco_y1 = int(board.aruco_corners_coords[0][1])
+        self.aruco_x2 = int(board.aruco_corners_coords[2][0])
+        self.aruco_y2 = int(board.aruco_corners_coords[2][1])
+
+    # ── Main loop ───────────────────────────────────────────────────────
+
+    def run(self):
+        self.images = sorted(collect_images(self.data_dir))
+        if not self.images:
+            print("No images found.", file=sys.stderr)
+            return
+
+        self._load_ground_truth()
+        first = self._find_unannotated(-1, forward=True)
+        if first == -1:
+            print("All images already annotated. Starting from the beginning.")
+            self.current_idx = 0
+        else:
+            self.current_idx = first
+            rel = str(self.images[first].relative_to(self.data_dir))
+            print(f"Resuming at image {first + 1}/{len(self.images)}: {rel}")
+
+        cv2.namedWindow(WINDOW_NAME, cv2.WINDOW_NORMAL)
+        cv2.setMouseCallback(WINDOW_NAME, self._mouse_callback)
+
+        while 0 <= self.current_idx < len(self.images):
+            image_path = self.images[self.current_idx]
+            rel_path = str(image_path.relative_to(self.data_dir))
+
+            image = cv2.imread(str(image_path))
+            if image is None:
+                print(f"Cannot read {image_path}", file=sys.stderr)
+                self.current_idx += 1
+                continue
+
+            # Run pipeline
+            self.stats = {}
+            try:
+                process_frame(image, CameraType.RGB, 0, stats=self.stats)
+            except Exception as e:
+                print(f"Pipeline error on {rel_path}: {e}", file=sys.stderr)
+                self.stats["rectified"] = None
+                self.stats["aruco_id"] = None
+
+            # Resolve board profile from pipeline detection or saved annotation
+            aruco_id = self.stats.get("aruco_id")
+            if rel_path in self.ground_truth["images"]:
+                saved_id = self.ground_truth["images"][rel_path].get("aruco", {}).get("id")
+                if saved_id is not None:
+                    aruco_id = saved_id
+            board = PROFILES_BY_ARUCO.get(aruco_id, BOARD_V1).rectify()
+            self._set_board(board)
+
+            # Load existing annotation or create from pipeline
+            if rel_path in self.ground_truth["images"]:
+                self.annotation = ImageAnnotation.from_dict(
+                    self.ground_truth["images"][rel_path], board)
+            else:
+                self.annotation = ImageAnnotation.from_stats(self.stats, board)
+                # Use the pipeline homography for new annotations
+                H = self.stats.get("homography")
+                if H is not None:
+                    self.annotation.homography = np.array(H, dtype=np.float64).tolist()
+
+            # Ensure invisible corners have positions in original image coords
+            if self.annotation.homography is not None:
+                for i, c in enumerate(self.annotation.corners):
+                    if not c["visible"]:
+                        c["position"] = self.annotation.to_original(*self.corner_pos[i])
+            else:
+                # No homography — place invisible corners in a centered square
+                # proportional to the board's corner layout.
+                img_h, img_w = image.shape[:2]
+                scale = 0.5 * min(img_w, img_h) / board.board_size
+                ox = (img_w - board.board_size * scale) / 2
+                oy = (img_h - board.board_size * scale) / 2
+                for i, c in enumerate(self.annotation.corners):
+                    if not c["visible"]:
+                        bx, by = self.corner_pos[i]
+                        c["position"] = [ox + bx * scale, oy + by * scale]
+
+            # Re-warp the rectified image using the annotation's homography
+            # so the displayed image is consistent with to_original/to_board.
+            # This matters when loading a saved annotation whose homography
+            # differs from the pipeline's (e.g. user corrected corners earlier).
+            if all(c["visible"] for c in self.annotation.corners):
+                self._recompute_homography(image)
+            elif self.annotation.homography is not None:
+                # Not all corners visible but we have a saved homography.
+                # Warp using it so the displayed image matches to_original/to_board.
+                H = np.array(self.annotation.homography, dtype=np.float64)
+                mask = image[:, :, 2]
+                self.stats["rectified"] = cv2.warpPerspective(
+                    mask, H, (board.board_size, board.board_size))
+
+            self.mode = Mode.IDLE
+            self._ring_start_candidate = None
+            self.status_msg = ""
+            self._needs_redraw = True
+
+            self._current_image = image
+            action = self._image_loop(image, rel_path)
+
+            if action == "accept":
+                self.ground_truth["images"][rel_path] = self.annotation.to_dict()
+                self._save_ground_truth()
+                self.current_idx += 1
+            elif action == "skip":
+                self.current_idx += 1
+            elif action == "back":
+                self.current_idx = max(0, self.current_idx - 1)
+            elif action == "next_unannotated":
+                self.current_idx = self._find_unannotated(self.current_idx, forward=True)
+            elif action == "prev_unannotated":
+                self.current_idx = self._find_unannotated(self.current_idx, forward=False)
+            elif action == "clear":
+                self.ground_truth["images"].pop(rel_path, None)
+                self._save_ground_truth()
+                # stay on current image — re-runs pipeline on next iteration
+            elif action == "quit":
+                break
+
+        cv2.destroyAllWindows()
+
+    def _image_loop(self, image, rel_path):
+        composite = None
+        while True:
+            if self._needs_redraw:
+                composite = self._render(image, rel_path)
+                if not self._window_sized:
+                    h, w = composite.shape[:2]
+                    cv2.resizeWindow(WINDOW_NAME, w, h)
+                    self._window_sized = True
+                cv2.imshow(WINDOW_NAME, composite)
+                self._needs_redraw = False
+
+            key = cv2.waitKey(30) & 0xFF
+
+            if cv2.getWindowProperty(WINDOW_NAME, cv2.WND_PROP_VISIBLE) < 1:
+                return "quit"
+
+            if key == 255:
+                continue
+
+            action = self._process_key(key)
+            if action is not None:
+                return action
+
+    # ── Keyboard handling ───────────────────────────────────────────────
+
+    def _process_key(self, key):
+        if key in (13, 10, 32):  # Enter or Space
+            self._commit_aruco_change()
+            return "accept"
+        elif key == 83 or key == ord('d'):  # Right arrow
+            self._commit_aruco_change()
+            return "skip"
+        elif key == 81 or key == ord('a'):  # Left arrow
+            self._commit_aruco_change()
+            return "back"
+        elif key in (ord('n'), ord('N')):
+            self._commit_aruco_change()
+            return "next_unannotated"
+        elif key in (ord('b'), ord('B')):
+            self._commit_aruco_change()
+            return "prev_unannotated"
+        elif key in (ord('c'), ord('C'), 8, 127):  # C or Backspace
+            self._commit_aruco_change()
+            return "clear"
+        elif key in (ord('q'), ord('Q')):
+            self._commit_aruco_change()
+            return "quit"
+        elif key in (ord('h'), ord('H')):
+            self.show_help = not self.show_help
+            self._needs_redraw = True
+        elif key == 27:  # Escape
+            if self.mode == Mode.ARUCO_CONFIRM:
+                self._revert_aruco_change()
+            elif self.mode == Mode.RING_AWAITING_END:
+                self.mode = Mode.IDLE
+                self._ring_start_candidate = None
+                self.status_msg = ""
+                self._needs_redraw = True
+        return None
+
+    # ── Mouse handling ──────────────────────────────────────────────────
+
+    def _display_to_board(self, x, y):
+        """Convert display pixel coords to board coords. Returns None if outside board panel."""
+        if x < self.left_panel_w:
+            return None, None
+        panel_x = x - self.left_panel_w
+        bx = int(panel_x / self.board_scale)
+        by = int(y / self.board_scale)
+        bs = self.board.board_size
+        if bx < 0 or bx >= bs or by < 0 or by >= bs:
+            return None, None
+        return bx, by
+
+    def _display_to_original(self, x, y):
+        """Convert display pixel coords to original image coords. Returns None if outside left panel."""
+        if x >= self.left_panel_w:
+            return None, None
+        ox = x / self.left_scale
+        oy = y / self.left_scale
+        return ox, oy
+
+    def _hit_test(self, bx, by):
+        """Returns (element_type, index) or (None, None)."""
+        # 1. Corner LEDs
+        for i, c in enumerate(self.annotation.corners):
+            cx, cy = self.annotation.to_board(*c["position"])
+            if (bx - cx) ** 2 + (by - cy) ** 2 <= HIT_CORNER ** 2:
+                return "corner", i
+
+        # 2. Counter LEDs (individual)
+        for i, (cx, cy) in enumerate(self.counter_pos):
+            if (bx - cx) ** 2 + (by - cy) ** 2 <= HIT_COUNTER ** 2:
+                return "counter", i
+
+        # 3. Counter bounding box (outside LED circles → toggle visibility)
+        x1, y1, x2, y2 = self.counter_box
+        if x1 <= bx <= x2 and y1 <= by <= y2:
+            return "counter_bbox", 0
+
+        # 4. ArUco region
+        if self.aruco_x1 <= bx <= self.aruco_x2 and self.aruco_y1 <= by <= self.aruco_y2:
+            return "aruco", 0
+
+        # 5. Ring LEDs (nearest within radius)
+        best_i, best_d = 0, float('inf')
+        for i, (rx, ry) in enumerate(self.ring_pos):
+            d = (bx - rx) ** 2 + (by - ry) ** 2
+            if d < best_d:
+                best_d = d
+                best_i = i
+        if best_d <= HIT_RING ** 2:
+            return "ring", best_i
+
+        return None, None
+
+    def _hit_test_corner_original(self, ox, oy):
+        """Hit-test corners in original image coordinates."""
+        img_h, img_w = self._current_image.shape[:2]
+        hit_r = 2 * int(max(0.01 * min(img_w, img_h), 2))
+        for i, c in enumerate(self.annotation.corners):
+            cx, cy = c["position"]
+            if (ox - cx) ** 2 + (oy - cy) ** 2 <= hit_r ** 2:
+                return i
+        return None
+
+    def _mouse_callback(self, event, x, y, flags, param):
+        # Try left panel (original image) — corners only
+        ox, oy = self._display_to_original(x, y)
+        if ox is not None:
+            if event == cv2.EVENT_LBUTTONDOWN:
+                self._commit_aruco_change()
+                idx = self._hit_test_corner_original(ox, oy)
+                if idx is not None:
+                    self._drag_idx = idx
+                    self._drag_start_original = (ox, oy)
+                    self._drag_started = False
+                    self._drag_on_left = True
+            elif event == cv2.EVENT_MOUSEMOVE and self._drag_on_left:
+                if self._drag_idx is not None and (flags & cv2.EVENT_FLAG_LBUTTON):
+                    dx = ox - self._drag_start_original[0]
+                    dy = oy - self._drag_start_original[1]
+                    img_h, img_w = self._current_image.shape[:2]
+                    threshold = int(max(0.01 * min(img_w, img_h), DRAG_THRESHOLD))
+                    if not self._drag_started and (dx * dx + dy * dy) > threshold ** 2:
+                        self._drag_started = True
+                        self.mode = Mode.DRAGGING_CORNER
+                    if self._drag_started:
+                        self.annotation.corners[self._drag_idx]["position"] = [ox, oy]
+                        self._needs_redraw = True
+            elif event == cv2.EVENT_LBUTTONUP and self._drag_on_left:
+                if self._drag_idx is not None:
+                    if not self._drag_started:
+                        self._cycle_corner_state(self._drag_idx)
+                    if all(c["visible"] for c in self.annotation.corners):
+                        self._recompute_homography(self._current_image)
+                    self._drag_idx = None
+                    self._drag_started = False
+                    self._drag_on_left = False
+                    self.mode = Mode.IDLE
+                    self._needs_redraw = True
+            return
+
+        # Right panel (rectified board)
+        bx, by = self._display_to_board(x, y)
+        if bx is None:
+            return
+
+        if event == cv2.EVENT_LBUTTONDOWN:
+            self._drag_on_left = False
+            self._on_left_down(bx, by)
+        elif event == cv2.EVENT_MOUSEMOVE:
+            self._on_mouse_move(bx, by, flags)
+        elif event == cv2.EVENT_LBUTTONUP:
+            self._on_left_up(bx, by)
+
+    def _on_left_down(self, bx, by):
+        if self.mode == Mode.RING_AWAITING_END:
+            elem, idx = self._hit_test(bx, by)
+            if elem == "ring":
+                # Convert CW clicks to ascending [start, end):
+                # CW first ON  → ascending end (exclusive)
+                # CW first OFF → ascending start
+                self.annotation.ring_start = (idx + 1) % self.board.period
+                self.annotation.ring_end = (self._ring_start_candidate + 1) % self.board.period
+                self.mode = Mode.IDLE
+                self._ring_start_candidate = None
+                self.status_msg = ""
+                self._needs_redraw = True
+            return
+
+        elem, idx = self._hit_test(bx, by)
+        if elem != "aruco":
+            self._commit_aruco_change()
+        if elem == "corner":
+            self._drag_idx = idx
+            self._drag_start = (bx, by)
+            self._drag_started = False
+        elif elem == "counter":
+            self._toggle_counter_led(idx)
+        elif elem == "counter_bbox":
+            self._toggle_counter_visibility()
+        elif elem == "aruco":
+            self._cycle_aruco()
+        elif elem == "ring":
+            self._handle_ring_first_click(idx)
+
+    def _on_mouse_move(self, bx, by, flags):
+        if self._drag_idx is not None and (flags & cv2.EVENT_FLAG_LBUTTON):
+            dx = bx - self._drag_start[0]
+            dy = by - self._drag_start[1]
+            if not self._drag_started and (dx * dx + dy * dy) > DRAG_THRESHOLD ** 2:
+                self._drag_started = True
+                self.mode = Mode.DRAGGING_CORNER
+            if self._drag_started:
+                bs = self.board.board_size
+                cbx = max(0, min(bs - 1, bx))
+                cby = max(0, min(bs - 1, by))
+                self.annotation.corners[self._drag_idx]["position"] = \
+                    self.annotation.to_original(cbx, cby)
+                self._needs_redraw = True
+
+    def _on_left_up(self, bx, by):
+        if self._drag_idx is not None:
+            if not self._drag_started:
+                self._cycle_corner_state(self._drag_idx)
+            if all(c["visible"] for c in self.annotation.corners):
+                self._recompute_homography(self._current_image)
+            self._drag_idx = None
+            self._drag_started = False
+            self.mode = Mode.IDLE
+            self._needs_redraw = True
+
+    def _cycle_corner_state(self, idx):
+        c = self.annotation.corners[idx]
+        c["visible"] = not c["visible"]
+        self._needs_redraw = True
+
+    def _toggle_counter_led(self, idx):
+        if self.annotation.counter_visible:
+            self.annotation.counter_leds[idx] = not self.annotation.counter_leds[idx]
+            self.annotation.recompute_counter()
+        else:
+            self.annotation.counter_visible = True
+        self._needs_redraw = True
+
+    def _toggle_counter_visibility(self):
+        self.annotation.counter_visible = not self.annotation.counter_visible
+        self._needs_redraw = True
+
+    def _cycle_aruco(self):
+        ann = self.annotation
+
+        # Determine the new ArUco state
+        new_visible = ann.aruco_visible
+        new_id = ann.aruco_id
+        if not ann.aruco_visible:
+            new_visible = True
+            new_id = ARUCO_IDS[0]
+        else:
+            try:
+                idx = ARUCO_IDS.index(ann.aruco_id)
+                if idx + 1 < len(ARUCO_IDS):
+                    new_id = ARUCO_IDS[idx + 1]
+                else:
+                    new_visible = False
+            except ValueError:
+                new_visible = False
+
+        # Snapshot on first cycle; subsequent cycles update in-place
+        if self._aruco_snapshot is None:
+            self._aruco_snapshot = (copy.deepcopy(self.annotation), self.board)
+
+        # Check if the board profile changes
+        new_board = PROFILES_BY_ARUCO.get(new_id, self.board) if new_visible else self.board
+        board_changes = new_board is not self.board
+
+        if board_changes:
+            snap_ann, snap_board = self._aruco_snapshot
+            self._set_board(new_board)
+
+            if new_board is snap_board:
+                # Cycling back to the snapshot's board — restore full annotations
+                self.annotation = copy.deepcopy(snap_ann)
+                self.annotation.aruco_visible = new_visible
+                self.annotation.aruco_id = new_id
+            else:
+                # Different board — build fresh annotation
+                new_ann = ImageAnnotation(board=new_board)
+                new_ann.aruco_visible = new_visible
+                new_ann.aruco_id = new_id
+                # Carry over board-independent state
+                new_ann.homography = ann.homography
+                if new_board.period == ann.board.period:
+                    new_ann.ring_start = ann.ring_start
+                    new_ann.ring_end = ann.ring_end
+                # Place corners at the new board's default positions.
+                # If a homography is available, convert to original image coords.
+                new_corner_pos = corner_led_positions(new_board)
+                for i, c in enumerate(new_ann.corners):
+                    if new_ann.homography is not None:
+                        c["position"] = new_ann.to_original(*new_corner_pos[i])
+                    else:
+                        c["position"] = list(new_corner_pos[i])
+                    c["visible"] = False
+                self.annotation = new_ann
+
+            self.status_msg = f"Board changed to {new_board.name} — Esc to undo"
+        else:
+            ann.aruco_visible = new_visible
+            ann.aruco_id = new_id
+            self.status_msg = "ArUco changed — Esc to undo"
+
+        self.mode = Mode.ARUCO_CONFIRM
+        self._needs_redraw = True
+
+    def _commit_aruco_change(self):
+        """Discard ArUco snapshot, committing the board profile change."""
+        if self._aruco_snapshot is not None:
+            self._aruco_snapshot = None
+            if self.mode == Mode.ARUCO_CONFIRM:
+                self.mode = Mode.IDLE
+                self.status_msg = ""
+                self._needs_redraw = True
+
+    def _revert_aruco_change(self):
+        """Restore annotation and board profile from snapshot."""
+        if self._aruco_snapshot is None:
+            return
+        self.annotation, old_board = self._aruco_snapshot
+        self._aruco_snapshot = None
+        self._set_board(old_board)
+        self.mode = Mode.IDLE
+        self.status_msg = ""
+        self._needs_redraw = True
+
+    def _recompute_homography(self, original):
+        """Recompute homography and re-warp rectified image from all visible corners."""
+        ann = self.annotation
+        board = self.board
+        visible = [c for c in ann.corners if c["visible"]]
+        if len(visible) < 4:
+            return
+        src = np.array([c["position"] for c in ann.corners if c["visible"]], dtype=np.float32)
+        dst = np.array([board.always_on_leds[CameraType.RGB][i] for i, c in enumerate(ann.corners) if c["visible"]], dtype=np.float32)
+        if len(src) == 4:
+            H = cv2.getPerspectiveTransform(src, dst)
+        else:
+            H, _ = cv2.findHomography(src, dst)
+        ann.homography = H.tolist()
+        mask = original[:, :, 2]  # red channel
+        bs = board.board_size
+        self.stats["rectified"] = cv2.warpPerspective(mask, H, (bs, bs))
+
+    def _handle_ring_first_click(self, idx):
+        """First ring click (CW first ON LED), then wait for CW first OFF LED."""
+        self._ring_start_candidate = idx
+        self.mode = Mode.RING_AWAITING_END
+        self.status_msg = f"Ring: (clock-wise) first ON={idx}, click first OFF LED..."
+        self._needs_redraw = True
+
+    # ── Rendering ───────────────────────────────────────────────────────
+
+    def _render(self, original, rel_path):
+        """Build the composite side-by-side display image."""
+        font = cv2.FONT_HERSHEY_SIMPLEX
+        ann = self.annotation
+
+        # Left panel: original image with corner LEDs
+        left = original.copy()
+        left_h, left_w = left.shape[:2]
+        corner_radius = int(max(0.01 * min(left_w, left_h), 2))
+        overlay = left.copy()
+        for i, c in enumerate(ann.corners):
+            cx, cy = int(round(c["position"][0])), int(round(c["position"][1]))
+            color = COLOR_ON if c["visible"] else COLOR_NOT_VIS
+            cv2.circle(overlay, (cx, cy), corner_radius, (0, 255, 255), -1)
+            cv2.circle(left, (cx, cy), corner_radius, color, 2)
+            cv2.putText(left, str(i), (cx + corner_radius + 4, cy + 5),
+                        font, 0.5, color, 1)
+        cv2.addWeighted(overlay, 0.35, left, 0.65, 0, dst=left)
+
+        # Right panel: rectified board with overlays
+        bs = self.board.board_size
+        rectified = self.stats.get("rectified")
+        if rectified is not None:
+            if len(rectified.shape) == 2:
+                board_img = cv2.cvtColor(rectified, cv2.COLOR_GRAY2BGR)
+            else:
+                board_img = rectified.copy()
+        else:
+            board_img = np.zeros((bs, bs, 3), dtype=np.uint8)
+
+        # ArUco overlay (always shown)
+        ax1, ay1 = self.aruco_x1, self.aruco_y1
+        ax2, ay2 = self.aruco_x2, self.aruco_y2
+        if ann.aruco_visible:
+            marker_size = ax2 - ax1
+            marker = cv2.aruco.generateImageMarker(ARUCO_DICTIONARY, ann.aruco_id, marker_size)
+            marker_bgr = cv2.cvtColor(marker, cv2.COLOR_GRAY2BGR)
+            board_img[ay1:ay2, ax1:ax2] = cv2.addWeighted(
+                board_img[ay1:ay2, ax1:ax2], 0.5, marker_bgr, 0.5, 0)
+        else:
+            # Grey box with diagonal cross
+            cv2.rectangle(board_img, (ax1, ay1), (ax2, ay2), COLOR_NOT_VIS, 2)
+            cv2.line(board_img, (ax1, ay1), (ax2, ay2), COLOR_NOT_VIS, 2)
+            cv2.line(board_img, (ax2, ay1), (ax1, ay2), COLOR_NOT_VIS, 2)
+
+        # ArUco label
+        if ann.aruco_visible:
+            aruco_label = f"ArUco ID {ann.aruco_id}"
+        else:
+            aruco_label = "ArUco: none"
+        cv2.putText(board_img, aruco_label, (ax1, ay1 - 8), font, 0.5, (128, 128, 128), 1)
+
+        # Corner LEDs (positions stored in original image space, transform to board)
+        for i, c in enumerate(ann.corners):
+            cx, cy = ann.to_board(*c["position"])
+            color = COLOR_ON if c["visible"] else COLOR_NOT_VIS
+            cv2.circle(board_img, (cx, cy), LED_RADIUS_PX + 4, color, 2)
+            cv2.putText(board_img, str(i), (cx + 14, cy + 5), font, 0.4, color, 1)
+
+        # Counter bounding box
+        bx1, by1, bx2, by2 = self.counter_box
+        bbox_color = COLOR_BOARD_TEXT if ann.counter_visible else COLOR_NOT_VIS
+        cv2.rectangle(board_img, (bx1, by1), (bx2, by2), bbox_color, 1)
+
+        # Counter LEDs
+        for i, (cx, cy) in enumerate(self.counter_pos):
+            if not ann.counter_visible:
+                color = COLOR_NOT_VIS
+            elif ann.counter_leds[i]:
+                color = COLOR_ON
+            else:
+                color = COLOR_OFF
+            cv2.circle(board_img, (cx, cy), LED_RADIUS_PX, color, 1)
+
+        # Counter value text
+        if ann.counter_visible:
+            counter_text = f"Counter: {ann.counter_value}"
+        else:
+            counter_text = "Counter: n/a"
+        cv2.putText(board_img, counter_text, (bx1, by1 - 8), font, 0.5, COLOR_BOARD_TEXT, 1)
+
+        # Ring LEDs
+        for i, (rx, ry) in enumerate(self.ring_pos):
+            if ann.ring_start == ann.ring_end:
+                color = COLOR_NOT_VIS
+            else:
+                in_arc = self._led_in_ring_arc(i, ann.ring_start, ann.ring_end)
+                color = COLOR_ON if in_arc else COLOR_OFF
+            if self.mode == Mode.RING_AWAITING_END and i == self._ring_start_candidate:
+                color = COLOR_RING_SEL
+            cv2.circle(board_img, (rx, ry), LED_RADIUS_PX, color, 1)
+
+        # Annotation status label in top-right corner
+        is_annotated = rel_path in self.ground_truth["images"]
+        annotation_label = "Annotated" if is_annotated else "UNANNOTATED"
+        font_scale, thickness = 0.6, (1 if is_annotated else 2)
+        (tw, th), _ = cv2.getTextSize(annotation_label, font, font_scale, thickness)
+        margin = 10
+        tx = bs - tw - margin
+        ty = th + margin
+        annotation_color = (0, 255, 0) if is_annotated else (0, 0, 255)
+        cv2.putText(board_img, annotation_label, (tx, ty), font, font_scale, annotation_color, thickness)
+
+        # Scale both to common height
+        h = TARGET_HEIGHT
+        left_h, left_w = left.shape[:2]
+        left_scaled = cv2.resize(left, (int(left_w * h / left_h), h))
+        board_scaled = cv2.resize(board_img, (int(bs * h / bs), h))
+
+        self.left_panel_w = left_scaled.shape[1]
+        self.left_scale = h / left_h
+        self.board_scale = h / bs
+
+        # Status bar (3 rows: info, shortcuts, legend)
+        row_h = 22
+        status_h = row_h * 3 + 8
+        total_w = left_scaled.shape[1] + board_scaled.shape[1]
+        status_bar = np.full((status_h, total_w, 3), COLOR_STATUS_BG, dtype=np.uint8)
+
+        # Row 1: progress + file path
+        n_annotated = len(self.ground_truth["images"])
+        progress = f"[{self.current_idx + 1}/{len(self.images)}] ({n_annotated} annotated)"
+        info = f"{progress}  {rel_path}"
+        cv2.putText(status_bar, info, (8, row_h - 4),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.45, COLOR_TEXT, 1)
+
+        if self.status_msg:
+            cv2.putText(status_bar, self.status_msg, (total_w - 380, row_h - 4),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.45, (0, 128, 0), 1)
+
+        # Row 2: keyboard shortcuts
+        shortcuts = "Enter=Accept  Left/Right=Prev/Next  N/B=Skip to unannotated  C=Clear  Q=Quit  H=Help"
+        cv2.putText(status_bar, shortcuts, (8, row_h * 2 - 4),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.4, (80, 80, 80), 1)
+
+        # Row 3: color legend
+        legend_y = row_h * 3 - 4
+        legend_items = [
+            (COLOR_ON, "ON"),
+            (COLOR_OFF, "OFF"),
+            (COLOR_NOT_VIS, "Hidden"),
+            (COLOR_RING_SEL, "Selection"),
+        ]
+        lx = 8
+        for color, label in legend_items:
+            cv2.circle(status_bar, (lx + 6, legend_y - 4), 5, color, -1)
+            cv2.putText(status_bar, label, (lx + 16, legend_y),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.4, color, 1)
+            lx += 16 + len(label) * 10 + 15
+
+        composite = np.vstack([
+            np.hstack([left_scaled, board_scaled]),
+            status_bar,
+        ])
+
+        if self.show_help:
+            self._draw_help(composite)
+
+        return composite
+
+    @staticmethod
+    def _led_in_ring_arc(idx, start, end):
+        """Check if LED idx is ON in the half-open arc [start, end).
+
+        Ascending index order: start, start+1, ..., end-1.
+        LED at index `end` is the first OFF and is excluded.
+        """
+        if start == end:
+            return False  # undecodable
+        if start < end:
+            # Non-wrapping: ON indices are start, start+1, ..., end-1
+            return start <= idx < end
+        else:
+            # Wrapping past 99→0: ON indices are start, ..., 99, 0, ..., end-1
+            return idx >= start or idx < end
+
+    @staticmethod
+    def _draw_help(img):
+        """Draw semi-transparent help overlay."""
+        overlay = img.copy()
+        h, w = img.shape[:2]
+        pad = 20
+        box_w, box_h = 380, len(HELP_TEXT) * 22 + 2 * pad
+        x0 = (w - box_w) // 2
+        y0 = (h - box_h) // 2
+        cv2.rectangle(overlay, (x0, y0), (x0 + box_w, y0 + box_h), (30, 30, 30), -1)
+        cv2.addWeighted(overlay, 0.85, img, 0.15, 0, dst=img)
+        for i, line in enumerate(HELP_TEXT):
+            cv2.putText(img, line, (x0 + pad, y0 + pad + 18 + i * 22),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.45, (255, 255, 255), 1)
+
+    # ── Persistence ─────────────────────────────────────────────────────
+
+    def _load_ground_truth(self):
+        if self.output_path.exists():
+            with open(self.output_path) as f:
+                self.ground_truth = json.load(f)
+            if "images" not in self.ground_truth:
+                self.ground_truth = {"images": {}}
+            n = len(self.ground_truth["images"])
+            print(f"Loaded {n} existing annotations from {self.output_path}")
+
+    def _save_ground_truth(self):
+        with open(self.output_path, 'w') as f:
+            json.dump(self.ground_truth, f, indent=2)
+
+    def _find_unannotated(self, from_idx, forward=True):
+        """Find the next/previous unannotated image index. Returns from_idx if none found."""
+        step = 1 if forward else -1
+        idx = from_idx + step
+        while 0 <= idx < len(self.images):
+            rel = str(self.images[idx].relative_to(self.data_dir))
+            if rel not in self.ground_truth["images"]:
+                return idx
+            idx += step
+        return from_idx
+
+
+
+# ── CLI entry point ─────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Annotate and verify RocSync benchmark images")
+    parser.add_argument("data_dir", nargs="?", default="validation_data",
+                        help="Path to validation data directory (default: validation_data)")
+    parser.add_argument("-o", "--output", default=None,
+                        help="Output ground truth JSON (default: <data_dir>/ground_truth.json)")
+    args = parser.parse_args()
+
+    tool = AnnotationTool(args.data_dir, output_path=args.output)
+    tool.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -20,16 +20,17 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-from rocsync.vision import ARUCO_DICTIONARY, process_frame
-from rocsync.camera import CameraType
-from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO
 from rocsync.benchmark.common import collect_images
+from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO, RectifiedBoard
+from rocsync.camera import CameraType
+from rocsync.vision import ARUCO_DICTIONARY, process_frame
 
 # Every board rectifies to the same pixel grid, so one radius serves the whole GUI.
 LED_RADIUS_PX = BOARD_V1.rectify().led_sample_radius
 
 
 # ── Board geometry helpers ──────────────────────────────────────────────────
+
 
 def ring_led_positions(board):
     """Return list of (x, y) tuples for ring LEDs in rectified board coords."""
@@ -71,6 +72,7 @@ DRAG_THRESHOLD = 3  # px before a click becomes a drag
 
 # ── Annotation data ────────────────────────────────────────────────────────
 
+
 @dataclass
 class ImageAnnotation:
     """Mutable annotation state for a single image.
@@ -82,7 +84,8 @@ class ImageAnnotation:
     Ring uses half-open semantics: ring_start = first ON LED,
     ring_end = first OFF LED.  ring_start == ring_end means undecodable.
     """
-    board: object = None  # BoardProfile (not serialized)
+
+    board: RectifiedBoard  # not serialized
 
     aruco_visible: bool = False
     aruco_id: int = 0
@@ -99,15 +102,13 @@ class ImageAnnotation:
     counter_value: int = 0
 
     ring_start: int = 0  # first ON LED index
-    ring_end: int = 0    # first OFF LED index (exclusive); == start → undecodable
+    ring_end: int = 0  # first OFF LED index (exclusive); == start → undecodable
 
     def __post_init__(self):
-        if not self.corners and self.board is not None:
+        if not self.corners:
             corner_pos = corner_led_positions(self.board)
-            self.corners = [
-                {"visible": False, "position": list(p)} for p in corner_pos
-            ]
-        if not self.counter_leds and self.board is not None:
+            self.corners = [{"visible": False, "position": list(p)} for p in corner_pos]
+        if not self.counter_leds:
             self.counter_leds = [False] * self.board.counter_bits
 
     @classmethod
@@ -182,11 +183,11 @@ class ImageAnnotation:
     def to_board(self, orig_x, orig_y):
         """Transform a point from original image coords to rectified board coords."""
         if self.homography is None:
-            return int(round(orig_x)), int(round(orig_y))
+            return round(orig_x), round(orig_y)
         H = np.array(self.homography, dtype=np.float64)
         pt = np.array([[[orig_x, orig_y]]], dtype=np.float64)
         board = cv2.perspectiveTransform(pt, H).reshape(2)
-        return int(round(board[0])), int(round(board[1]))
+        return round(board[0]), round(board[1])
 
     def to_dict(self):
         """Serialize annotation. Invisible components are stripped to visibility only."""
@@ -244,9 +245,7 @@ class ImageAnnotation:
         ann.counter_visible = counter.get("visible", False)
         ann.counter_value = counter.get("value", 0)
         n = board.counter_bits
-        ann.counter_leds = [
-            bool(ann.counter_value & (2 ** (n - 1 - i))) for i in range(n)
-        ]
+        ann.counter_leds = [bool(ann.counter_value & (2 ** (n - 1 - i))) for i in range(n)]
 
         ring = data.get("ring", {})
         ann.ring_start = ring.get("start", 0)
@@ -255,6 +254,7 @@ class ImageAnnotation:
 
 
 # ── Interaction state ───────────────────────────────────────────────────────
+
 
 class Mode(Enum):
     IDLE = "idle"
@@ -265,11 +265,11 @@ class Mode(Enum):
 
 # ── Display and interaction ─────────────────────────────────────────────────
 
-COLOR_ON = (0, 0, 255)           # red  — LED is ON
-COLOR_OFF = (255, 0, 0)          # blue — LED is OFF
+COLOR_ON = (0, 0, 255)  # red  — LED is ON
+COLOR_OFF = (255, 0, 0)  # blue — LED is OFF
 COLOR_NOT_VIS = (128, 128, 128)  # gray — component hidden/undecodable
-COLOR_RING_SEL = (0, 255, 0)     # green — ring selection highlight
-COLOR_TEXT = (0, 0, 0)           # black text on bright bg
+COLOR_RING_SEL = (0, 255, 0)  # green — ring selection highlight
+COLOR_TEXT = (0, 0, 0)  # black text on bright bg
 COLOR_STATUS_BG = (220, 220, 220)  # light gray
 COLOR_BOARD_TEXT = (255, 255, 255)  # white text on dark board
 
@@ -289,6 +289,11 @@ HELP_TEXT = [
 
 
 class AnnotationTool:
+    # Per-image state. Set by run() before any handler can fire, so it is never None.
+    annotation: ImageAnnotation
+    stats: dict
+    _current_image: np.ndarray
+
     def __init__(self, data_dir, output_path=None):
         self.data_dir = Path(data_dir)
         self.output_path = Path(output_path) if output_path else self.data_dir / "ground_truth.json"
@@ -316,18 +321,16 @@ class AnnotationTool:
 
         # Interaction state
         self.mode = Mode.IDLE
-        self.annotation = None
-        self.stats = None
-        self._current_image = None
-        self._drag_idx = None
-        self._drag_start = None
-        self._drag_start_original = None
+        self._drag_idx: int | None = None
+        self._drag_start: tuple[float, float] | None = None
+        self._drag_start_original: tuple[float, float] | None = None
         self._drag_started = False
         self._drag_on_left = False
-        self._ring_start_candidate = None
+        self._ring_start_candidate: int | None = None
         self._needs_redraw = True
         self._window_sized = False
-        self._aruco_snapshot = None   # (annotation, board) before board-changing ArUco cycle
+        # (annotation, board) before board-changing ArUco cycle
+        self._aruco_snapshot: tuple[ImageAnnotation, RectifiedBoard] | None = None
 
     def _set_board(self, board):
         """Update board profile and recompute derived geometry."""
@@ -376,7 +379,7 @@ class AnnotationTool:
             self.stats = {}
             try:
                 process_frame(image, CameraType.RGB, 0, stats=self.stats)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 — a bad frame must not kill the session
                 print(f"Pipeline error on {rel_path}: {e}", file=sys.stderr)
                 self.stats["rectified"] = None
                 self.stats["aruco_id"] = None
@@ -387,13 +390,17 @@ class AnnotationTool:
                 saved_id = self.ground_truth["images"][rel_path].get("aruco", {}).get("id")
                 if saved_id is not None:
                     aruco_id = saved_id
-            board = PROFILES_BY_ARUCO.get(aruco_id, BOARD_V1).rectify()
+            profile = (
+                PROFILES_BY_ARUCO.get(aruco_id, BOARD_V1) if aruco_id is not None else BOARD_V1
+            )
+            board = profile.rectify()
             self._set_board(board)
 
             # Load existing annotation or create from pipeline
             if rel_path in self.ground_truth["images"]:
                 self.annotation = ImageAnnotation.from_dict(
-                    self.ground_truth["images"][rel_path], board)
+                    self.ground_truth["images"][rel_path], board
+                )
             else:
                 self.annotation = ImageAnnotation.from_stats(self.stats, board)
                 # Use the pipeline homography for new annotations
@@ -430,7 +437,8 @@ class AnnotationTool:
                 H = np.array(self.annotation.homography, dtype=np.float64)
                 mask = image[:, :, 2]
                 self.stats["rectified"] = cv2.warpPerspective(
-                    mask, H, (board.board_size, board.board_size))
+                    mask, H, (board.board_size, board.board_size)
+                )
 
             self.mode = Mode.IDLE
             self._ring_start_candidate = None
@@ -491,25 +499,25 @@ class AnnotationTool:
         if key in (13, 10, 32):  # Enter or Space
             self._commit_aruco_change()
             return "accept"
-        elif key == 83 or key == ord('d'):  # Right arrow
+        elif key == 83 or key == ord("d"):  # Right arrow
             self._commit_aruco_change()
             return "skip"
-        elif key == 81 or key == ord('a'):  # Left arrow
+        elif key == 81 or key == ord("a"):  # Left arrow
             self._commit_aruco_change()
             return "back"
-        elif key in (ord('n'), ord('N')):
+        elif key in (ord("n"), ord("N")):
             self._commit_aruco_change()
             return "next_unannotated"
-        elif key in (ord('b'), ord('B')):
+        elif key in (ord("b"), ord("B")):
             self._commit_aruco_change()
             return "prev_unannotated"
-        elif key in (ord('c'), ord('C'), 8, 127):  # C or Backspace
+        elif key in (ord("c"), ord("C"), 8, 127):  # C or Backspace
             self._commit_aruco_change()
             return "clear"
-        elif key in (ord('q'), ord('Q')):
+        elif key in (ord("q"), ord("Q")):
             self._commit_aruco_change()
             return "quit"
-        elif key in (ord('h'), ord('H')):
+        elif key in (ord("h"), ord("H")):
             self.show_help = not self.show_help
             self._needs_redraw = True
         elif key == 27:  # Escape
@@ -549,12 +557,12 @@ class AnnotationTool:
         # 1. Corner LEDs
         for i, c in enumerate(self.annotation.corners):
             cx, cy = self.annotation.to_board(*c["position"])
-            if (bx - cx) ** 2 + (by - cy) ** 2 <= HIT_CORNER ** 2:
+            if (bx - cx) ** 2 + (by - cy) ** 2 <= HIT_CORNER**2:
                 return "corner", i
 
         # 2. Counter LEDs (individual)
         for i, (cx, cy) in enumerate(self.counter_pos):
-            if (bx - cx) ** 2 + (by - cy) ** 2 <= HIT_COUNTER ** 2:
+            if (bx - cx) ** 2 + (by - cy) ** 2 <= HIT_COUNTER**2:
                 return "counter", i
 
         # 3. Counter bounding box (outside LED circles → toggle visibility)
@@ -567,13 +575,13 @@ class AnnotationTool:
             return "aruco", 0
 
         # 5. Ring LEDs (nearest within radius)
-        best_i, best_d = 0, float('inf')
+        best_i, best_d = 0, float("inf")
         for i, (rx, ry) in enumerate(self.ring_pos):
             d = (bx - rx) ** 2 + (by - ry) ** 2
             if d < best_d:
                 best_d = d
                 best_i = i
-        if best_d <= HIT_RING ** 2:
+        if best_d <= HIT_RING**2:
             return "ring", best_i
 
         return None, None
@@ -584,14 +592,14 @@ class AnnotationTool:
         hit_r = 2 * int(max(0.01 * min(img_w, img_h), 2))
         for i, c in enumerate(self.annotation.corners):
             cx, cy = c["position"]
-            if (ox - cx) ** 2 + (oy - cy) ** 2 <= hit_r ** 2:
+            if (ox - cx) ** 2 + (oy - cy) ** 2 <= hit_r**2:
                 return i
         return None
 
     def _mouse_callback(self, event, x, y, flags, param):
         # Try left panel (original image) — corners only
         ox, oy = self._display_to_original(x, y)
-        if ox is not None:
+        if ox is not None and oy is not None:
             if event == cv2.EVENT_LBUTTONDOWN:
                 self._commit_aruco_change()
                 idx = self._hit_test_corner_original(ox, oy)
@@ -601,12 +609,16 @@ class AnnotationTool:
                     self._drag_started = False
                     self._drag_on_left = True
             elif event == cv2.EVENT_MOUSEMOVE and self._drag_on_left:
-                if self._drag_idx is not None and (flags & cv2.EVENT_FLAG_LBUTTON):
+                if (
+                    self._drag_idx is not None
+                    and self._drag_start_original is not None
+                    and (flags & cv2.EVENT_FLAG_LBUTTON)
+                ):
                     dx = ox - self._drag_start_original[0]
                     dy = oy - self._drag_start_original[1]
                     img_h, img_w = self._current_image.shape[:2]
                     threshold = int(max(0.01 * min(img_w, img_h), DRAG_THRESHOLD))
-                    if not self._drag_started and (dx * dx + dy * dy) > threshold ** 2:
+                    if not self._drag_started and (dx * dx + dy * dy) > threshold**2:
                         self._drag_started = True
                         self.mode = Mode.DRAGGING_CORNER
                     if self._drag_started:
@@ -641,7 +653,7 @@ class AnnotationTool:
     def _on_left_down(self, bx, by):
         if self.mode == Mode.RING_AWAITING_END:
             elem, idx = self._hit_test(bx, by)
-            if elem == "ring":
+            if elem == "ring" and idx is not None and self._ring_start_candidate is not None:
                 # Convert CW clicks to ascending [start, end):
                 # CW first ON  → ascending end (exclusive)
                 # CW first OFF → ascending start
@@ -670,18 +682,23 @@ class AnnotationTool:
             self._handle_ring_first_click(idx)
 
     def _on_mouse_move(self, bx, by, flags):
-        if self._drag_idx is not None and (flags & cv2.EVENT_FLAG_LBUTTON):
+        if (
+            self._drag_idx is not None
+            and self._drag_start is not None
+            and (flags & cv2.EVENT_FLAG_LBUTTON)
+        ):
             dx = bx - self._drag_start[0]
             dy = by - self._drag_start[1]
-            if not self._drag_started and (dx * dx + dy * dy) > DRAG_THRESHOLD ** 2:
+            if not self._drag_started and (dx * dx + dy * dy) > DRAG_THRESHOLD**2:
                 self._drag_started = True
                 self.mode = Mode.DRAGGING_CORNER
             if self._drag_started:
                 bs = self.board.board_size
                 cbx = max(0, min(bs - 1, bx))
                 cby = max(0, min(bs - 1, by))
-                self.annotation.corners[self._drag_idx]["position"] = \
-                    self.annotation.to_original(cbx, cby)
+                self.annotation.corners[self._drag_idx]["position"] = self.annotation.to_original(
+                    cbx, cby
+                )
                 self._needs_redraw = True
 
     def _on_left_up(self, bx, by):
@@ -735,8 +752,11 @@ class AnnotationTool:
         if self._aruco_snapshot is None:
             self._aruco_snapshot = (copy.deepcopy(self.annotation), self.board)
 
-        # Check if the board profile changes
-        new_board = PROFILES_BY_ARUCO.get(new_id, self.board) if new_visible else self.board
+        # Check if the board profile changes. Rectified boards are cached per profile,
+        # so identity comparison is enough to spot a change.
+        new_board = self.board
+        if new_visible and new_id in PROFILES_BY_ARUCO:
+            new_board = PROFILES_BY_ARUCO[new_id].rectify()
         board_changes = new_board is not self.board
 
         if board_changes:
@@ -769,7 +789,7 @@ class AnnotationTool:
                     c["visible"] = False
                 self.annotation = new_ann
 
-            self.status_msg = f"Board changed to {new_board.name} — Esc to undo"
+            self.status_msg = f"Board changed to {new_board.profile.name} — Esc to undo"
         else:
             ann.aruco_visible = new_visible
             ann.aruco_id = new_id
@@ -806,7 +826,14 @@ class AnnotationTool:
         if len(visible) < 4:
             return
         src = np.array([c["position"] for c in ann.corners if c["visible"]], dtype=np.float32)
-        dst = np.array([board.always_on_leds[CameraType.RGB][i] for i, c in enumerate(ann.corners) if c["visible"]], dtype=np.float32)
+        dst = np.array(
+            [
+                board.always_on_leds[CameraType.RGB][i]
+                for i, c in enumerate(ann.corners)
+                if c["visible"]
+            ],
+            dtype=np.float32,
+        )
         if len(src) == 4:
             H = cv2.getPerspectiveTransform(src, dst)
         else:
@@ -836,12 +863,11 @@ class AnnotationTool:
         corner_radius = int(max(0.01 * min(left_w, left_h), 2))
         overlay = left.copy()
         for i, c in enumerate(ann.corners):
-            cx, cy = int(round(c["position"][0])), int(round(c["position"][1]))
+            cx, cy = round(c["position"][0]), round(c["position"][1])
             color = COLOR_ON if c["visible"] else COLOR_NOT_VIS
             cv2.circle(overlay, (cx, cy), corner_radius, (0, 255, 255), -1)
             cv2.circle(left, (cx, cy), corner_radius, color, 2)
-            cv2.putText(left, str(i), (cx + corner_radius + 4, cy + 5),
-                        font, 0.5, color, 1)
+            cv2.putText(left, str(i), (cx + corner_radius + 4, cy + 5), font, 0.5, color, 1)
         cv2.addWeighted(overlay, 0.35, left, 0.65, 0, dst=left)
 
         # Right panel: rectified board with overlays
@@ -863,7 +889,8 @@ class AnnotationTool:
             marker = cv2.aruco.generateImageMarker(ARUCO_DICTIONARY, ann.aruco_id, marker_size)
             marker_bgr = cv2.cvtColor(marker, cv2.COLOR_GRAY2BGR)
             board_img[ay1:ay2, ax1:ax2] = cv2.addWeighted(
-                board_img[ay1:ay2, ax1:ax2], 0.5, marker_bgr, 0.5, 0)
+                board_img[ay1:ay2, ax1:ax2], 0.5, marker_bgr, 0.5, 0
+            )
         else:
             # Grey box with diagonal cross
             cv2.rectangle(board_img, (ax1, ay1), (ax2, ay2), COLOR_NOT_VIS, 2)
@@ -871,10 +898,7 @@ class AnnotationTool:
             cv2.line(board_img, (ax2, ay1), (ax1, ay2), COLOR_NOT_VIS, 2)
 
         # ArUco label
-        if ann.aruco_visible:
-            aruco_label = f"ArUco ID {ann.aruco_id}"
-        else:
-            aruco_label = "ArUco: none"
+        aruco_label = f"ArUco ID {ann.aruco_id}" if ann.aruco_visible else "ArUco: none"
         cv2.putText(board_img, aruco_label, (ax1, ay1 - 8), font, 0.5, (128, 128, 128), 1)
 
         # Corner LEDs (positions stored in original image space, transform to board)
@@ -900,10 +924,7 @@ class AnnotationTool:
             cv2.circle(board_img, (cx, cy), LED_RADIUS_PX, color, 1)
 
         # Counter value text
-        if ann.counter_visible:
-            counter_text = f"Counter: {ann.counter_value}"
-        else:
-            counter_text = "Counter: n/a"
+        counter_text = f"Counter: {ann.counter_value}" if ann.counter_visible else "Counter: n/a"
         cv2.putText(board_img, counter_text, (bx1, by1 - 8), font, 0.5, COLOR_BOARD_TEXT, 1)
 
         # Ring LEDs
@@ -926,7 +947,9 @@ class AnnotationTool:
         tx = bs - tw - margin
         ty = th + margin
         annotation_color = (0, 255, 0) if is_annotated else (0, 0, 255)
-        cv2.putText(board_img, annotation_label, (tx, ty), font, font_scale, annotation_color, thickness)
+        cv2.putText(
+            board_img, annotation_label, (tx, ty), font, font_scale, annotation_color, thickness
+        )
 
         # Scale both to common height
         h = TARGET_HEIGHT
@@ -948,17 +971,32 @@ class AnnotationTool:
         n_annotated = len(self.ground_truth["images"])
         progress = f"[{self.current_idx + 1}/{len(self.images)}] ({n_annotated} annotated)"
         info = f"{progress}  {rel_path}"
-        cv2.putText(status_bar, info, (8, row_h - 4),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.45, COLOR_TEXT, 1)
+        cv2.putText(status_bar, info, (8, row_h - 4), cv2.FONT_HERSHEY_SIMPLEX, 0.45, COLOR_TEXT, 1)
 
         if self.status_msg:
-            cv2.putText(status_bar, self.status_msg, (total_w - 380, row_h - 4),
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.45, (0, 128, 0), 1)
+            cv2.putText(
+                status_bar,
+                self.status_msg,
+                (total_w - 380, row_h - 4),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.45,
+                (0, 128, 0),
+                1,
+            )
 
         # Row 2: keyboard shortcuts
-        shortcuts = "Enter=Accept  Left/Right=Prev/Next  N/B=Skip to unannotated  C=Clear  Q=Quit  H=Help"
-        cv2.putText(status_bar, shortcuts, (8, row_h * 2 - 4),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.4, (80, 80, 80), 1)
+        shortcuts = (
+            "Enter=Accept  Left/Right=Prev/Next  N/B=Skip to unannotated  C=Clear  Q=Quit  H=Help"
+        )
+        cv2.putText(
+            status_bar,
+            shortcuts,
+            (8, row_h * 2 - 4),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.4,
+            (80, 80, 80),
+            1,
+        )
 
         # Row 3: color legend
         legend_y = row_h * 3 - 4
@@ -971,14 +1009,17 @@ class AnnotationTool:
         lx = 8
         for color, label in legend_items:
             cv2.circle(status_bar, (lx + 6, legend_y - 4), 5, color, -1)
-            cv2.putText(status_bar, label, (lx + 16, legend_y),
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.4, color, 1)
+            cv2.putText(
+                status_bar, label, (lx + 16, legend_y), cv2.FONT_HERSHEY_SIMPLEX, 0.4, color, 1
+            )
             lx += 16 + len(label) * 10 + 15
 
-        composite = np.vstack([
-            np.hstack([left_scaled, board_scaled]),
-            status_bar,
-        ])
+        composite = np.vstack(
+            [
+                np.hstack([left_scaled, board_scaled]),
+                status_bar,
+            ]
+        )
 
         if self.show_help:
             self._draw_help(composite)
@@ -1013,8 +1054,15 @@ class AnnotationTool:
         cv2.rectangle(overlay, (x0, y0), (x0 + box_w, y0 + box_h), (30, 30, 30), -1)
         cv2.addWeighted(overlay, 0.85, img, 0.15, 0, dst=img)
         for i, line in enumerate(HELP_TEXT):
-            cv2.putText(img, line, (x0 + pad, y0 + pad + 18 + i * 22),
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.45, (255, 255, 255), 1)
+            cv2.putText(
+                img,
+                line,
+                (x0 + pad, y0 + pad + 18 + i * 22),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.45,
+                (255, 255, 255),
+                1,
+            )
 
     # ── Persistence ─────────────────────────────────────────────────────
 
@@ -1028,7 +1076,7 @@ class AnnotationTool:
             print(f"Loaded {n} existing annotations from {self.output_path}")
 
     def _save_ground_truth(self):
-        with open(self.output_path, 'w') as f:
+        with open(self.output_path, "w") as f:
             json.dump(self.ground_truth, f, indent=2)
 
     def _find_unannotated(self, from_idx, forward=True):
@@ -1043,16 +1091,23 @@ class AnnotationTool:
         return from_idx
 
 
-
 # ── CLI entry point ─────────────────────────────────────────────────────────
 
+
 def main():
-    parser = argparse.ArgumentParser(
-        description="Annotate and verify RocSync benchmark images")
-    parser.add_argument("data_dir", nargs="?", default="validation_data",
-                        help="Path to validation data directory (default: validation_data)")
-    parser.add_argument("-o", "--output", default=None,
-                        help="Output ground truth JSON (default: <data_dir>/ground_truth.json)")
+    parser = argparse.ArgumentParser(description="Annotate and verify RocSync benchmark images")
+    parser.add_argument(
+        "data_dir",
+        nargs="?",
+        default="validation_data",
+        help="Path to validation data directory (default: validation_data)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Output ground truth JSON (default: <data_dir>/ground_truth.json)",
+    )
     args = parser.parse_args()
 
     tool = AnnotationTool(args.data_dir, output_path=args.output)

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Interactive annotation and verification tool for RocSync benchmark images.
+"""Interactive annotation and verification tool for RocSync benchmark frames.
 
-Runs the rocsync pipeline on validation images, displays results with LED
-overlays, and lets the user verify or correct the decoded values. Produces
-a ground_truth.json file for benchmark evaluation.
+Runs the rocsync pipeline on validation images and videos, displays results
+with LED overlays, and lets the user verify or correct the decoded values.
+Produces a ground_truth.json file for benchmark evaluation.
 
 Usage:
     python -m rocsync.benchmark.annotate [data_dir] [-o ground_truth.json]
@@ -20,7 +20,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-from rocsync.benchmark.common import collect_images, corner_positions_in_image
+from rocsync.benchmark.common import FrameSource, collect_frames, corner_positions_in_image
 from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO, RectifiedBoard
 from rocsync.camera import CameraType
 from rocsync.vision import ARUCO_DICTIONARY, process_frame
@@ -286,6 +286,7 @@ HELP_TEXT = [
     "                    (same LED = undecodable)",
     "=== Keys ===",
     "0-N               : Place that corner next",
+    ". / ,             : Next / previous input file",
 ]
 
 
@@ -299,7 +300,8 @@ class AnnotationTool:
         self.data_dir = Path(data_dir)
         self.output_path = Path(output_path) if output_path else self.data_dir / "ground_truth.json"
         self.ground_truth = {"images": {}}
-        self.images = []
+        self.frames = []
+        self.source = FrameSource()
         self.current_idx = 0
 
         # Board profile and derived geometry (set per-image)
@@ -353,39 +355,40 @@ class AnnotationTool:
     # ── Main loop ───────────────────────────────────────────────────────
 
     def run(self):
-        self.images = sorted(collect_images(self.data_dir))
-        if not self.images:
-            print("No images found.", file=sys.stderr)
+        self.frames = collect_frames(self.data_dir)
+        if not self.frames:
+            print("No images or videos found.", file=sys.stderr)
             return
 
         self._load_ground_truth()
         first = self._find_unannotated(-1, forward=True)
         if first == -1:
-            print("All images already annotated. Starting from the beginning.")
+            print("All frames already annotated. Starting from the beginning.")
             self.current_idx = 0
         else:
             self.current_idx = first
-            rel = str(self.images[first].relative_to(self.data_dir))
-            print(f"Resuming at image {first + 1}/{len(self.images)}: {rel}")
+            print(f"Resuming at frame {first + 1}/{len(self.frames)}: {self.frames[first].key}")
 
         cv2.namedWindow(WINDOW_NAME, cv2.WINDOW_NORMAL)
         cv2.setMouseCallback(WINDOW_NAME, self._mouse_callback)
 
-        n_images = len(self.images)
+        n_frames = len(self.frames)
         unreadable = 0  # consecutive read failures; bail out rather than spin forever
         while True:
-            image_path = self.images[self.current_idx]
-            rel_path = str(image_path.relative_to(self.data_dir))
+            ref = self.frames[self.current_idx]
+            frame_key = ref.key
 
-            image = cv2.imread(str(image_path))
+            # Decoding a video frame can seek, so present a frame before blocking on it
+            self._pump()
+            image = self.source.read(ref)
             if image is None:
-                print(f"Cannot read {image_path}", file=sys.stderr)
+                print(f"Cannot read {frame_key}", file=sys.stderr)
                 self._pump()
                 unreadable += 1
-                if unreadable >= n_images:
-                    print("No readable images.", file=sys.stderr)
+                if unreadable >= n_frames:
+                    print("No readable frames.", file=sys.stderr)
                     break
-                self.current_idx = (self.current_idx + 1) % n_images
+                self.current_idx = (self.current_idx + 1) % n_frames
                 continue
             unreadable = 0
             self._pump()
@@ -395,15 +398,15 @@ class AnnotationTool:
             try:
                 process_frame(image, CameraType.RGB, 0, stats=self.stats)
             except Exception as e:  # noqa: BLE001 — a bad frame must not kill the session
-                print(f"Pipeline error on {rel_path}: {e}", file=sys.stderr)
+                print(f"Pipeline error on {frame_key}: {e}", file=sys.stderr)
                 self.stats["rectified"] = None
                 self.stats["aruco_id"] = None
             self._pump()
 
             # Resolve board profile from pipeline detection or saved annotation
             aruco_id = self.stats.get("aruco_id")
-            if rel_path in self.ground_truth["images"]:
-                saved_id = self.ground_truth["images"][rel_path].get("aruco", {}).get("id")
+            if frame_key in self.ground_truth["images"]:
+                saved_id = self.ground_truth["images"][frame_key].get("aruco", {}).get("id")
                 if saved_id is not None:
                     aruco_id = saved_id
             profile = (
@@ -413,9 +416,9 @@ class AnnotationTool:
             self._set_board(board)
 
             # Load existing annotation or create from pipeline
-            if rel_path in self.ground_truth["images"]:
+            if frame_key in self.ground_truth["images"]:
                 self.annotation = ImageAnnotation.from_dict(
-                    self.ground_truth["images"][rel_path], board
+                    self.ground_truth["images"][frame_key], board
                 )
             else:
                 self.annotation = ImageAnnotation.from_stats(self.stats, board)
@@ -465,27 +468,32 @@ class AnnotationTool:
             self._needs_redraw = True
 
             self._current_image = image
-            action = self._image_loop(image, rel_path)
+            action = self._image_loop(image, frame_key)
 
             if action == "accept":
-                self.ground_truth["images"][rel_path] = self.annotation.to_dict()
+                self.ground_truth["images"][frame_key] = self.annotation.to_dict()
                 self._save_ground_truth()
-                self.current_idx = (self.current_idx + 1) % n_images
+                self.current_idx = (self.current_idx + 1) % n_frames
             elif action == "skip":
-                self.current_idx = (self.current_idx + 1) % n_images
+                self.current_idx = (self.current_idx + 1) % n_frames
             elif action == "back":
-                self.current_idx = (self.current_idx - 1) % n_images
+                self.current_idx = (self.current_idx - 1) % n_frames
             elif action == "next_unannotated":
                 self.current_idx = self._find_unannotated(self.current_idx, forward=True)
             elif action == "prev_unannotated":
                 self.current_idx = self._find_unannotated(self.current_idx, forward=False)
+            elif action == "next_source":
+                self.current_idx = self._find_source_boundary(self.current_idx, forward=True)
+            elif action == "prev_source":
+                self.current_idx = self._find_source_boundary(self.current_idx, forward=False)
             elif action == "clear":
-                self.ground_truth["images"].pop(rel_path, None)
+                self.ground_truth["images"].pop(frame_key, None)
                 self._save_ground_truth()
-                # stay on current image — re-runs pipeline on next iteration
+                # stay on current frame — re-runs pipeline on next iteration
             elif action == "quit":
                 break
 
+        self.source.close()
         cv2.destroyAllWindows()
 
     def _pump(self):
@@ -496,11 +504,11 @@ class AnnotationTool:
         if key != 255 and self._pending_key is None:
             self._pending_key = key  # hold keys typed while work blocked the loop
 
-    def _image_loop(self, image, rel_path):
+    def _image_loop(self, image, frame_key):
         composite = None
         while True:
             if self._needs_redraw or composite is None:
-                composite = self._render(image, rel_path)
+                composite = self._render(image, frame_key)
                 if not self._window_sized:
                     h, w = composite.shape[:2]
                     cv2.resizeWindow(WINDOW_NAME, w, h)
@@ -545,6 +553,12 @@ class AnnotationTool:
         elif key in (ord("b"), ord("B")):
             self._commit_aruco_change()
             return "prev_unannotated"
+        elif key == ord("."):
+            self._commit_aruco_change()
+            return "next_source"
+        elif key == ord(","):
+            self._commit_aruco_change()
+            return "prev_source"
         elif key in (ord("c"), ord("C"), 8, 127):  # C or Backspace
             self._commit_aruco_change()
             return "clear"
@@ -918,7 +932,7 @@ class AnnotationTool:
 
     # ── Rendering ───────────────────────────────────────────────────────
 
-    def _render(self, original, rel_path):
+    def _render(self, original, frame_key):
         """Build the composite side-by-side display image."""
         font = cv2.FONT_HERSHEY_SIMPLEX
         ann = self.annotation
@@ -1020,7 +1034,7 @@ class AnnotationTool:
             cv2.circle(board_img, (rx, ry), LED_RADIUS_PX, color, 1)
 
         # Annotation status label in top-right corner
-        is_annotated = rel_path in self.ground_truth["images"]
+        is_annotated = frame_key in self.ground_truth["images"]
         annotation_label = "Annotated" if is_annotated else "UNANNOTATED"
         font_scale, thickness = 0.6, (1 if is_annotated else 2)
         (tw, th), _ = cv2.getTextSize(annotation_label, font, font_scale, thickness)
@@ -1049,8 +1063,8 @@ class AnnotationTool:
 
         # Row 1: progress + file path
         n_annotated = len(self.ground_truth["images"])
-        progress = f"[{self.current_idx + 1}/{len(self.images)}] ({n_annotated} annotated)"
-        info = f"{progress}  {rel_path}"
+        progress = f"[{self.current_idx + 1}/{len(self.frames)}] ({n_annotated} annotated)"
+        info = f"{progress}  {frame_key}"
         cv2.putText(status_bar, info, (8, row_h - 4), cv2.FONT_HERSHEY_SIMPLEX, 0.45, COLOR_TEXT, 1)
 
         if self.status_msg:
@@ -1067,7 +1081,7 @@ class AnnotationTool:
         # Row 2: keyboard shortcuts
         shortcuts = (
             "Enter=Accept  Left/Right=Prev/Next  N/B=Skip to unannotated  "
-            "0-N=Pick corner  C=Clear  Q=Quit  H=Help"
+            ",/.=Prev/Next file  0-N=Pick corner  C=Clear  Q=Quit  H=Help"
         )
         cv2.putText(
             status_bar,
@@ -1205,17 +1219,39 @@ class AnnotationTool:
             json.dump(self.ground_truth, f, indent=2)
 
     def _find_unannotated(self, from_idx, forward=True):
-        """Find the next/previous unannotated image index, wrapping around the list.
+        """Find the next/previous unannotated frame index, wrapping around the list.
 
-        Returns from_idx if every image is annotated.
+        Returns from_idx if every frame is annotated.
         """
-        n = len(self.images)
+        n = len(self.frames)
         step = 1 if forward else -1
         for k in range(1, n + 1):
             idx = (from_idx + k * step) % n
-            rel = str(self.images[idx].relative_to(self.data_dir))
-            if rel not in self.ground_truth["images"]:
+            if self.frames[idx].key not in self.ground_truth["images"]:
                 return idx
+        return from_idx
+
+    def _find_source_boundary(self, from_idx, forward=True):
+        """First frame of the next/previous input file, wrapping around the list.
+
+        A video contributes one frame per key, so stepping past one otherwise costs a
+        keypress per frame, and jump-to-unannotated only helps while frames are still
+        unannotated.
+        """
+        n = len(self.frames)
+        current = self.frames[from_idx].path
+        step = 1 if forward else -1
+        for k in range(1, n + 1):
+            idx = (from_idx + k * step) % n
+            if self.frames[idx].path == current:
+                continue
+            if forward:
+                return idx
+            # Going back lands on that file's last frame; rewind to its first
+            found = self.frames[idx].path
+            while self.frames[(idx - 1) % n].path == found:
+                idx = (idx - 1) % n
+            return idx
         return from_idx
 
 
@@ -1223,7 +1259,7 @@ class AnnotationTool:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Annotate and verify RocSync benchmark images")
+    parser = argparse.ArgumentParser(description="Annotate and verify RocSync benchmark frames")
     parser.add_argument(
         "data_dir",
         nargs="?",

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -606,7 +606,11 @@ class AnnotationTool:
             # Run pipeline
             self.stats = {}
             try:
-                process_frame(image, CameraType.RGB, 0, stats=self.stats)
+                # No area gate: the annotator should see every marker the detector found,
+                # however small — rejecting it is the benchmark's call, not the ground truth's.
+                process_frame(
+                    image, CameraType.RGB, 0, stats=self.stats, min_aruco_area_fraction=0.0
+                )
             except Exception as e:  # noqa: BLE001 — a bad frame must not kill the session
                 print(f"Pipeline error on {frame_key}: {e}", file=sys.stderr)
                 self.stats["rectified"] = None

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -1229,11 +1229,20 @@ class AnnotationTool:
             board_img = cv2.cvtColor(view, cv2.COLOR_GRAY2BGR)
         else:
             board_img = np.zeros((cs, cs, 3), dtype=np.uint8)
-        # Corner ticks marking where the board proper ends and the margin begins
-        for cx, sx in ((m, 1), (m + bs - 1, -1)):
-            for cy, sy in ((m, 1), (m + bs - 1, -1)):
+        # Ticks marking where the board proper ends and the margin begins: an L at each
+        # corner, plus one centred on each edge.
+        x0, x1 = m, m + bs - 1
+        y0, y1 = m, m + bs - 1
+        half = BOARD_TICK_PX // 2
+        xc, yc = m + bs // 2, m + bs // 2
+        for cx, sx in ((x0, 1), (x1, -1)):
+            for cy, sy in ((y0, 1), (y1, -1)):
                 cv2.line(board_img, (cx, cy), (cx + sx * BOARD_TICK_PX, cy), COLOR_MARGIN, 1)
                 cv2.line(board_img, (cx, cy), (cx, cy + sy * BOARD_TICK_PX), COLOR_MARGIN, 1)
+        for y in (y0, y1):
+            cv2.line(board_img, (xc - half, y), (xc - half + BOARD_TICK_PX, y), COLOR_MARGIN, 1)
+        for x in (x0, x1):
+            cv2.line(board_img, (x, yc - half), (x, yc - half + BOARD_TICK_PX), COLOR_MARGIN, 1)
 
         # ArUco overlay (always shown)
         ax1, ay1 = self.aruco_x1 + m, self.aruco_y1 + m

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -44,6 +44,12 @@ from rocsync.vision import ARUCO_DICTIONARY, process_frame, read_counter, read_r
 # Every board rectifies to the same pixel grid, so one radius serves the whole GUI.
 LED_RADIUS_PX = BOARD_V1.rectify().led_sample_radius
 
+# Slack warped in around the board, so LEDs that a coarse fit pushes off the edge stay visible.
+BOARD_MARGIN_PX = 10
+
+# Length of the tick marks drawn along the board edge at each board corner
+BOARD_TICK_PX = 10
+
 
 # ── Board geometry helpers ──────────────────────────────────────────────────
 
@@ -147,6 +153,19 @@ def coarse_homography_from_aruco(stats, board):
     if H is None or not np.isfinite(H).all():
         return None
     return H
+
+
+def warp_board_view(image, H, board, margin=BOARD_MARGIN_PX):
+    """Rectify `image` into a board grid padded by `margin` px on every side."""
+    T = np.array([[1, 0, margin], [0, 1, margin], [0, 0, 1]], dtype=np.float64)
+    side = board.board_size + 2 * margin
+    return cv2.warpPerspective(image[:, :, 2], T @ np.asarray(H, dtype=np.float64), (side, side))
+
+
+def board_from_view(view, board, margin=BOARD_MARGIN_PX):
+    """The board itself, cropped back out of a padded view."""
+    bs = board.board_size
+    return view[margin : margin + bs, margin : margin + bs].copy()
 
 
 def decode_clock(rectified, board):
@@ -418,6 +437,7 @@ COLOR_RING_SEL = (0, 255, 0)  # green — ring selection highlight
 COLOR_TEXT = (0, 0, 0)  # black text on bright bg
 COLOR_STATUS_BG = (220, 220, 220)  # light gray
 COLOR_BOARD_TEXT = (255, 255, 255)  # white text on dark board
+COLOR_MARGIN = (180, 180, 180)  # light gray — board corner ticks inside the margin
 
 WINDOW_NAME = "RocSync Annotation"
 TARGET_HEIGHT = 800
@@ -506,6 +526,7 @@ class AnnotationTool:
         self.left_panel_w = 0
         self.left_scale = 1.0
         self.board_scale = 1.0
+        self._board_view = None  # rectified board plus margin, as drawn on the right
         self.status_msg = ""
         self._last_composite = None  # last frame, re-presented while work blocks the loop
         self._pending_key: int | None = None  # key caught by _pump, consumed by _image_loop
@@ -644,12 +665,11 @@ class AnnotationTool:
             # Warp with the annotation's own homography, saved or from the pipeline, so
             # the displayed image is consistent with to_original/to_board. Loading never
             # refits: a stored annotation keeps the homography it was accepted with.
+            self._board_view = None
             if self.annotation.homography is not None:
                 H = np.array(self.annotation.homography, dtype=np.float64)
-                mask = image[:, :, 2]
-                self.stats["rectified"] = cv2.warpPerspective(
-                    mask, H, (board.board_size, board.board_size)
-                )
+                self._board_view = warp_board_view(image, H, board)
+                self.stats["rectified"] = board_from_view(self._board_view, board)
             self._pump()
 
             # Demuxing for presentation timestamps blocks, so do it before the loop
@@ -796,10 +816,11 @@ class AnnotationTool:
         if x < self.left_panel_w:
             return None, None
         panel_x = x - self.left_panel_w
-        bx = int(panel_x / self.board_scale)
-        by = int(y / self.board_scale)
+        m = BOARD_MARGIN_PX
+        bx = int(panel_x / self.board_scale) - m
+        by = int(y / self.board_scale) - m
         bs = self.board.board_size
-        if bx < 0 or bx >= bs or by < 0 or by >= bs:
+        if bx < -m or bx >= bs + m or by < -m or by >= bs + m:
             return None, None
         return bx, by
 
@@ -964,8 +985,9 @@ class AnnotationTool:
                 self.mode = Mode.DRAGGING_CORNER
             if self._drag_started:
                 bs = self.board.board_size
-                cbx = max(0, min(bs - 1, bx))
-                cby = max(0, min(bs - 1, by))
+                m = BOARD_MARGIN_PX
+                cbx = max(-m, min(bs - 1 + m, bx))
+                cby = max(-m, min(bs - 1 + m, by))
                 self.annotation.corners[self._drag_idx]["position"] = self.annotation.to_original(
                     cbx, cby
                 )
@@ -1129,9 +1151,8 @@ class AnnotationTool:
         for i, c in enumerate(ann.corners):
             if not c["visible"]:
                 c["position"] = ann.to_original(*self.corner_pos[i])
-        mask = original[:, :, 2]  # red channel
-        bs = board.board_size
-        self.stats["rectified"] = cv2.warpPerspective(mask, H, (bs, bs))
+        self._board_view = warp_board_view(original, H, board)
+        self.stats["rectified"] = board_from_view(self._board_view, board)
         self._redecode_clock()
         return True
 
@@ -1197,18 +1218,22 @@ class AnnotationTool:
 
         # Right panel: rectified board with overlays
         bs = self.board.board_size
-        rectified = self.stats.get("rectified")
-        if rectified is not None:
-            if len(rectified.shape) == 2:
-                board_img = cv2.cvtColor(rectified, cv2.COLOR_GRAY2BGR)
-            else:
-                board_img = rectified.copy()
+        m = BOARD_MARGIN_PX
+        cs = bs + 2 * m
+        view = self._board_view
+        if view is not None:
+            board_img = cv2.cvtColor(view, cv2.COLOR_GRAY2BGR)
         else:
-            board_img = np.zeros((bs, bs, 3), dtype=np.uint8)
+            board_img = np.zeros((cs, cs, 3), dtype=np.uint8)
+        # Corner ticks marking where the board proper ends and the margin begins
+        for cx, sx in ((m, 1), (m + bs - 1, -1)):
+            for cy, sy in ((m, 1), (m + bs - 1, -1)):
+                cv2.line(board_img, (cx, cy), (cx + sx * BOARD_TICK_PX, cy), COLOR_MARGIN, 1)
+                cv2.line(board_img, (cx, cy), (cx, cy + sy * BOARD_TICK_PX), COLOR_MARGIN, 1)
 
         # ArUco overlay (always shown)
-        ax1, ay1 = self.aruco_x1, self.aruco_y1
-        ax2, ay2 = self.aruco_x2, self.aruco_y2
+        ax1, ay1 = self.aruco_x1 + m, self.aruco_y1 + m
+        ax2, ay2 = self.aruco_x2 + m, self.aruco_y2 + m
         if ann.aruco_visible:
             marker_size = ax2 - ax1
             marker = cv2.aruco.generateImageMarker(ARUCO_DICTIONARY, ann.aruco_id, marker_size)
@@ -1226,17 +1251,19 @@ class AnnotationTool:
         corner_labels = []
         for i, c in enumerate(ann.corners):
             cx, cy = ann.to_board(*c["position"])
+            cx, cy = cx + m, cy + m
             color = COLOR_ON if c["visible"] else COLOR_NOT_VIS
             cv2.circle(board_img, (cx, cy), LED_RADIUS_PX + 4, color, 2)
             corner_labels.append((str(i), cx + LED_RADIUS_PX + 8, cy + 6, color))
 
         # Counter bounding box
-        bx1, by1, bx2, by2 = self.counter_box
+        bx1, by1, bx2, by2 = (v + m for v in self.counter_box)
         bbox_color = COLOR_BOARD_TEXT if ann.counter_visible else COLOR_NOT_VIS
         cv2.rectangle(board_img, (bx1, by1), (bx2, by2), bbox_color, 1)
 
         # Counter LEDs
         for i, (cx, cy) in enumerate(self.counter_pos):
+            cx, cy = cx + m, cy + m
             if not ann.counter_visible:
                 color = COLOR_NOT_VIS
             elif ann.counter_leds[i]:
@@ -1247,6 +1274,7 @@ class AnnotationTool:
 
         # Ring LEDs
         for i, (rx, ry) in enumerate(self.ring_pos):
+            rx, ry = rx + m, ry + m
             if ann.ring_start == ann.ring_end:
                 color = COLOR_NOT_VIS
             else:
@@ -1261,7 +1289,7 @@ class AnnotationTool:
         board_scaled = cv2.resize(board_img, (h, h))
 
         self.left_panel_w = left_scaled.shape[1]
-        self.board_scale = h / bs
+        self.board_scale = h / cs
 
         # Board labels go on after the resize, so they are drawn at display
         # resolution rather than magnified along with the board.

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -14,15 +14,29 @@ import copy
 import json
 import sys
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 
 import cv2
 import numpy as np
 
-from rocsync.benchmark.common import FrameSource, collect_frames, corner_positions_in_image
+from rocsync.benchmark.common import (
+    MIN_REFERENCE_FRAMES,
+    REFERENCE_RESIDUAL_THRESHOLD_MS,
+    FrameSource,
+    collect_frames,
+    corner_positions_in_image,
+    fit_reference_clock,
+    frame_key,
+    parse_frame_key,
+    reconstruct_timestamp,
+    reference_outliers,
+    reference_residual,
+)
 from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO, RectifiedBoard
 from rocsync.camera import CameraType
+from rocsync.timeline import frame_pts
 from rocsync.vision import ARUCO_DICTIONARY, process_frame
 
 # Every board rectifies to the same pixel grid, so one radius serves the whole GUI.
@@ -245,6 +259,46 @@ class ImageAnnotation:
 # ── Interaction state ───────────────────────────────────────────────────────
 
 
+# ── Reference clock ─────────────────────────────────────────────────────────
+
+
+def annotated_starts(images, rel_path):
+    """Annotated board start time in ms per frame index, for one video."""
+    starts = {}
+    for key, entry in images.items():
+        path, index = parse_frame_key(key)
+        if index is None or path != rel_path:
+            continue
+        board = PROFILES_BY_ARUCO.get(entry.get("aruco", {}).get("id"))
+        if board is None:
+            continue
+        timestamp = reconstruct_timestamp(entry, board)
+        if timestamp is not None:
+            starts[index] = timestamp[0]
+    return starts
+
+
+def video_rel_paths(frames):
+    """Relative paths of the videos in a frame list, sorted."""
+    return sorted({parse_frame_key(ref.key)[0] for ref in frames if ref.index is not None})
+
+
+def derive_reference_clock(images, rel_path, pts):
+    """(clock, outliers) for one video, clock None below MIN_REFERENCE_FRAMES."""
+    starts = annotated_starts(images, rel_path)
+    clock = fit_reference_clock(starts, pts)
+    if clock is None:
+        return None, []
+    return clock, reference_outliers(clock, starts, pts)
+
+
+def describe_outliers(rel_path, outliers):
+    """One line per frame whose annotation the rest of the video contradicts."""
+    lines = [f"{rel_path}: {len(outliers)} frame(s) beyond {REFERENCE_RESIDUAL_THRESHOLD_MS} ms"]
+    lines += [f"  {frame_key(rel_path, i)}  {residual:+.2f} ms" for i, residual in outliers]
+    return "\n".join(lines)
+
+
 class Mode(Enum):
     IDLE = "idle"
     DRAGGING_CORNER = "dragging"
@@ -299,10 +353,15 @@ class AnnotationTool:
     def __init__(self, data_dir, output_path=None):
         self.data_dir = Path(data_dir)
         self.output_path = Path(output_path) if output_path else self.data_dir / "ground_truth.json"
-        self.ground_truth = {"images": {}}
+        self.ground_truth = {"images": {}, "videos": {}}
         self.frames = []
         self.source = FrameSource()
         self.current_idx = 0
+
+        # Reference clock state. pts are read once per video and kept; a video is
+        # re-derived only once one of its annotations has actually changed.
+        self._video_pts: dict[str, dict[int, float]] = {}
+        self._dirty_videos: set[str] = set()
 
         # Board profile and derived geometry (set per-image)
         self.board = BOARD_V1.rectify()
@@ -460,6 +519,11 @@ class AnnotationTool:
                 )
             self._pump()
 
+            # Demuxing for presentation timestamps blocks, so do it before the loop
+            if ref.index is not None:
+                self._load_pts(parse_frame_key(frame_key)[0])
+            self._pump()
+
             self.mode = Mode.IDLE
             self._ring_start_candidate = None
             self.placing_idx = 0
@@ -472,6 +536,7 @@ class AnnotationTool:
 
             if action == "accept":
                 self.ground_truth["images"][frame_key] = self.annotation.to_dict()
+                self._mark_video_dirty(frame_key)
                 self._save_ground_truth()
                 self.current_idx = (self.current_idx + 1) % n_frames
             elif action == "skip":
@@ -488,6 +553,7 @@ class AnnotationTool:
                 self.current_idx = self._find_source_boundary(self.current_idx, forward=False)
             elif action == "clear":
                 self.ground_truth["images"].pop(frame_key, None)
+                self._mark_video_dirty(frame_key)
                 self._save_ground_truth()
                 # stay on current frame — re-runs pipeline on next iteration
             elif action == "quit":
@@ -1046,6 +1112,13 @@ class AnnotationTool:
             board_img, annotation_label, (tx, ty), font, font_scale, annotation_color, thickness
         )
 
+        # How this frame's timestamp sits against the clock the rest of its video implies
+        for i, (text, color) in enumerate(self._clock_overlay(frame_key), start=1):
+            (lw, lh), _ = cv2.getTextSize(text, font, 0.45, 1)
+            cv2.putText(
+                board_img, text, (bs - lw - margin, ty + i * (lh + 10)), font, 0.45, color, 1
+            )
+
         # The left panel is already at the common height; scale the board to match.
         left_scaled = left
         board_scaled = cv2.resize(board_img, (h, h))
@@ -1211,12 +1284,99 @@ class AnnotationTool:
                 self.ground_truth = json.load(f)
             if "images" not in self.ground_truth:
                 self.ground_truth = {"images": {}}
+            self.ground_truth.setdefault("videos", {})
             n = len(self.ground_truth["images"])
             print(f"Loaded {n} existing annotations from {self.output_path}")
 
     def _save_ground_truth(self):
+        self._update_references()
         with open(self.output_path, "w") as f:
             json.dump(self.ground_truth, f, indent=2)
+
+    # ── Reference clock ─────────────────────────────────────────────────
+
+    def _mark_video_dirty(self, frame_key_str):
+        """Note that a video's annotations changed, so its reference is re-derived."""
+        rel_path, index = parse_frame_key(frame_key_str)
+        if index is not None:
+            self._dirty_videos.add(rel_path)
+
+    def _load_pts(self, rel_path):
+        """Presentation timestamps of a video, keyed by frame index.
+
+        Reading them demuxes the whole file, so it happens once per video and off
+        the render path.
+        """
+        if rel_path not in self._video_pts:
+            self._video_pts[rel_path] = dict(enumerate(frame_pts(self.data_dir / rel_path)))
+        return self._video_pts[rel_path]
+
+    def _update_references(self):
+        """Re-derive the reference clock of every video that needs one.
+
+        Gated so a frozen reference is never silently replaced: a video is derived
+        only when it has none yet or one of its annotations just changed. A video
+        the rest of the session never touched keeps the exact number it had.
+        """
+        videos = self.ground_truth.setdefault("videos", {})
+        for rel_path in video_rel_paths(self.frames):
+            if rel_path in videos and rel_path not in self._dirty_videos:
+                continue
+            clock, outliers = derive_reference_clock(
+                self.ground_truth["images"], rel_path, self._load_pts(rel_path)
+            )
+            if clock is None:
+                continue
+            if outliers:
+                # Refusing to store is the point; losing the annotation work is not
+                self.status_msg = describe_outliers(rel_path, outliers).splitlines()[0]
+                print(describe_outliers(rel_path, outliers), file=sys.stderr)
+                continue
+            videos[rel_path] = {
+                **clock.to_dict(),
+                "derived_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            }
+        self._dirty_videos.clear()
+
+    def _clock_overlay(self, frame_key_str):
+        """Lines describing how this frame's timestamp sits against its video's clock.
+
+        The residual is leave-one-out: the clock is fitted over the video's *other*
+        annotated frames and asked to predict this one, so a frame cannot drag the
+        line towards itself and hide its own mistake. It reads the live annotation,
+        so a correction shows up before it is saved.
+        """
+        rel_path, index = parse_frame_key(frame_key_str)
+        pts = self._video_pts.get(rel_path)
+        if index is None or not pts:
+            return []
+
+        starts = annotated_starts(self.ground_truth["images"], rel_path)
+        live = reconstruct_timestamp(self.annotation.to_dict(), self.board)
+        if live is None:
+            starts.pop(index, None)
+        else:
+            starts[index] = live[0]
+
+        lines = []
+        residual = reference_residual(
+            fit_reference_clock(starts, pts, exclude=index), index, starts, pts
+        )
+        if residual is not None:
+            within = abs(residual) <= REFERENCE_RESIDUAL_THRESHOLD_MS
+            lines.append((f"dt {residual:+.2f} ms", (0, 255, 0) if within else (0, 0, 255)))
+        clock = fit_reference_clock(starts, pts)
+        if clock is not None:
+            lines.append(
+                (
+                    f"fit {clock.n_frames_fitted} frames  RMSE {clock.rmse_ms:.2f}"
+                    f"  max {clock.max_residual_ms:.2f} ms",
+                    COLOR_BOARD_TEXT,
+                )
+            )
+        elif len(starts) < MIN_REFERENCE_FRAMES:
+            lines.append((f"fit needs {MIN_REFERENCE_FRAMES} annotated frames", COLOR_NOT_VIS))
+        return lines
 
     def _find_unannotated(self, from_idx, forward=True):
         """Find the next/previous unannotated frame index, wrapping around the list.
@@ -1255,6 +1415,57 @@ class AnnotationTool:
         return from_idx
 
 
+def fit_clocks(data_dir, output_path):
+    """Re-derive every video's reference clock without opening the GUI.
+
+    Unlike the annotator this recomputes unconditionally -- it is an explicit request
+    to re-derive, which is what to run after editing a ground truth file by hand.
+    Returns a process exit code.
+    """
+    data_dir = Path(data_dir)
+    output_path = Path(output_path) if output_path else data_dir / "ground_truth.json"
+    if not output_path.exists():
+        print(f"No ground truth at {output_path}", file=sys.stderr)
+        return 1
+
+    with open(output_path) as f:
+        ground_truth = json.load(f)
+    ground_truth.setdefault("images", {})
+    videos = ground_truth.setdefault("videos", {})
+
+    frames = collect_frames(data_dir)
+    failed = False
+    for rel_path in video_rel_paths(frames):
+        pts = dict(enumerate(frame_pts(data_dir / rel_path)))
+        clock, outliers = derive_reference_clock(ground_truth["images"], rel_path, pts)
+        if clock is None:
+            print(f"{rel_path}: fewer than {MIN_REFERENCE_FRAMES} annotated frames, skipped")
+            continue
+        if outliers:
+            print(describe_outliers(rel_path, outliers), file=sys.stderr)
+            failed = True
+            continue
+
+        previous = videos.get(rel_path)
+        videos[rel_path] = {
+            **clock.to_dict(),
+            "derived_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        }
+        if previous is None:
+            print(f"{rel_path}: derived {clock.clock_rate:.7f}x, {clock.clock_offset_ms:.2f} ms")
+        elif any(previous.get(k) != videos[rel_path][k] for k in ("clock_rate", "clock_offset_ms")):
+            print(
+                f"{rel_path}: {previous['clock_rate']:.7f}x -> {clock.clock_rate:.7f}x, "
+                f"{previous['clock_offset_ms']:.2f} -> {clock.clock_offset_ms:.2f} ms"
+            )
+        else:
+            print(f"{rel_path}: unchanged")
+
+    with open(output_path, "w") as f:
+        json.dump(ground_truth, f, indent=2)
+    return 1 if failed else 0
+
+
 # ── CLI entry point ─────────────────────────────────────────────────────────
 
 
@@ -1272,7 +1483,15 @@ def main():
         default=None,
         help="Output ground truth JSON (default: <data_dir>/ground_truth.json)",
     )
+    parser.add_argument(
+        "--fit-clocks",
+        action="store_true",
+        help="Re-derive every video's reference clock and exit, without opening the GUI",
+    )
     args = parser.parse_args()
+
+    if args.fit_clocks:
+        sys.exit(fit_clocks(args.data_dir, args.output))
 
     tool = AnnotationTool(args.data_dir, output_path=args.output)
     tool.run()

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -23,16 +23,17 @@ import numpy as np
 
 from rocsync.benchmark.common import (
     MIN_REFERENCE_FRAMES,
-    REFERENCE_RESIDUAL_THRESHOLD_MS,
     FrameSource,
     collect_frames,
     corner_positions_in_image,
     fit_reference_clock,
     frame_key,
+    measured_residual_threshold_ms,
     parse_frame_key,
     reconstruct_timestamp,
     reference_outliers,
     reference_residual,
+    source_frame_period_ms,
 )
 from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO, RectifiedBoard
 from rocsync.camera import CameraType
@@ -283,20 +284,38 @@ def video_rel_paths(frames):
     return sorted({parse_frame_key(ref.key)[0] for ref in frames if ref.index is not None})
 
 
-def derive_reference_clock(images, rel_path, pts):
-    """(clock, outliers) for one video, clock None below MIN_REFERENCE_FRAMES."""
-    starts = annotated_starts(images, rel_path)
+def derive_reference_clock(starts, pts, threshold_ms):
+    """(clock, outliers) for one video, clock None below MIN_REFERENCE_FRAMES.
+
+    Takes the annotated board times rather than finding them, so a caller scoring a
+    retimed clip can hand over the source annotations in that clip's own numbering.
+    """
     clock = fit_reference_clock(starts, pts)
     if clock is None:
         return None, []
-    return clock, reference_outliers(clock, starts, pts)
+    return clock, reference_outliers(clock, starts, pts, threshold_ms)
 
 
-def describe_outliers(rel_path, outliers):
+def describe_outliers(rel_path, outliers, threshold_ms):
     """One line per frame whose annotation the rest of the video contradicts."""
-    lines = [f"{rel_path}: {len(outliers)} frame(s) beyond {REFERENCE_RESIDUAL_THRESHOLD_MS} ms"]
+    lines = [f"{rel_path}: {len(outliers)} frame(s) beyond {threshold_ms:.2f} ms"]
     lines += [f"  {frame_key(rel_path, i)}  {residual:+.2f} ms" for i, residual in outliers]
     return "\n".join(lines)
+
+
+def measured_video_entry(clock, source_period_ms, threshold_ms):
+    """The `videos` entry for a clip whose timeline is the camera's own."""
+    return {
+        **clock.to_dict(threshold_ms),
+        "timeline": "measured",
+        "source_frame_period_ms": source_period_ms,
+        "derived_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+
+
+def is_synthesized(videos, rel_path):
+    """Whether a stored entry describes a retimed clip, which is not ours to re-derive."""
+    return (videos.get(rel_path) or {}).get("timeline") == "synthesized"
 
 
 class Mode(Enum):
@@ -379,6 +398,7 @@ class AnnotationTool:
         # Reference clock state. pts are read once per video and kept; a video is
         # re-derived only once one of its annotations has actually changed.
         self._video_pts: dict[str, dict[int, float]] = {}
+        self._video_threshold: dict[str, tuple[float | None, float]] = {}
         self._dirty_videos: set[str] = set()
 
         # Board profile and derived geometry (set per-image)
@@ -432,7 +452,7 @@ class AnnotationTool:
     # ── Main loop ───────────────────────────────────────────────────────
 
     def run(self):
-        self.frames = collect_frames(self.data_dir)
+        self.frames = collect_frames(self.data_dir, sources_only=True)
         if not self.frames:
             print("No images or videos found.", file=sys.stderr)
             return
@@ -1316,6 +1336,17 @@ class AnnotationTool:
             self._video_pts[rel_path] = dict(enumerate(frame_pts(self.data_dir / rel_path)))
         return self._video_pts[rel_path]
 
+    def _load_threshold(self, rel_path):
+        """(source frame period, residual tolerance) of a video, both in ms.
+
+        The period comes from ffprobe, so like the timestamps it is read once per
+        video and kept off the render path.
+        """
+        if rel_path not in self._video_threshold:
+            period = source_frame_period_ms(self.data_dir / rel_path)
+            self._video_threshold[rel_path] = (period, measured_residual_threshold_ms(period))
+        return self._video_threshold[rel_path]
+
     def _update_references(self):
         """Re-derive the reference clock of every video that needs one.
 
@@ -1325,22 +1356,25 @@ class AnnotationTool:
         """
         videos = self.ground_truth.setdefault("videos", {})
         for rel_path in video_rel_paths(self.frames):
+            if is_synthesized(videos, rel_path):
+                continue
             if rel_path in videos and rel_path not in self._dirty_videos:
                 continue
+            period, threshold = self._load_threshold(rel_path)
             clock, outliers = derive_reference_clock(
-                self.ground_truth["images"], rel_path, self._load_pts(rel_path)
+                annotated_starts(self.ground_truth["images"], rel_path),
+                self._load_pts(rel_path),
+                threshold,
             )
             if clock is None:
                 continue
             if outliers:
                 # Refusing to store is the point; losing the annotation work is not
-                self.status_msg = describe_outliers(rel_path, outliers).splitlines()[0]
-                print(describe_outliers(rel_path, outliers), file=sys.stderr)
+                described = describe_outliers(rel_path, outliers, threshold)
+                self.status_msg = described.splitlines()[0]
+                print(described, file=sys.stderr)
                 continue
-            videos[rel_path] = {
-                **clock.to_dict(),
-                "derived_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-            }
+            videos[rel_path] = measured_video_entry(clock, period, threshold)
         self._dirty_videos.clear()
 
     def _clock_overlay(self, frame_key_str):
@@ -1368,7 +1402,7 @@ class AnnotationTool:
             fit_reference_clock(starts, pts, exclude=index), index, starts, pts
         )
         if residual is not None:
-            within = abs(residual) <= REFERENCE_RESIDUAL_THRESHOLD_MS
+            within = abs(residual) <= self._load_threshold(rel_path)[1]
             lines.append((f"dt {residual:+.2f} ms", (0, 128, 0) if within else (0, 0, 200)))
         clock = fit_reference_clock(starts, pts)
         if clock is not None:
@@ -1438,24 +1472,26 @@ def fit_clocks(data_dir, output_path):
     ground_truth.setdefault("images", {})
     videos = ground_truth.setdefault("videos", {})
 
-    frames = collect_frames(data_dir)
+    frames = collect_frames(data_dir, sources_only=True)
     failed = False
     for rel_path in video_rel_paths(frames):
+        if is_synthesized(videos, rel_path):
+            continue
+        period = source_frame_period_ms(data_dir / rel_path)
+        threshold = measured_residual_threshold_ms(period)
         pts = dict(enumerate(frame_pts(data_dir / rel_path)))
-        clock, outliers = derive_reference_clock(ground_truth["images"], rel_path, pts)
+        starts = annotated_starts(ground_truth["images"], rel_path)
+        clock, outliers = derive_reference_clock(starts, pts, threshold)
         if clock is None:
             print(f"{rel_path}: fewer than {MIN_REFERENCE_FRAMES} annotated frames, skipped")
             continue
         if outliers:
-            print(describe_outliers(rel_path, outliers), file=sys.stderr)
+            print(describe_outliers(rel_path, outliers, threshold), file=sys.stderr)
             failed = True
             continue
 
         previous = videos.get(rel_path)
-        videos[rel_path] = {
-            **clock.to_dict(),
-            "derived_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        }
+        videos[rel_path] = measured_video_entry(clock, period, threshold)
         if previous is None:
             print(f"{rel_path}: derived {clock.clock_rate:.7f}x, {clock.clock_offset_ms:.2f} ms")
         elif any(previous.get(k) != videos[rel_path][k] for k in ("clock_rate", "clock_offset_ms")):

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -319,6 +319,13 @@ COLOR_BOARD_TEXT = (255, 255, 255)  # white text on dark board
 WINDOW_NAME = "RocSync Annotation"
 TARGET_HEIGHT = 800
 
+# Every label uses one size, and is drawn at display resolution so it never gets
+# magnified along with the panel it sits on.
+FONT = cv2.FONT_HERSHEY_SIMPLEX
+FONT_SCALE = 0.75
+LINE_H = 32  # baseline spacing for stacked text rows
+
+
 # Zoom inset shown while placing corners in the left panel.
 LOUPE_SIZE = 220  # on-screen size of the inset (px)
 LOUPE_SOURCE_PX = 70  # side of the original-image region it magnifies
@@ -342,6 +349,17 @@ HELP_TEXT = [
     "0-N               : Place that corner next",
     ". / ,             : Next / previous input file",
 ]
+
+
+def draw_text(img, text, org, color, scale=FONT_SCALE, thickness=1):
+    """Draw a label in the one global font. Hershey strokes look ragged without LINE_AA."""
+    cv2.putText(img, text, org, FONT, scale, color, thickness, cv2.LINE_AA)
+
+
+def fit_scale(text, max_w, scale=FONT_SCALE):
+    """Largest font scale up to `scale` at which `text` still fits `max_w` pixels."""
+    w = cv2.getTextSize(text, FONT, scale, 1)[0][0]
+    return scale if w <= max_w else scale * max_w / w
 
 
 class AnnotationTool:
@@ -1000,7 +1018,6 @@ class AnnotationTool:
 
     def _render(self, original, frame_key):
         """Build the composite side-by-side display image."""
-        font = cv2.FONT_HERSHEY_SIMPLEX
         ann = self.annotation
 
         # Left panel: original image, downscaled first so the overlays are drawn
@@ -1020,16 +1037,16 @@ class AnnotationTool:
             cv2.circle(left, (cx, cy), corner_radius, color, 2)
             if i == self.placing_idx:  # the corner the next click places
                 cv2.circle(left, (cx, cy), corner_radius + 5, COLOR_RING_SEL, 2)
-            cv2.putText(left, str(i), (cx + corner_radius + 4, cy + 5), font, 0.5, color, 1)
+            draw_text(left, str(i), (cx + corner_radius + 6, cy + 7), color, thickness=2)
         cv2.addWeighted(overlay, 0.35, left, 0.65, 0, dst=left)
 
         # Which corner the next click places, and how to pick another. On a darkened
         # strip so it stays readable over whatever the image happens to show.
         hint = f"Click places corner {self.placing_idx}   (keys 0-{len(ann.corners) - 1})"
-        (tw, th), _ = cv2.getTextSize(hint, font, 0.55, 1)
-        strip = left[0 : th + 18, 0 : tw + 20]
+        (tw, th), _ = cv2.getTextSize(hint, FONT, FONT_SCALE, 2)
+        strip = left[0 : th + 20, 0 : tw + 24]
         cv2.addWeighted(strip, 0.25, np.zeros_like(strip), 0.75, 0, dst=strip)
-        cv2.putText(left, hint, (10, th + 8), font, 0.55, COLOR_RING_SEL, 1)
+        draw_text(left, hint, (12, th + 9), COLOR_RING_SEL, thickness=2)
 
         # Right panel: rectified board with overlays
         bs = self.board.board_size
@@ -1058,16 +1075,13 @@ class AnnotationTool:
             cv2.line(board_img, (ax1, ay1), (ax2, ay2), COLOR_NOT_VIS, 2)
             cv2.line(board_img, (ax2, ay1), (ax1, ay2), COLOR_NOT_VIS, 2)
 
-        # ArUco label
-        aruco_label = f"ArUco ID {ann.aruco_id}" if ann.aruco_visible else "ArUco: none"
-        cv2.putText(board_img, aruco_label, (ax1, ay1 - 8), font, 0.5, (128, 128, 128), 1)
-
         # Corner LEDs (positions stored in original image space, transform to board)
+        corner_labels = []
         for i, c in enumerate(ann.corners):
             cx, cy = ann.to_board(*c["position"])
             color = COLOR_ON if c["visible"] else COLOR_NOT_VIS
             cv2.circle(board_img, (cx, cy), LED_RADIUS_PX + 4, color, 2)
-            cv2.putText(board_img, str(i), (cx + 14, cy + 5), font, 0.4, color, 1)
+            corner_labels.append((str(i), cx + LED_RADIUS_PX + 8, cy + 6, color))
 
         # Counter bounding box
         bx1, by1, bx2, by2 = self.counter_box
@@ -1084,10 +1098,6 @@ class AnnotationTool:
                 color = COLOR_OFF
             cv2.circle(board_img, (cx, cy), LED_RADIUS_PX, color, 1)
 
-        # Counter value text
-        counter_text = f"Counter: {ann.counter_value}" if ann.counter_visible else "Counter: n/a"
-        cv2.putText(board_img, counter_text, (bx1, by1 - 8), font, 0.5, COLOR_BOARD_TEXT, 1)
-
         # Ring LEDs
         for i, (rx, ry) in enumerate(self.ring_pos):
             if ann.ring_start == ann.ring_end:
@@ -1099,26 +1109,6 @@ class AnnotationTool:
                 color = COLOR_RING_SEL
             cv2.circle(board_img, (rx, ry), LED_RADIUS_PX, color, 1)
 
-        # Annotation status label in top-right corner
-        is_annotated = frame_key in self.ground_truth["images"]
-        annotation_label = "Annotated" if is_annotated else "UNANNOTATED"
-        font_scale, thickness = 0.6, (1 if is_annotated else 2)
-        (tw, th), _ = cv2.getTextSize(annotation_label, font, font_scale, thickness)
-        margin = 10
-        tx = bs - tw - margin
-        ty = th + margin
-        annotation_color = (0, 255, 0) if is_annotated else (0, 0, 255)
-        cv2.putText(
-            board_img, annotation_label, (tx, ty), font, font_scale, annotation_color, thickness
-        )
-
-        # How this frame's timestamp sits against the clock the rest of its video implies
-        for i, (text, color) in enumerate(self._clock_overlay(frame_key), start=1):
-            (lw, lh), _ = cv2.getTextSize(text, font, 0.45, 1)
-            cv2.putText(
-                board_img, text, (bs - lw - margin, ty + i * (lh + 10)), font, 0.45, color, 1
-            )
-
         # The left panel is already at the common height; scale the board to match.
         left_scaled = left
         board_scaled = cv2.resize(board_img, (h, h))
@@ -1126,48 +1116,63 @@ class AnnotationTool:
         self.left_panel_w = left_scaled.shape[1]
         self.board_scale = h / bs
 
+        # Board labels go on after the resize, so they are drawn at display
+        # resolution rather than magnified along with the board.
+        def board_text(text, x, y, color):
+            pos = (round(x * self.board_scale), round(y * self.board_scale))
+            draw_text(board_scaled, text, pos, color)
+
+        aruco_label = f"ArUco ID {ann.aruco_id}" if ann.aruco_visible else "ArUco: none"
+        board_text(aruco_label, ax1, ay1 - 8, (128, 128, 128))
+        counter_text = f"Counter: {ann.counter_value}" if ann.counter_visible else "Counter: n/a"
+        board_text(counter_text, bx1, by1 - 8, COLOR_BOARD_TEXT)
+        for text, cx, cy, color in corner_labels:
+            board_text(text, cx, cy, color)
+
+        # Annotation status label in top-right corner
+        is_annotated = frame_key in self.ground_truth["images"]
+        annotation_label = "Annotated" if is_annotated else "UNANNOTATED"
+        thickness = 1 if is_annotated else 2
+        (tw, th), _ = cv2.getTextSize(annotation_label, FONT, FONT_SCALE, thickness)
+        draw_text(
+            board_scaled,
+            annotation_label,
+            (h - tw - 10, th + 10),
+            (0, 255, 0) if is_annotated else (0, 0, 255),
+            thickness=thickness,
+        )
+
         self._draw_loupe(left_scaled, original)
 
-        # Status bar (3 rows: info, shortcuts, legend)
-        row_h = 22
-        status_h = row_h * 3 + 8
+        # Status bar (3 rows). Left of the panel split: progress, shortcuts, legend.
+        # Right of it, under the board: the reference-clock fit and status messages.
+        row_h = LINE_H
+        status_h = row_h * 3 + 10
         total_w = left_scaled.shape[1] + board_scaled.shape[1]
         status_bar = np.full((status_h, total_w, 3), COLOR_STATUS_BG, dtype=np.uint8)
+        right_x = left_scaled.shape[1] + 8
 
         # Row 1: progress + file path
         n_annotated = len(self.ground_truth["images"])
         progress = f"[{self.current_idx + 1}/{len(self.frames)}] ({n_annotated} annotated)"
         info = f"{progress}  {frame_key}"
-        cv2.putText(status_bar, info, (8, row_h - 4), cv2.FONT_HERSHEY_SIMPLEX, 0.45, COLOR_TEXT, 1)
+        draw_text(status_bar, info, (8, row_h - 10), COLOR_TEXT, fit_scale(info, left_w - 16))
 
-        if self.status_msg:
-            cv2.putText(
-                status_bar,
-                self.status_msg,
-                (total_w - 380, row_h - 4),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.45,
-                (0, 128, 0),
-                1,
-            )
-
-        # Row 2: keyboard shortcuts
+        # Row 2: keyboard shortcuts, shrunk if they would reach past the panel split
         shortcuts = (
             "Enter=Accept  Left/Right=Prev/Next  N/B=Skip to unannotated  "
             ",/.=Prev/Next file  0-N=Pick corner  C=Clear  Q=Quit  H=Help"
         )
-        cv2.putText(
+        draw_text(
             status_bar,
             shortcuts,
-            (8, row_h * 2 - 4),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.4,
+            (8, row_h * 2 - 10),
             (80, 80, 80),
-            1,
+            fit_scale(shortcuts, left_w - 16),
         )
 
         # Row 3: color legend
-        legend_y = row_h * 3 - 4
+        legend_y = row_h * 3 - 10
         legend_items = [
             (COLOR_ON, "ON"),
             (COLOR_OFF, "OFF"),
@@ -1176,11 +1181,22 @@ class AnnotationTool:
         ]
         lx = 8
         for color, label in legend_items:
-            cv2.circle(status_bar, (lx + 6, legend_y - 4), 5, color, -1)
-            cv2.putText(
-                status_bar, label, (lx + 16, legend_y), cv2.FONT_HERSHEY_SIMPLEX, 0.4, color, 1
+            cv2.circle(status_bar, (lx + 8, legend_y - 6), 7, color, -1)
+            draw_text(status_bar, label, (lx + 24, legend_y), color)
+            lx += 24 + cv2.getTextSize(label, FONT, FONT_SCALE, 1)[0][0] + 22
+
+        # How this frame's timestamp sits against the clock the rest of its video implies
+        for i, (text, color) in enumerate(self._clock_overlay(frame_key), start=1):
+            draw_text(status_bar, text, (right_x, row_h * i - 10), color)
+
+        if self.status_msg:
+            draw_text(
+                status_bar,
+                self.status_msg,
+                (right_x, row_h * 3 - 10),
+                (0, 128, 0),
+                fit_scale(self.status_msg, board_scaled.shape[1] - 16),
             )
-            lx += 16 + len(label) * 10 + 15
 
         composite = np.vstack(
             [
@@ -1202,7 +1218,6 @@ class AnnotationTool:
         if pw < LOUPE_SIZE + 2 * LOUPE_MARGIN or ph < LOUPE_SIZE + 2 * LOUPE_MARGIN:
             return
 
-        font = cv2.FONT_HERSHEY_SIMPLEX
         cx, cy = self._cursor_left
         # getRectSubPix replicates the border, so cursors near the edge still work.
         patch = cv2.getRectSubPix(
@@ -1221,7 +1236,7 @@ class AnnotationTool:
                 cv2.circle(loupe, (px, py), 8, color, 1)
                 if i == self.placing_idx:
                     cv2.circle(loupe, (px, py), 12, COLOR_RING_SEL, 1)
-                cv2.putText(loupe, str(i), (px + 14, py + 4), font, 0.4, color, 1)
+                draw_text(loupe, str(i), (px + 14, py + 6), color)
 
         # Crosshair marking the exact click point, with a gap so the pixel stays visible
         for dx0, dy0, dx1, dy1 in ((-16, 0, -4, 0), (4, 0, 16, 0), (0, -16, 0, -4), (0, 4, 0, 16)):
@@ -1257,24 +1272,14 @@ class AnnotationTool:
         overlay = img.copy()
         h, w = img.shape[:2]
         pad = 20
-        text_w = max(
-            cv2.getTextSize(line, cv2.FONT_HERSHEY_SIMPLEX, 0.45, 1)[0][0] for line in HELP_TEXT
-        )
-        box_w, box_h = text_w + 2 * pad, len(HELP_TEXT) * 22 + 2 * pad
+        text_w = max(cv2.getTextSize(line, FONT, FONT_SCALE, 1)[0][0] for line in HELP_TEXT)
+        box_w, box_h = text_w + 2 * pad, len(HELP_TEXT) * LINE_H + 2 * pad
         x0 = (w - box_w) // 2
         y0 = (h - box_h) // 2
         cv2.rectangle(overlay, (x0, y0), (x0 + box_w, y0 + box_h), (30, 30, 30), -1)
         cv2.addWeighted(overlay, 0.85, img, 0.15, 0, dst=img)
         for i, line in enumerate(HELP_TEXT):
-            cv2.putText(
-                img,
-                line,
-                (x0 + pad, y0 + pad + 18 + i * 22),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.45,
-                (255, 255, 255),
-                1,
-            )
+            draw_text(img, line, (x0 + pad, y0 + pad + 22 + i * LINE_H), (255, 255, 255))
 
     # ── Persistence ─────────────────────────────────────────────────────
 
@@ -1364,14 +1369,14 @@ class AnnotationTool:
         )
         if residual is not None:
             within = abs(residual) <= REFERENCE_RESIDUAL_THRESHOLD_MS
-            lines.append((f"dt {residual:+.2f} ms", (0, 255, 0) if within else (0, 0, 255)))
+            lines.append((f"dt {residual:+.2f} ms", (0, 128, 0) if within else (0, 0, 200)))
         clock = fit_reference_clock(starts, pts)
         if clock is not None:
             lines.append(
                 (
                     f"fit {clock.n_frames_fitted} frames  RMSE {clock.rmse_ms:.2f}"
                     f"  max {clock.max_residual_ms:.2f} ms",
-                    COLOR_BOARD_TEXT,
+                    COLOR_TEXT,
                 )
             )
         elif len(starts) < MIN_REFERENCE_FRAMES:

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -11,6 +11,7 @@ Usage:
 
 import argparse
 import copy
+import itertools
 import json
 import sys
 from dataclasses import dataclass, field
@@ -73,6 +74,60 @@ def counter_bbox(counter_pos):
         max(cx) + LED_RADIUS_PX + 10,
         max(cy) + LED_RADIUS_PX + 10,
     )
+
+
+# A homography follows from four point pairs whose board coordinates are in general
+# position. v2's LEDs 0, 1 and 4 are collinear, so a fifth-LED set needs a corner off
+# that line. The area threshold separates the collinear zero from the smallest triangle
+# the layout actually forms (~10000 px² on v2) with room to spare.
+MIN_HOMOGRAPHY_CORNERS = 4
+MIN_CORNER_TRIANGLE_FRACTION = 0.02  # of board_size, squared, as an area
+FIT_WARNING = "Rectified view needs"  # prefix of the message a failed fit leaves
+
+
+def _min_triangle_area(points):
+    """Smallest triangle area over all triples of points — zero if three are collinear."""
+    return min(
+        abs(np.linalg.det(np.array([points[j] - points[i], points[k] - points[i]]))) / 2
+        for i, j, k in itertools.combinations(range(len(points)), 3)
+    )
+
+
+def _determines_homography(points, min_area):
+    """Whether four of the points sit in general position, i.e. no three of them collinear."""
+    return any(
+        _min_triangle_area([points[i] for i in quad]) >= min_area
+        for quad in itertools.combinations(range(len(points)), MIN_HOMOGRAPHY_CORNERS)
+    )
+
+
+def fit_corner_homography(corners, board):
+    """Fit original image → rectified board from the visible corner LEDs, or None.
+
+    None means the visible corners do not determine a map: too few of them, board
+    coordinates that are degenerate, or a fit that came out singular.
+    """
+    board_pos = board.always_on_leds[CameraType.RGB]
+    visible = [i for i, c in enumerate(corners) if c["visible"]]
+    if len(visible) < MIN_HOMOGRAPHY_CORNERS:
+        return None
+
+    dst = np.array([board_pos[i] for i in visible], dtype=np.float32)
+    min_area = (MIN_CORNER_TRIANGLE_FRACTION * board.board_size) ** 2
+    if not _determines_homography(dst, min_area):
+        return None
+
+    src = np.array([corners[i]["position"] for i in visible], dtype=np.float32)
+    try:
+        if len(visible) == MIN_HOMOGRAPHY_CORNERS:
+            H = cv2.getPerspectiveTransform(src, dst)
+        else:
+            H, _ = cv2.findHomography(src, dst)
+    except cv2.error:
+        return None
+    if H is None or not np.isfinite(H).all():
+        return None
+    return H
 
 
 # Known ArUco marker IDs to cycle through
@@ -367,6 +422,9 @@ HELP_TEXT = [
     "=== Keys ===",
     "0-N               : Place that corner next",
     ". / ,             : Next / previous input file",
+    "=== Rectified view ===",
+    "Any corner edit re-fits the board view,",
+    "from 4 or more visible corner LEDs",
 ]
 
 
@@ -541,15 +599,10 @@ class AnnotationTool:
                         bx, by = self.corner_pos[i]
                         c["position"] = [ox + bx * scale, oy + by * scale]
 
-            # Re-warp the rectified image using the annotation's homography
-            # so the displayed image is consistent with to_original/to_board.
-            # This matters when loading a saved annotation whose homography
-            # differs from the pipeline's (e.g. user corrected corners earlier).
-            if all(c["visible"] for c in self.annotation.corners):
-                self._recompute_homography(image)
-            elif self.annotation.homography is not None:
-                # Not all corners visible but we have a saved homography.
-                # Warp using it so the displayed image matches to_original/to_board.
+            # Warp with the annotation's own homography, saved or from the pipeline, so
+            # the displayed image is consistent with to_original/to_board. Loading never
+            # refits: a stored annotation keeps the homography it was accepted with.
+            if self.annotation.homography is not None:
                 H = np.array(self.annotation.homography, dtype=np.float64)
                 mask = image[:, :, 2]
                 self.stats["rectified"] = cv2.warpPerspective(
@@ -787,8 +840,7 @@ class AnnotationTool:
             elif event == cv2.EVENT_LBUTTONUP and self._drag_on_left:
                 if self._drag_idx is not None:
                     if self._drag_started:
-                        if all(c["visible"] for c in self.annotation.corners):
-                            self._recompute_homography(self._current_image)
+                        self._recompute_homography(self._current_image)
                     else:
                         self._place_corner(ox, oy)
                     self._drag_idx = None
@@ -870,8 +922,7 @@ class AnnotationTool:
         if self._drag_idx is not None:
             if not self._drag_started:
                 self._cycle_corner_state(self._drag_idx)
-            if all(c["visible"] for c in self.annotation.corners):
-                self._recompute_homography(self._current_image)
+            self._recompute_homography(self._current_image)
             self._drag_idx = None
             self._drag_started = False
             self.mode = Mode.IDLE
@@ -891,8 +942,7 @@ class AnnotationTool:
         corner = self.annotation.corners[self.placing_idx]
         corner["position"] = [ox, oy]
         corner["visible"] = True
-        if all(c["visible"] for c in self.annotation.corners):
-            self._recompute_homography(self._current_image)
+        self._recompute_homography(self._current_image)
         self.placing_idx = (self.placing_idx + 1) % len(self.annotation.corners)
         self._needs_redraw = True
 
@@ -1003,29 +1053,31 @@ class AnnotationTool:
         self._needs_redraw = True
 
     def _recompute_homography(self, original):
-        """Recompute homography and re-warp rectified image from all visible corners."""
+        """Refit the homography and re-warp the board from the visible corners.
+
+        Returns whether the fit succeeded; a failed one leaves the previous homography
+        and rectified view in place, so the board stays usable while corners are edited.
+        """
         ann = self.annotation
         board = self.board
-        visible = [c for c in ann.corners if c["visible"]]
-        if len(visible) < 4:
-            return
-        src = np.array([c["position"] for c in ann.corners if c["visible"]], dtype=np.float32)
-        dst = np.array(
-            [
-                board.always_on_leds[CameraType.RGB][i]
-                for i, c in enumerate(ann.corners)
-                if c["visible"]
-            ],
-            dtype=np.float32,
-        )
-        if len(src) == 4:
-            H = cv2.getPerspectiveTransform(src, dst)
-        else:
-            H, _ = cv2.findHomography(src, dst)
+        H = fit_corner_homography(ann.corners, board)
+        if H is None:
+            n = sum(1 for c in ann.corners if c["visible"])
+            self.status_msg = (
+                f"{FIT_WARNING} {MIN_HOMOGRAPHY_CORNERS} non-collinear corner LEDs ({n} visible)"
+            )
+            return False
+        if self.status_msg.startswith(FIT_WARNING):
+            self.status_msg = ""
         ann.homography = H.tolist()
+        # Hidden corners have no annotated position, so park them where the fit predicts.
+        for i, c in enumerate(ann.corners):
+            if not c["visible"]:
+                c["position"] = ann.to_original(*self.corner_pos[i])
         mask = original[:, :, 2]  # red channel
         bs = board.board_size
         self.stats["rectified"] = cv2.warpPerspective(mask, H, (bs, bs))
+        return True
 
     def _handle_ring_first_click(self, idx):
         """First ring click (CW first ON LED), then wait for CW first OFF LED."""

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -30,6 +30,7 @@ from rocsync.benchmark.common import (
     fit_reference_clock,
     frame_key,
     measured_residual_threshold_ms,
+    orphaned_entries,
     parse_frame_key,
     reconstruct_timestamp,
     reference_outliers,
@@ -406,6 +407,97 @@ def describe_outliers(rel_path, outliers, threshold_ms):
     return "\n".join(lines)
 
 
+def _group_by_path(keys):
+    """{relative path: [key]} for a list of frame keys, in path order."""
+    grouped = {}
+    for key in keys:
+        grouped.setdefault(parse_frame_key(key)[0], []).append(key)
+    return dict(sorted(grouped.items()))
+
+
+def describe_orphans(orphans, ground_truth):
+    """One line per file the ground truth still describes and the dataset no longer backs.
+
+    Grouped by file rather than by key: a video contributes one annotation per frame, and
+    a thousand of those say nothing a single line about the file does not.
+    """
+    images = ground_truth.get("images") or {}
+    videos = ground_truth.get("videos") or {}
+    lines = []
+    for rel_path, keys in _group_by_path(orphans.missing_images).items():
+        detail = "reference clock and " if rel_path in orphans.missing_videos else ""
+        lines.append(f"  {rel_path}: no such file ({detail}{len(keys)} annotation(s))")
+    described = set(_group_by_path(orphans.missing_images))
+    for rel_path in orphans.missing_videos:
+        if rel_path in described:
+            continue
+        # A retimed clip is orphaned by its source, which is the file to name
+        source = (videos.get(rel_path) or {}).get("source")
+        gone = f"its source {source} is gone" if source else "no such file"
+        lines.append(f"  {rel_path}: {gone} (reference clock)")
+    for rel_path, keys in _group_by_path(orphans.out_of_range_images).items():
+        lines.append(f"  {rel_path}: {len(keys)} annotation(s) past the last frame")
+    for rel_path in orphans.unreadable_videos:
+        n = sum(1 for key in images if parse_frame_key(key)[0] == rel_path)
+        kept = f"{n} annotation(s) kept" if n else "no annotations"
+        lines.append(f"  {rel_path}: could not be read, so nothing was pruned ({kept})")
+    return "\n".join(lines)
+
+
+def annotations_behind(orphans, images):
+    """How many annotations sit behind files that are present but would not decode."""
+    unreadable = set(orphans.unreadable_videos)
+    return sum(1 for key in images if parse_frame_key(key)[0] in unreadable)
+
+
+def prune(data_dir, output_path, dry_run=False):
+    """Drop ground truth entries whose input is gone. Returns a process exit code.
+
+    Removal is opt-in and never touches a file that merely failed to decode: those are
+    listed and kept, and make the exit code non-zero so a partial clean-up is not read
+    as a finished one.
+    """
+    data_dir = Path(data_dir)
+    output_path = Path(output_path) if output_path else data_dir / "ground_truth.json"
+    if not output_path.exists():
+        print(f"No ground truth at {output_path}", file=sys.stderr)
+        return 1
+
+    with open(output_path) as f:
+        ground_truth = json.load(f)
+    images = ground_truth.setdefault("images", {})
+    videos = ground_truth.setdefault("videos", {})
+
+    frames = collect_frames(data_dir, sources_only=True)
+    orphans = orphaned_entries(ground_truth, data_dir, frames)
+    if orphans.is_empty():
+        print(f"{output_path}: every entry still has its input")
+        return 0
+
+    print(describe_orphans(orphans, ground_truth))
+    if not orphans.prunable():
+        return 1
+
+    if dry_run:
+        print("Dry run, nothing written")
+        return 1 if orphans.unreadable_videos else 0
+
+    for key in orphans.missing_images + orphans.out_of_range_images:
+        del images[key]
+    for rel_path in orphans.missing_videos:
+        del videos[rel_path]
+    with open(output_path, "w") as f:
+        json.dump(ground_truth, f, indent=2)
+
+    n_images = len(orphans.missing_images) + len(orphans.out_of_range_images)
+    print(f"Removed {n_images} annotation(s) and {len(orphans.missing_videos)} video reference(s)")
+    if orphans.out_of_range_images:
+        # Those videos are still in the benchmark, and their reference was fitted over
+        # annotations that no longer all exist
+        print("Re-derive the affected clocks with --fit-clocks")
+    return 1 if annotations_behind(orphans, images) else 0
+
+
 def measured_video_entry(clock, source_period_ms, threshold_ms):
     """The `videos` entry for a clip whose timeline is the camera's own."""
     return {
@@ -571,6 +663,7 @@ class AnnotationTool:
             return
 
         self._load_ground_truth()
+        self._report_orphans()
         first = self._find_unannotated(-1, forward=True)
         if first == -1:
             print("All frames already annotated. Starting from the beginning.")
@@ -1481,6 +1574,20 @@ class AnnotationTool:
             n = len(self.ground_truth["images"])
             print(f"Loaded {n} existing annotations from {self.output_path}")
 
+    def _report_orphans(self):
+        """Say which entries no longer have an input, without touching any of them.
+
+        The GUI walks the disk, so an entry whose file is gone is otherwise invisible
+        here -- and saving would write it straight back out.
+        """
+        orphans = orphaned_entries(self.ground_truth, self.data_dir, self.frames)
+        if orphans.is_empty():
+            return
+        print(f"Ground truth entries with no input in {self.data_dir}:", file=sys.stderr)
+        print(describe_orphans(orphans, self.ground_truth), file=sys.stderr)
+        if orphans.prunable():
+            print("Run with --prune to remove them.", file=sys.stderr)
+
     def _save_ground_truth(self):
         self._update_references()
         with open(self.output_path, "w") as f:
@@ -1697,7 +1804,20 @@ def main():
         action="store_true",
         help="Re-derive every video's reference clock and exit, without opening the GUI",
     )
+    parser.add_argument(
+        "--prune",
+        action="store_true",
+        help="Remove ground truth entries whose image or video is gone, and exit",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="With --prune, list what would be removed without writing",
+    )
     args = parser.parse_args()
+
+    if args.prune:
+        sys.exit(prune(args.data_dir, args.output, dry_run=args.dry_run))
 
     if args.fit_clocks:
         sys.exit(fit_clocks(args.data_dir, args.output))

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-from rocsync.benchmark.common import collect_images
+from rocsync.benchmark.common import collect_images, corner_positions_in_image
 from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO, RectifiedBoard
 from rocsync.camera import CameraType
 from rocsync.vision import ARUCO_DICTIONARY, process_frame
@@ -127,22 +127,11 @@ class ImageAnnotation:
         ann.aruco_visible = aruco_id is not None
         ann.aruco_id = aruco_id if aruco_id is not None else 0
 
-        # Corner LEDs — stats positions are in rough-rectified space,
-        # convert to original image space via the rough homography inverse.
-        corner_positions = stats.get("corner_positions")
-        aruco_corners = stats.get("aruco_corners")
-        if corner_positions is not None and aruco_corners is not None:
-            rough_H = cv2.getPerspectiveTransform(
-                np.array(aruco_corners, dtype=np.float32),
-                board.aruco_corners_coords,
-            )
-            inv_rough = np.linalg.inv(rough_H)
-            for i, pos in enumerate(corner_positions):
-                if i < len(ann.corners) and pos is not None:
-                    pt = np.array([[pos]], dtype=np.float64)
-                    orig_pt = cv2.perspectiveTransform(pt, inv_rough).reshape(2)
-                    ann.corners[i]["visible"] = True
-                    ann.corners[i]["position"] = [float(orig_pt[0]), float(orig_pt[1])]
+        # Corner LEDs — the pipeline detects them in rough-rectified space
+        for i, pos in enumerate(corner_positions_in_image(stats)):
+            if i < len(ann.corners) and pos is not None:
+                ann.corners[i]["visible"] = True
+                ann.corners[i]["position"] = [float(pos[0]), float(pos[1])]
 
         # Counter
         counter_leds = stats.get("counter_leds")

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -330,6 +330,8 @@ class AnnotationTool:
         self.left_scale = 1.0
         self.board_scale = 1.0
         self.status_msg = ""
+        self._last_composite = None  # last frame, re-presented while work blocks the loop
+        self._pending_key: int | None = None  # key caught by _pump, consumed by _image_loop
 
         # Interaction state
         self.mode = Mode.IDLE
@@ -387,8 +389,10 @@ class AnnotationTool:
             image = cv2.imread(str(image_path))
             if image is None:
                 print(f"Cannot read {image_path}", file=sys.stderr)
+                self._pump()
                 self.current_idx += 1
                 continue
+            self._pump()
 
             # Run pipeline
             self.stats = {}
@@ -398,6 +402,7 @@ class AnnotationTool:
                 print(f"Pipeline error on {rel_path}: {e}", file=sys.stderr)
                 self.stats["rectified"] = None
                 self.stats["aruco_id"] = None
+            self._pump()
 
             # Resolve board profile from pipeline detection or saved annotation
             aruco_id = self.stats.get("aruco_id")
@@ -454,6 +459,7 @@ class AnnotationTool:
                 self.stats["rectified"] = cv2.warpPerspective(
                     mask, H, (board.board_size, board.board_size)
                 )
+            self._pump()
 
             self.mode = Mode.IDLE
             self._ring_start_candidate = None
@@ -486,19 +492,34 @@ class AnnotationTool:
 
         cv2.destroyAllWindows()
 
+    def _pump(self):
+        """Present a frame and service events so the window manager sees a live window."""
+        if self._last_composite is not None:
+            cv2.imshow(WINDOW_NAME, self._last_composite)
+        key = cv2.waitKey(1) & 0xFF
+        if key != 255 and self._pending_key is None:
+            self._pending_key = key  # hold keys typed while work blocked the loop
+
     def _image_loop(self, image, rel_path):
         composite = None
         while True:
-            if self._needs_redraw:
+            if self._needs_redraw or composite is None:
                 composite = self._render(image, rel_path)
                 if not self._window_sized:
                     h, w = composite.shape[:2]
                     cv2.resizeWindow(WINDOW_NAME, w, h)
                     self._window_sized = True
-                cv2.imshow(WINDOW_NAME, composite)
                 self._needs_redraw = False
 
-            key = cv2.waitKey(30) & 0xFF
+            # A window that stops presenting frames is flagged as not responding.
+            cv2.imshow(WINDOW_NAME, composite)
+            self._last_composite = composite
+
+            if self._pending_key is not None:
+                key = self._pending_key
+                self._pending_key = None
+            else:
+                key = cv2.waitKey(30) & 0xFF
 
             if cv2.getWindowProperty(WINDOW_NAME, cv2.WND_PROP_VISIBLE) < 1:
                 return "quit"

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -26,6 +26,7 @@ FRAME_KEY_SEPARATOR = "#"
 FRAME_INDEX_DIGITS = 6  # zero-padded so keys sort in frame order
 FRAME_CACHE_SIZE = 4  # a decoded 4K frame is ~25 MB
 FORWARD_GRAB_LIMIT = 12  # a seek re-decodes from the preceding keyframe anyway
+SEEK_BACKOFF_FRAMES = 32  # retry margin for a seek that landed past the frame wanted
 
 MIN_REFERENCE_FRAMES = 5  # a two-point fit is exact by construction and proves nothing
 
@@ -34,7 +35,7 @@ MIN_REFERENCE_FRAMES = 5  # a two-point fit is exact by construction and proves 
 # absorb the camera: the container stores a nominal frame rate while the sensor exposes
 # when it pleases, which on the dataset's 30 fps clips scatters by up to 9 ms.
 SYNTHESIZED_RESIDUAL_THRESHOLD_MS = 2.0
-MEASURED_RESIDUAL_FRACTION = 1 / 3  # of a source frame
+MEASURED_RESIDUAL_FRACTION = 1 / 2  # of a source frame
 MEASURED_RESIDUAL_MIN_MS = 2.0  # never tighter than the board itself resolves
 MEASURED_RESIDUAL_MAX_MS = 50.0  # below the ring period, so a counter step still shows
 
@@ -302,6 +303,7 @@ class FrameSource:
         self._cap = None
         self._cap_path = None
         self._next_index = -1  # index the open capture would read next; -1 forces a seek
+        self._pts: dict[Path, list[float] | None] = {}  # every frame's presentation timestamp
 
     def read(self, ref):
         """Decoded BGR image for `ref`, or None if it could not be read."""
@@ -325,19 +327,79 @@ class FrameSource:
                 return None
             self._cap, self._cap_path, self._next_index = cap, ref.path, 0
         cap = self._cap
+        pts = self._frame_pts(ref.path)
 
         ahead = ref.index - self._next_index
-        if 0 <= ahead <= FORWARD_GRAB_LIMIT:
-            for _ in range(ahead):
-                if not cap.grab():
-                    self._next_index = -1
-                    return None
-        else:
-            cap.set(cv2.CAP_PROP_POS_FRAMES, ref.index)
+        frame = (
+            self._grab_forward(cap, ahead, pts, ref.index)
+            if 0 <= ahead <= FORWARD_GRAB_LIMIT
+            else None
+        )
+        if frame is None:
+            frame = self._seek_and_read(cap, pts, ref.index)
+        self._next_index = ref.index + 1 if frame is not None else -1
+        return frame
 
+    def _frame_pts(self, path):
+        """Presentation timestamps for `path`, or None when they cannot be read."""
+        if path not in self._pts:
+            self._pts[path] = frame_pts(path) or None
+        return self._pts[path]
+
+    def _window(self, pts, index):
+        """The timestamp span that belongs to frame `index` and to no other."""
+        low = (pts[index - 1] + pts[index]) / 2 if index > 0 else pts[index] - 1.0
+        high = (pts[index] + pts[index + 1]) / 2 if index + 1 < len(pts) else pts[index] + 1.0
+        return low, high
+
+    def _is_frame(self, cap, pts, index):
+        """Whether the frame just read off `cap` is the one `index` names."""
+        if pts is None or index >= len(pts):
+            return True
+        low, high = self._window(pts, index)
+        return low < cap.get(cv2.CAP_PROP_POS_MSEC) < high
+
+    def _grab_forward(self, cap, ahead, pts, index):
+        """Frame `index`, reached by reading on from where the capture stands.
+
+        None when it is not what came back, which leaves the caller to seek: an earlier
+        read may have been served a neighbouring frame, and counting on from there lands
+        every later frame one out.
+        """
+        for _ in range(ahead):
+            if not cap.grab():
+                return None
         success, frame = cap.read()
-        self._next_index = ref.index + 1 if success else -1
-        return frame if success else None
+        return frame if success and self._is_frame(cap, pts, index) else None
+
+    def _seek_and_read(self, cap, pts, index):
+        """Frame `index`, reached by seeking, or None if it could not be read.
+
+        `CAP_PROP_POS_FRAMES` converts the index into a timestamp through the stream's
+        average frame rate, so a recording whose frames are not spaced at that rate --
+        anything variable-rate, or cut from a faster source -- lands on a neighbour,
+        while the capture still reports the index that was asked for. The frame is
+        identified by its own timestamp instead: read on when the seek falls short, and
+        seek further back when it overshoots.
+        """
+        if pts is None or index >= len(pts):
+            cap.set(cv2.CAP_PROP_POS_FRAMES, index)
+            success, frame = cap.read()
+            return frame if success else None
+
+        low, high = self._window(pts, index)
+        for start in (index, max(index - SEEK_BACKOFF_FRAMES, 0), 0):
+            cap.set(cv2.CAP_PROP_POS_FRAMES, start)
+            while True:
+                if not cap.grab():
+                    return None
+                now = cap.get(cv2.CAP_PROP_POS_MSEC)
+                if now > low:
+                    break
+            if now < high:
+                success, frame = cap.retrieve()
+                return frame if success else None
+        return None
 
     def close(self):
         if self._cap is not None:

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -1,0 +1,68 @@
+"""Shared utilities for RocSync benchmark tools."""
+
+from pathlib import Path
+import numpy as np
+
+STEP_ORDER = [
+    "aruco_detection",
+    "corner_detection",
+    "fine_rectification",
+    "counter_reading",
+    "ring_reading",
+]
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg"}
+
+
+def collect_images(root_dir):
+    """Collect all image files recursively, sorted by path."""
+    return sorted(
+        p for p in Path(root_dir).rglob("*") if p.suffix.lower() in IMAGE_EXTENSIONS
+    )
+
+
+def ring_visible(image_data):
+    """Ring is visible when start != end (half-open interval has nonzero length)."""
+    ring = image_data.get("ring", {})
+    return ring.get("start", 0) != ring.get("end", 0)
+
+
+def reconstruct_timestamp(image_data, board):
+    """Reconstruct [start, end] timestamp from counter value and ring position.
+
+    Returns [start, end] list or None if counter or ring is not visible.
+    """
+    counter_value = image_data.get("counter", {}).get("value")
+    ring = image_data.get("ring", {})
+    if counter_value is None or ring.get("start", 0) == ring.get("end", 0):
+        return None
+    start = ring["start"] + counter_value * board.period
+    end = ring["end"] + counter_value * board.period
+    return [start, end]
+
+
+def descriptive_stats(values):
+    """Compute mean, median, std, min, max, n for a list of numbers."""
+    if not values:
+        return {"mean": None, "median": None, "std": None, "min": None, "max": None, "n": 0}
+    a = np.array(values, dtype=np.float64)
+    return {
+        "mean": float(np.mean(a)),
+        "median": float(np.median(a)),
+        "std": float(np.std(a)),
+        "min": float(np.min(a)),
+        "max": float(np.max(a)),
+        "n": len(values),
+    }
+
+
+def confusion_metrics(tp, fp, fn, tn):
+    """Derive precision, recall, FPR, and F1 from confusion matrix counts."""
+    precision = tp / (tp + fp) if (tp + fp) > 0 else None
+    recall = tp / (tp + fn) if (tp + fn) > 0 else None
+    fpr = fp / (fp + tn) if (fp + tn) > 0 else None
+    f1 = 2 * precision * recall / (precision + recall) if precision and recall else None
+    return {
+        "tp": tp, "fp": fp, "fn": fn, "tn": tn,
+        "precision": precision, "recall": recall, "fpr": fpr, "f1": f1,
+    }

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import cv2
 import numpy as np
 
 STEP_ORDER = [
@@ -18,6 +19,23 @@ IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg"}
 def collect_images(root_dir):
     """Collect all image files recursively, sorted by path."""
     return sorted(p for p in Path(root_dir).rglob("*") if p.suffix.lower() in IMAGE_EXTENSIONS)
+
+
+def corner_positions_in_image(stats):
+    """Detected corner LED positions in original image coordinates.
+
+    The pipeline detects corners in the rough-rectified grid, whose scale is a
+    property of the branch under test. Un-warping through that grid's own
+    homography yields the annotated quantity, comparable across branches.
+    """
+    positions = stats.get("corner_positions")
+    rough_H = stats.get("rough_homography")
+    if positions is None or rough_H is None:
+        return [None] * 4
+
+    inv_rough = np.linalg.inv(np.array(rough_H, dtype=np.float64))
+    pts = np.array([positions], dtype=np.float64)
+    return cv2.perspectiveTransform(pts, inv_rough).reshape(-1, 2).tolist()
 
 
 def ring_visible(image_data):

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -1,5 +1,6 @@
 """Shared utilities for RocSync benchmark tools."""
 
+import subprocess
 import sys
 from collections import OrderedDict
 from dataclasses import asdict, dataclass
@@ -8,7 +9,9 @@ from pathlib import Path
 import cv2
 import numpy as np
 
+from rocsync.board_profiles import PROFILES_BY_ARUCO
 from rocsync.dataset import VIDEO_SUFFIXES
+from rocsync.timeline import frame_pts, median_frame_period
 
 STEP_ORDER = [
     "aruco_detection",
@@ -25,8 +28,18 @@ FRAME_INDEX_DIGITS = 6  # zero-padded so keys sort in frame order
 FRAME_CACHE_SIZE = 4  # a decoded 4K frame is ~25 MB
 FORWARD_GRAB_LIMIT = 12  # a seek re-decodes from the preceding keyframe anyway
 
-REFERENCE_RESIDUAL_THRESHOLD_MS = 2.0  # one ring LED is 1 ms; more is a bad annotation
 MIN_REFERENCE_FRAMES = 5  # a two-point fit is exact by construction and proves nothing
+
+# A synthesized timeline is built from the annotations themselves, so the only slack it
+# needs covers reading the ring arc one LED out at either end. A measured one has to
+# absorb the camera: the container stores a nominal frame rate while the sensor exposes
+# when it pleases, which on the dataset's 30 fps clips scatters by up to 9 ms.
+SYNTHESIZED_RESIDUAL_THRESHOLD_MS = 2.0
+MEASURED_RESIDUAL_FRACTION = 1 / 3  # of a source frame
+MEASURED_RESIDUAL_MIN_MS = 2.0  # never tighter than the board itself resolves
+MEASURED_RESIDUAL_MAX_MS = 50.0  # below the ring period, so a counter step still shows
+
+RETIMED_MARKER = ".retimed"  # `clip.retimed.mp4` is `clip.mp4` on a synthesized timeline
 
 
 @dataclass(frozen=True)
@@ -95,12 +108,111 @@ def count_video_frames(path):
         cap.release()
 
 
-def collect_frames(root_dir):
+def _is_positive_float(text):
+    """Whether `text` parses as a number above zero; ffprobe prints 'N/A' for some."""
+    try:
+        return float(text) > 0
+    except ValueError:
+        return False
+
+
+def source_frame_period_ms(video_path):
+    """Frame period of the recording this file was cut from, in ms, or None.
+
+    Read from the packet duration, which survives decimation: a clip holding every 16th
+    frame of a 30 fps recording still says 33.3 ms per packet while its timestamps sit
+    533 ms apart. The timestamp spacing would describe the subsampling instead, and a
+    tolerance scaled from that would be far too loose to catch anything.
+    """
+    try:
+        output = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-read_intervals",
+                "%+#50",
+                "-show_entries",
+                "frame=duration_time",
+                "-of",
+                "csv=p=0",
+                str(video_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        output = ""
+
+    fields = (line.strip().rstrip(",") for line in output.splitlines())
+    durations = [float(f) for f in fields if _is_positive_float(f)]
+    if durations:
+        # The mode, so one odd packet at a cut cannot stand for the whole recording
+        return float(max(set(durations), key=durations.count)) * 1000
+
+    # Without a packet duration the spacing is all there is, subsampled or not
+    return median_frame_period(frame_pts(video_path))
+
+
+def measured_residual_threshold_ms(source_period_ms):
+    """How far an annotated frame may sit from a clock fitted to a recorded timeline."""
+    if not source_period_ms:
+        return MEASURED_RESIDUAL_MAX_MS
+    scaled = source_period_ms * MEASURED_RESIDUAL_FRACTION
+    return min(max(scaled, MEASURED_RESIDUAL_MIN_MS), MEASURED_RESIDUAL_MAX_MS)
+
+
+def residual_threshold_ms(video_entry):
+    """The tolerance that applies to one video, from how its timeline came about.
+
+    An entry records the tolerance its reference was checked against, and that stored
+    number wins: a frozen reference stays valid under the rule it was frozen by, not
+    whichever rule the code holds today. Deriving is the fallback for an entry written
+    before the tolerance was recorded.
+    """
+    entry = video_entry or {}
+    stored = entry.get("residual_threshold_ms")
+    if stored is not None:
+        return float(stored)
+    if entry.get("timeline") == "synthesized":
+        return SYNTHESIZED_RESIDUAL_THRESHOLD_MS
+    return measured_residual_threshold_ms(entry.get("source_frame_period_ms"))
+
+
+def is_retimed(path):
+    """Whether this file is a retimed clip rather than something recorded."""
+    return Path(path).stem.endswith(RETIMED_MARKER)
+
+
+def retimed_path(path):
+    """Where the retimed clip cut from `path` belongs."""
+    path = Path(path)
+    return path.with_name(f"{path.stem}{RETIMED_MARKER}{path.suffix}")
+
+
+def has_retimed_sibling(path):
+    """Whether a retimed clip cut from `path` sits beside it, in any video container."""
+    path = Path(path)
+    return any(
+        path.with_name(f"{path.stem}{RETIMED_MARKER}{suffix}").is_file()
+        for suffix in VIDEO_SUFFIXES
+    )
+
+
+def collect_frames(root_dir, sources_only=False):
     """Every benchmark frame under `root_dir`, sorted, images and videos alike.
 
     Every frame of a video is benchmark material, so all of them are enumerated. A video
     that will not open contributes no frames at all, which keeps the annotator and the
     validator from disagreeing about what the dataset contains.
+
+    A retimed clip stands in for the video it was cut from, so scoring a dataset holding
+    both counts each frame once. `sources_only` walks what was recorded instead, which is
+    what the annotator wants: a retimed clip is trimmed to the frames already annotated,
+    and annotating the ones outside that window is how the window grows.
     """
     root_dir = Path(root_dir)
     frames = []
@@ -112,6 +224,8 @@ def collect_frames(root_dir):
         if suffix in IMAGE_EXTENSIONS:
             frames.append(FrameRef(path, None, rel_path))
         elif suffix in VIDEO_SUFFIXES:
+            if is_retimed(path) if sources_only else has_retimed_sibling(path):
+                continue
             n_frames = count_video_frames(path)
             if not n_frames:
                 print(f"WARNING: could not read any frame of {path}", file=sys.stderr)
@@ -236,6 +350,18 @@ def reconstruct_timestamp(image_data, board):
     return list(timestamp) if timestamp is not None else None
 
 
+def annotated_board_time(entry):
+    """Board time in ms an annotation pins down, or None when it pins down none.
+
+    Resolves the board from the annotated marker, so a caller only needs the entry.
+    """
+    board = PROFILES_BY_ARUCO.get(entry.get("aruco", {}).get("id"))
+    if board is None:
+        return None
+    timestamp = reconstruct_timestamp(entry, board)
+    return None if timestamp is None else timestamp[0]
+
+
 def descriptive_stats(values):
     """Compute mean, median, std, min, max, n for a list of numbers."""
     if not values:
@@ -292,11 +418,9 @@ class ReferenceClock:
         """Board time in ms for one or many container timestamps in ms."""
         return self.clock_rate * np.asarray(pts_ms, dtype=float) + self.clock_offset_ms
 
-    def to_dict(self):
-        return {
-            **asdict(self),
-            "residual_threshold_ms": REFERENCE_RESIDUAL_THRESHOLD_MS,
-        }
+    def to_dict(self, threshold_ms):
+        """Serialized form, recording the tolerance the reference was checked against."""
+        return {**asdict(self), "residual_threshold_ms": threshold_ms}
 
     @classmethod
     def from_dict(cls, data):
@@ -349,13 +473,53 @@ def reference_residual(clock, index, starts_by_index, pts_by_index):
     return float(clock.predict(pts)) - float(starts_by_index[index])
 
 
-def reference_outliers(clock, starts_by_index, pts_by_index):
-    """[(index, signed residual ms)] for frames beyond the reference threshold."""
+def reference_outliers(clock, starts_by_index, pts_by_index, threshold_ms):
+    """[(index, signed residual ms)] for frames the clock disagrees with.
+
+    The tolerance is passed in rather than fixed, because what counts as too far
+    depends on where the timeline came from -- see `residual_threshold_ms`.
+    """
     if clock is None:
         return []
     outliers = []
     for index in sorted(starts_by_index):
         residual = reference_residual(clock, index, starts_by_index, pts_by_index)
-        if residual is not None and abs(residual) > REFERENCE_RESIDUAL_THRESHOLD_MS:
+        if residual is not None and abs(residual) > threshold_ms:
             outliers.append((index, residual))
     return outliers
+
+
+@dataclass(frozen=True)
+class RetimedVideo:
+    """A retimed clip and the recording it was cut from.
+
+    Annotations stay keyed to the source, so the clip can be regenerated or thrown away
+    without touching them; this is what turns a prediction about a retimed frame back
+    into the annotation it should be scored against.
+    """
+
+    path: str  # relative path of the retimed clip
+    source: str  # relative path of the clip it was cut from
+    frame_offset: int  # retimed frame j is source frame j + frame_offset
+
+
+def retimed_videos(ground_truth):
+    """{retimed path: RetimedVideo} for every retimed clip the ground truth describes."""
+    videos = {}
+    for path, entry in (ground_truth.get("videos") or {}).items():
+        if entry.get("source") is not None:
+            videos[path] = RetimedVideo(
+                path=path,
+                source=entry["source"],
+                frame_offset=int(entry.get("source_frame_offset", 0)),
+            )
+    return videos
+
+
+def source_key(key, retimed):
+    """The annotation key a frame key refers to, unchanged for anything not retimed."""
+    path, index = parse_frame_key(key)
+    video = retimed.get(path)
+    if video is None or index is None:
+        return key
+    return frame_key(video.source, index + video.frame_offset)

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -1,6 +1,7 @@
 """Shared utilities for RocSync benchmark tools."""
 
 from pathlib import Path
+
 import numpy as np
 
 STEP_ORDER = [
@@ -16,9 +17,7 @@ IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg"}
 
 def collect_images(root_dir):
     """Collect all image files recursively, sorted by path."""
-    return sorted(
-        p for p in Path(root_dir).rglob("*") if p.suffix.lower() in IMAGE_EXTENSIONS
-    )
+    return sorted(p for p in Path(root_dir).rglob("*") if p.suffix.lower() in IMAGE_EXTENSIONS)
 
 
 def ring_visible(image_data):
@@ -63,6 +62,12 @@ def confusion_metrics(tp, fp, fn, tn):
     fpr = fp / (fp + tn) if (fp + tn) > 0 else None
     f1 = 2 * precision * recall / (precision + recall) if precision and recall else None
     return {
-        "tp": tp, "fp": fp, "fn": fn, "tn": tn,
-        "precision": precision, "recall": recall, "fpr": fpr, "f1": f1,
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+        "tn": tn,
+        "precision": precision,
+        "recall": recall,
+        "fpr": fpr,
+        "f1": f1,
     }

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -218,15 +218,22 @@ def ring_visible(image_data):
 def reconstruct_timestamp(image_data, board):
     """Reconstruct [start, end] timestamp from counter value and ring position.
 
-    Returns [start, end] list or None if counter or ring is not visible.
+    Returns None when the counter or ring is not visible, and equally when the board
+    calls the pair undecodable -- an arc wrapping the end of the period, or ending
+    within a LED of it, means the counter changed mid-exposure and no longer says
+    which period the arc belongs to. The decision is the board's rather than a rule
+    of our own: annotating what is on screen is not the same as it being decodable,
+    and a benchmark that reconstructed a time here would score the pipeline against
+    timestamps it is designed never to produce.
     """
     counter_value = image_data.get("counter", {}).get("value")
     ring = image_data.get("ring", {})
-    if counter_value is None or ring.get("start", 0) == ring.get("end", 0):
+    start, end = ring.get("start", 0), ring.get("end", 0)
+    if counter_value is None or start == end:
         return None
-    start = ring["start"] + counter_value * board.period
-    end = ring["end"] + counter_value * board.period
-    return [start, end]
+    # Annotations hold a half-open interval; the board decodes an inclusive one
+    timestamp = board.board_time_from_ring(counter_value, (start, (end - 1) % board.period))
+    return list(timestamp) if timestamp is not None else None
 
 
 def descriptive_stats(values):

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -154,7 +154,10 @@ def source_frame_period_ms(video_path):
         return float(max(set(durations), key=durations.count)) * 1000
 
     # Without a packet duration the spacing is all there is, subsampled or not
-    return median_frame_period(frame_pts(video_path))
+    try:
+        return median_frame_period(frame_pts(video_path))
+    except OSError:
+        return None  # a file that will not open has no period to report
 
 
 def measured_residual_threshold_ms(source_period_ms):
@@ -233,6 +236,76 @@ def collect_frames(root_dir, sources_only=False):
             frames.extend(FrameRef(path, i, frame_key(rel_path, i)) for i in range(n_frames))
     frames.sort(key=lambda ref: (str(ref.path), -1 if ref.index is None else ref.index))
     return frames
+
+
+@dataclass(frozen=True)
+class Orphans:
+    """Ground truth entries no frame on disk stands behind, split by what is wrong.
+
+    The split is what makes pruning safe to automate: a file that is gone is gone, while
+    a file that is merely unreadable today -- a truncated download, a codec the machine
+    lacks -- must not cost the annotation work behind it.
+    """
+
+    missing_images: list  # keys whose file is not there at all
+    missing_videos: list  # `videos` paths whose recording is not there at all
+    out_of_range_images: list  # keys past the last frame of a file that did decode
+    unreadable_videos: list  # present but contributed no frame; their entries are kept
+
+    def prunable(self):
+        """Whether anything here can be removed without losing recoverable work."""
+        return bool(self.missing_images or self.missing_videos or self.out_of_range_images)
+
+    def is_empty(self):
+        return not (self.prunable() or self.unreadable_videos)
+
+
+def orphaned_entries(ground_truth, data_dir, frames):
+    """Ground truth entries with no frame behind them, as an `Orphans`.
+
+    `frames` is the caller's own `collect_frames(data_dir, sources_only=True)` result:
+    annotations are keyed to the recording and never to a retimed clip, so the sources
+    walk is the one whose keys they are supposed to match.
+
+    Existence is decided by a plain directory listing rather than by that walk, because
+    the walk drops an unreadable video too, and a file that cannot be decoded right now
+    is a different thing from one that was deleted.
+    """
+    data_dir = Path(data_dir)
+    on_disk = {str(p.relative_to(data_dir)) for p in data_dir.rglob("*") if p.is_file()}
+    valid_keys = {ref.key for ref in frames}
+    enumerated = {parse_frame_key(ref.key)[0] for ref in frames}
+
+    unreadable = {
+        rel
+        for rel in on_disk
+        if Path(rel).suffix.lower() in VIDEO_SUFFIXES
+        and rel not in enumerated
+        and not is_retimed(rel)
+    }
+
+    missing_images, out_of_range_images = [], []
+    for key in ground_truth.get("images") or {}:
+        if key in valid_keys:
+            continue
+        rel_path, index = parse_frame_key(key)
+        if rel_path not in on_disk:
+            missing_images.append(key)
+        elif index is not None and rel_path not in unreadable:
+            out_of_range_images.append(key)  # the file decoded and stops before this frame
+
+    missing_videos = []
+    for rel_path, entry in (ground_truth.get("videos") or {}).items():
+        # A retimed clip is cut again on demand, so its source is what has to exist
+        if (entry.get("source") or rel_path) not in on_disk:
+            missing_videos.append(rel_path)
+
+    return Orphans(
+        missing_images=sorted(missing_images),
+        missing_videos=sorted(missing_videos),
+        out_of_range_images=sorted(out_of_range_images),
+        unreadable_videos=sorted(unreadable),
+    )
 
 
 class FrameSource:

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -1,9 +1,14 @@
 """Shared utilities for RocSync benchmark tools."""
 
+import sys
+from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 
 import cv2
 import numpy as np
+
+from rocsync.dataset import VIDEO_SUFFIXES
 
 STEP_ORDER = [
     "aruco_detection",
@@ -15,10 +20,162 @@ STEP_ORDER = [
 
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg"}
 
+FRAME_KEY_SEPARATOR = "#"
+FRAME_INDEX_DIGITS = 6  # zero-padded so keys sort in frame order
+FRAME_CACHE_SIZE = 4  # a decoded 4K frame is ~25 MB
+FORWARD_GRAB_LIMIT = 12  # a seek re-decodes from the preceding keyframe anyway
 
-def collect_images(root_dir):
-    """Collect all image files recursively, sorted by path."""
-    return sorted(p for p in Path(root_dir).rglob("*") if p.suffix.lower() in IMAGE_EXTENSIONS)
+
+@dataclass(frozen=True)
+class FrameRef:
+    """One benchmark frame: a still image, or one frame of a video.
+
+    `key` is the identity used in both ground_truth.json and the results JSON, so those
+    two files associate through it alone and nothing downstream has to know which kind
+    of input produced a frame.
+    """
+
+    path: Path
+    index: int | None  # None for a still image
+    key: str
+
+
+def frame_key(rel_path, index=None):
+    """Ground truth key for a frame: the input's relative path, plus an index for video.
+
+    The index is the frame's absolute position in the file, not a presentation timestamp:
+    a timestamp shifts when a decoder reports it differently, while the index is a
+    property of the file. Zero padding keeps a video's keys sorting in frame order.
+    """
+    rel_path = str(rel_path)
+    if index is None:
+        return rel_path
+    return f"{rel_path}{FRAME_KEY_SEPARATOR}{index:0{FRAME_INDEX_DIGITS}d}"
+
+
+def count_video_frames(path):
+    """Number of frames a video contributes, or 0 if it cannot be read.
+
+    Enumeration defines the keys, so an over-reported count would invent keys that no
+    frame can ever fill -- and that the annotator's jump-to-unannotated would then land
+    on forever. The container's own count is checked by grabbing the frame it claims is
+    last, and only when that fails is the file demuxed to count for real.
+    """
+    cap = cv2.VideoCapture(str(path), cv2.CAP_FFMPEG)
+    if not cap.isOpened():
+        return 0
+    try:
+        reported = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        if reported > 0:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, reported - 1)
+            if cap.grab():
+                return reported
+
+        # grab() demuxes without decoding pixels, so counting for real stays cheap
+        cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+        counted = 0
+        while cap.grab():
+            counted += 1
+        return counted
+    finally:
+        cap.release()
+
+
+def collect_frames(root_dir):
+    """Every benchmark frame under `root_dir`, sorted, images and videos alike.
+
+    Every frame of a video is benchmark material, so all of them are enumerated. A video
+    that will not open contributes no frames at all, which keeps the annotator and the
+    validator from disagreeing about what the dataset contains.
+    """
+    root_dir = Path(root_dir)
+    frames = []
+    for path in root_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        suffix = path.suffix.lower()
+        rel_path = str(path.relative_to(root_dir))
+        if suffix in IMAGE_EXTENSIONS:
+            frames.append(FrameRef(path, None, rel_path))
+        elif suffix in VIDEO_SUFFIXES:
+            n_frames = count_video_frames(path)
+            if not n_frames:
+                print(f"WARNING: could not read any frame of {path}", file=sys.stderr)
+                continue
+            frames.extend(FrameRef(path, i, frame_key(rel_path, i)) for i in range(n_frames))
+    frames.sort(key=lambda ref: (str(ref.path), -1 if ref.index is None else ref.index))
+    return frames
+
+
+class FrameSource:
+    """Reads the image behind a `FrameRef`, for both sequential and random access.
+
+    The two tools walk the same list differently -- the validator front to back, the
+    annotator jumping around it -- and in both the frames of a video are interleaved with
+    still images, so a per-video iterator like `clips.read_frames_at_indices` does not
+    fit. One capture is held open across calls instead.
+
+    Reaching a nearby later frame grabs forward rather than seeking, because a seek makes
+    the decoder restart from the preceding keyframe and re-decode the span anyway. So the
+    validator, walking in order, never seeks, and the annotator's step forward costs one
+    grab while its step back is a cache hit. Frames are not copied: a caller keeping one
+    past the next `read` must copy it.
+    """
+
+    def __init__(self):
+        self._cache = OrderedDict()
+        self._cap = None
+        self._cap_path = None
+        self._next_index = -1  # index the open capture would read next; -1 forces a seek
+
+    def read(self, ref):
+        """Decoded BGR image for `ref`, or None if it could not be read."""
+        cached = self._cache.pop(ref.key, None)
+        if cached is not None:
+            self._cache[ref.key] = cached
+            return cached
+
+        frame = cv2.imread(str(ref.path)) if ref.index is None else self._read_video(ref)
+        if frame is not None:
+            self._cache[ref.key] = frame
+            while len(self._cache) > FRAME_CACHE_SIZE:
+                self._cache.popitem(last=False)
+        return frame
+
+    def _read_video(self, ref):
+        if self._cap is None or self._cap_path != ref.path:
+            self.close()
+            cap = cv2.VideoCapture(str(ref.path), cv2.CAP_FFMPEG)
+            if not cap.isOpened():
+                return None
+            self._cap, self._cap_path, self._next_index = cap, ref.path, 0
+        cap = self._cap
+
+        ahead = ref.index - self._next_index
+        if 0 <= ahead <= FORWARD_GRAB_LIMIT:
+            for _ in range(ahead):
+                if not cap.grab():
+                    self._next_index = -1
+                    return None
+        else:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, ref.index)
+
+        success, frame = cap.read()
+        self._next_index = ref.index + 1 if success else -1
+        return frame if success else None
+
+    def close(self):
+        if self._cap is not None:
+            self._cap.release()
+        self._cap = None
+        self._cap_path = None
+        self._next_index = -1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
 
 
 def corner_positions_in_image(stats):

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -1,6 +1,5 @@
 """Shared utilities for RocSync benchmark tools."""
 
-import subprocess
 import sys
 from collections import OrderedDict
 from dataclasses import asdict, dataclass
@@ -11,7 +10,7 @@ import numpy as np
 
 from rocsync.board_profiles import PROFILES_BY_ARUCO
 from rocsync.dataset import VIDEO_SUFFIXES
-from rocsync.timeline import frame_pts, median_frame_period
+from rocsync.timeline import frame_pts, median_frame_period, probe_packet_field, run_ffprobe
 
 STEP_ORDER = [
     "aruco_detection",
@@ -85,21 +84,19 @@ def count_video_frames(path):
 
     Enumeration defines the keys, so an over-reported count would invent keys that no
     frame can ever fill -- and that the annotator's jump-to-unannotated would then land
-    on forever. The container's own count is checked by grabbing the frame it claims is
-    last, and only when that fails is the file demuxed to count for real.
+    on forever. The stream's packets are therefore counted rather than the count the
+    container claims taken at its word.
     """
+    counted = _probe_packet_count(path)
+    if counted:
+        return counted
+
+    # ffprobe could not answer, so demux the file here instead
     cap = cv2.VideoCapture(str(path), cv2.CAP_FFMPEG)
     if not cap.isOpened():
         return 0
     try:
-        reported = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        if reported > 0:
-            cap.set(cv2.CAP_PROP_POS_FRAMES, reported - 1)
-            if cap.grab():
-                return reported
-
         # grab() demuxes without decoding pixels, so counting for real stays cheap
-        cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
         counted = 0
         while cap.grab():
             counted += 1
@@ -108,12 +105,13 @@ def count_video_frames(path):
         cap.release()
 
 
-def _is_positive_float(text):
-    """Whether `text` parses as a number above zero; ffprobe prints 'N/A' for some."""
-    try:
-        return float(text) > 0
-    except ValueError:
-        return False
+def _probe_packet_count(path):
+    """Packets the video stream holds, or None if ffprobe could not count them."""
+    output = run_ffprobe(
+        path, "-count_packets", "-show_entries", "stream=nb_read_packets", "-of", "csv=p=0"
+    )
+    counted = (output or "").strip().rstrip(",")
+    return int(counted) if counted.isdigit() else None
 
 
 def source_frame_period_ms(video_path):
@@ -124,31 +122,7 @@ def source_frame_period_ms(video_path):
     533 ms apart. The timestamp spacing would describe the subsampling instead, and a
     tolerance scaled from that would be far too loose to catch anything.
     """
-    try:
-        output = subprocess.run(
-            [
-                "ffprobe",
-                "-v",
-                "error",
-                "-select_streams",
-                "v:0",
-                "-read_intervals",
-                "%+#50",
-                "-show_entries",
-                "frame=duration_time",
-                "-of",
-                "csv=p=0",
-                str(video_path),
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout
-    except (OSError, subprocess.CalledProcessError):
-        output = ""
-
-    fields = (line.strip().rstrip(",") for line in output.splitlines())
-    durations = [float(f) for f in fields if _is_positive_float(f)]
+    durations = [d for d in probe_packet_field(video_path, "duration_time") if d > 0]
     if durations:
         # The mode, so one odd packet at a cut cannot stand for the whole recording
         return float(max(set(durations), key=durations.count)) * 1000

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -2,7 +2,7 @@
 
 import sys
 from collections import OrderedDict
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import cv2
@@ -24,6 +24,9 @@ FRAME_KEY_SEPARATOR = "#"
 FRAME_INDEX_DIGITS = 6  # zero-padded so keys sort in frame order
 FRAME_CACHE_SIZE = 4  # a decoded 4K frame is ~25 MB
 FORWARD_GRAB_LIMIT = 12  # a seek re-decodes from the preceding keyframe anyway
+
+REFERENCE_RESIDUAL_THRESHOLD_MS = 2.0  # one ring LED is 1 ms; more is a bad annotation
+MIN_REFERENCE_FRAMES = 5  # a two-point fit is exact by construction and proves nothing
 
 
 @dataclass(frozen=True)
@@ -51,6 +54,17 @@ def frame_key(rel_path, index=None):
     if index is None:
         return rel_path
     return f"{rel_path}{FRAME_KEY_SEPARATOR}{index:0{FRAME_INDEX_DIGITS}d}"
+
+
+def parse_frame_key(key):
+    """Split a frame key back into (relative path, index), with None for a still image.
+
+    Only the last separator counts, so a path that contains one itself round-trips.
+    """
+    head, sep, tail = str(key).rpartition(FRAME_KEY_SEPARATOR)
+    if not sep or not tail.isdigit():
+        return str(key), None
+    return head, int(tail)
 
 
 def count_video_frames(path):
@@ -246,3 +260,95 @@ def confusion_metrics(tp, fp, fn, tn):
         "fpr": fpr,
         "f1": f1,
     }
+
+
+@dataclass(frozen=True)
+class ReferenceClock:
+    """Affine map from container presentation time to annotated board time.
+
+    The benchmark's own least-squares fit rather than `rocsync.timeline.fit_timeline`.
+    A reference the evaluation scores against has to be a pure function of the
+    annotations: fitting it with the production estimator would let a change to that
+    estimator move the ground truth, and with it every error measured against it. No
+    outlier is tolerated here anyway, which is all RANSAC would have bought.
+    """
+
+    clock_rate: float  # board ms per container ms
+    clock_offset_ms: float  # board ms at pts == 0
+    pts_min_ms: float  # span of the annotated frames, not of the file
+    pts_max_ms: float
+    n_frames_fitted: int
+    rmse_ms: float
+    max_residual_ms: float
+
+    def predict(self, pts_ms):
+        """Board time in ms for one or many container timestamps in ms."""
+        return self.clock_rate * np.asarray(pts_ms, dtype=float) + self.clock_offset_ms
+
+    def to_dict(self):
+        return {
+            **asdict(self),
+            "residual_threshold_ms": REFERENCE_RESIDUAL_THRESHOLD_MS,
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        fields = (
+            "clock_rate",
+            "clock_offset_ms",
+            "pts_min_ms",
+            "pts_max_ms",
+            "n_frames_fitted",
+            "rmse_ms",
+            "max_residual_ms",
+        )
+        return cls(**{k: data[k] for k in fields})
+
+
+def fit_reference_clock(starts_by_index, pts_by_index, exclude=None):
+    """Least-squares clock over annotated frames, or None with too few of them.
+
+    `starts_by_index` maps a video's frame index to its annotated board time in ms,
+    `pts_by_index` to the frame's presentation timestamp. Passing `exclude` drops one
+    index, which measures a frame against a fit that does not contain it.
+    """
+    order = sorted(k for k in starts_by_index if k != exclude and pts_by_index.get(k) is not None)
+    if len(order) < MIN_REFERENCE_FRAMES:
+        return None
+
+    x = np.array([pts_by_index[k] for k in order], dtype=float)
+    y = np.array([starts_by_index[k] for k in order], dtype=float)
+    if x.min() == x.max():  # a vertical line has no slope to fit
+        return None
+
+    clock_rate, clock_offset_ms = (float(v) for v in np.polyfit(x, y, 1))
+    residuals = clock_rate * x + clock_offset_ms - y
+    return ReferenceClock(
+        clock_rate=clock_rate,
+        clock_offset_ms=clock_offset_ms,
+        pts_min_ms=float(x.min()),
+        pts_max_ms=float(x.max()),
+        n_frames_fitted=len(order),
+        rmse_ms=float(np.sqrt(np.mean(residuals**2))),
+        max_residual_ms=float(np.max(np.abs(residuals))),
+    )
+
+
+def reference_residual(clock, index, starts_by_index, pts_by_index):
+    """Signed residual of one frame in ms, predicted minus annotated, or None."""
+    pts = pts_by_index.get(index)
+    if clock is None or pts is None or index not in starts_by_index:
+        return None
+    return float(clock.predict(pts)) - float(starts_by_index[index])
+
+
+def reference_outliers(clock, starts_by_index, pts_by_index):
+    """[(index, signed residual ms)] for frames beyond the reference threshold."""
+    if clock is None:
+        return []
+    outliers = []
+    for index in sorted(starts_by_index):
+        residual = reference_residual(clock, index, starts_by_index, pts_by_index)
+        if residual is not None and abs(residual) > REFERENCE_RESIDUAL_THRESHOLD_MS:
+            outliers.append((index, residual))
+    return outliers

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -42,8 +42,8 @@ STEP_GT_POSITIVE = {
     "corners": lambda gt: any(c.get("visible", False) for c in gt.get("corners", [])),
     "counter": lambda gt: gt.get("counter", {}).get("visible", False),
     "ring": ring_visible,
-    # Overall: a timestamp is extractable when both counter and ring are visible
-    "overall": lambda gt: gt.get("counter", {}).get("visible", False) and ring_visible(gt),
+    # Defined below, since deciding this needs the annotation's board geometry
+    "overall": lambda gt: _timestamp_extractable(gt),
 }
 
 # Map pipeline steps to prediction visibility checks.
@@ -108,6 +108,18 @@ def _gt_aruco_corners(gt):
     inv_H = np.linalg.inv(np.array(H, dtype=np.float64))
     pts = np.array([board.aruco_corners_coords], dtype=np.float64)
     return cv2.perspectiveTransform(pts, inv_H).reshape(4, 2)
+
+
+def _timestamp_extractable(gt):
+    """Whether a timestamp follows from an annotation at all.
+
+    Counter and ring both being visible is not enough: an arc that wraps the end of
+    the period was exposed across a counter increment, so it names no single time.
+    The pipeline refuses those, and scoring the refusal as a miss would penalise it
+    for the one correct answer available.
+    """
+    board = _board_for_gt(gt)
+    return board is not None and reconstruct_timestamp(gt, board) is not None
 
 
 def _corner_positions(entry):

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -26,7 +26,6 @@ from rocsync.benchmark.common import (
     ring_visible,
 )
 from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO
-from rocsync.camera import CameraType
 
 CORNER_IMAGE_SPACE_THRESHOLD_PX = 3
 # A corner counts as found when it lands within one LED sampling disc of where it belongs.
@@ -109,45 +108,32 @@ def _gt_aruco_corners(gt):
     return cv2.perspectiveTransform(pts, inv_H).reshape(4, 2)
 
 
-def _gt_corner_positions(gt):
-    """Derive ground-truth corner LED positions in original image space.
+def _corner_positions(entry):
+    """Annotated or predicted corner LED positions in image space, None per invisible corner."""
+    return [
+        c["position"] if c.get("visible") and c.get("position") is not None else None
+        for c in entry.get("corners", [])
+    ]
 
-    Inverse-transforms the known board-space corner LED coordinates through
-    the ground-truth homography.  Returns list of [x, y] or None.
+
+def _to_board_space(positions, gt):
+    """Map image-space positions into the reference board grid via the GT homography.
+
+    Both sides of the comparison go through the same transform, so a board-space
+    error stays meaningful against a threshold expressed in LED sample radii.
     """
     H = gt.get("homography")
     if H is None:
-        return None
-    board = _board_for_gt(gt)
-    if board is None:
-        return None
-    inv_H = np.linalg.inv(np.array(H, dtype=np.float64))
-    pts = np.array([board.always_on_leds[CameraType.RGB]], dtype=np.float64)
-    return cv2.perspectiveTransform(pts, inv_H).reshape(-1, 2).tolist()
-
-
-def _pred_corner_positions_image(pred, gt):
-    """Transform predicted corner positions from board space to image space.
-
-    The pipeline detects corners in the rough-rectified (board-space) image,
-    so positions need to be inverse-transformed through the GT homography to
-    get image-space coordinates for comparison with GT image-space positions.
-
-    Returns a list of 4 image-space [x, y] positions (or None per corner).
-    """
-    H = gt.get("homography")
-    if H is None:
-        return [None] * 4
-    inv_H = np.linalg.inv(np.array(H, dtype=np.float64))
-    result = []
-    for c in pred.get("corners", []):
-        if c.get("visible") and c.get("position") is not None:
-            pt = np.array([[c["position"]]], dtype=np.float64)
-            img_pt = cv2.perspectiveTransform(pt, inv_H).reshape(2)
-            result.append(img_pt.tolist())
+        return [None] * len(positions)
+    H = np.array(H, dtype=np.float64)
+    out = []
+    for pos in positions:
+        if pos is None:
+            out.append(None)
         else:
-            result.append(None)
-    return result
+            pt = np.array([[pos]], dtype=np.float64)
+            out.append(cv2.perspectiveTransform(pt, H).reshape(2).tolist())
+    return out
 
 
 # ── Per-step metric computation ──────────────────────────────────────────────
@@ -156,8 +142,8 @@ def _pred_corner_positions_image(pred, gt):
 def compute_step_detection(benchmark_images, gt_images, step):
     """Compute TP/FP/FN/TN and derived rates for a single step.
 
-    Corner detection uses per-corner matching with a position error threshold
-    of CORNER_MAX_ERROR_PX in image coordinates.
+    Corner detection uses per-corner matching against the annotated positions,
+    with a threshold of CORNER_IMAGE_SPACE_THRESHOLD_PX in image coordinates.
     """
     gt_pos_fn = STEP_GT_POSITIVE[step]
     pred_pos_fn = STEP_PRED_POSITIVE[step]
@@ -171,22 +157,19 @@ def compute_step_detection(benchmark_images, gt_images, step):
         if step == "corners":
             gt_corners = gt.get("corners", [])
             pred_corners = pred.get("corners", [])
-            gt_positions = _gt_corner_positions(gt)
+            gt_positions = _corner_positions(gt)
+            pred_positions = _corner_positions(pred)
 
             gt_any_visible = any(c.get("visible", False) for c in gt_corners)
             pred_any_visible = any(c.get("visible", False) for c in pred_corners)
             any_tp = False
 
-            if gt_positions is not None:
-                pred_img = _pred_corner_positions_image(pred, gt)
-                for i in range(min(len(gt_corners), len(pred_corners), 4)):
-                    gt_vis = gt_corners[i].get("visible", False)
-                    pred_vis = pred_corners[i].get("visible", False)
-
-                    if gt_vis and pred_vis and pred_img[i] is not None:
-                        err = np.linalg.norm(np.array(pred_img[i]) - np.array(gt_positions[i]))
-                        if err <= CORNER_IMAGE_SPACE_THRESHOLD_PX:
-                            any_tp = True
+            for i in range(min(len(gt_positions), len(pred_positions), 4)):
+                if gt_positions[i] is None or pred_positions[i] is None:
+                    continue
+                err = np.linalg.norm(np.array(pred_positions[i]) - np.array(gt_positions[i]))
+                if err <= CORNER_IMAGE_SPACE_THRESHOLD_PX:
+                    any_tp = True
 
             if gt_any_visible and any_tp:
                 tp += 1
@@ -258,26 +241,25 @@ def compute_corner_metrics(benchmark_images, gt_images):
         board = _board_for_gt(gt)
         gt_corners = gt.get("corners", [])
         pred_corners = pred.get("corners", [])
-        gt_positions = _gt_corner_positions(gt)
-        pred_img = _pred_corner_positions_image(pred, gt)
+        gt_positions = _corner_positions(gt)
+        pred_positions = _corner_positions(pred)
+        # Board space normalises the threshold to LED sample radii, independent of apparent board size
+        gt_board = _to_board_space(gt_positions, gt)
+        pred_board = _to_board_space(pred_positions, gt)
         n_corners = min(len(gt_corners), len(pred_corners))
 
         for i in range(n_corners):
             gt_vis = gt_corners[i].get("visible", False)
             pred_vis = pred_corners[i].get("visible", False)
-            pred_pos = pred_corners[i].get("position") if pred_vis else None
+            both = gt_positions[i] is not None and pred_positions[i] is not None
 
             # Image-space pixel error (on TPs where both are visible with positions)
-            if gt_vis and pred_vis and pred_img[i] is not None and gt_positions is not None:
-                err_img = np.linalg.norm(np.array(pred_img[i]) - np.array(gt_positions[i]))
+            if both:
+                err_img = np.linalg.norm(np.array(pred_positions[i]) - np.array(gt_positions[i]))
                 errors_image.append(float(err_img))
 
-            # Board-space detection + pixel error
-            # Predicted positions are already in board space (from rough rectification)
-            if gt_vis and pred_vis and pred_pos is not None and board is not None:
-                err_board = np.linalg.norm(
-                    np.array(pred_pos) - np.array(board.always_on_leds[CameraType.RGB][i])
-                )
+            if both and board is not None and gt_board[i] is not None:
+                err_board = np.linalg.norm(np.array(pred_board[i]) - np.array(gt_board[i]))
                 errors_board.append(float(err_board))
                 if err_board <= CORNER_BOARD_SPACE_THRESHOLD_PX:
                     tp_board += 1
@@ -679,6 +661,25 @@ def print_timing(methods, timing, col_width, label_width=LABEL_WIDTH_DEFAULT):
                 print()
 
 
+def _describe_run(config):
+    """One-line provenance for a result file, so a column says which checkout produced it."""
+    if not config:
+        return "no provenance recorded"
+    branch = config.get("branch") or "?"
+    commit = config.get("commit") or "?"
+    dirty = "+dirty" if config.get("dirty") else ""
+    parts = [f"{branch}@{commit}{dirty}"]
+    if config.get("run_at"):
+        parts.append(config["run_at"])
+    if config.get("opencv"):
+        parts.append(f"cv2 {config['opencv']}")
+    if config.get("numpy"):
+        parts.append(f"numpy {config['numpy']}")
+    if config.get("n_images") is not None:
+        parts.append(f"{config['n_images']} images")
+    return "  ".join(parts)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Evaluate benchmark results against ground truth")
     parser.add_argument(
@@ -713,6 +714,8 @@ def main():
     n_images = len(gt_images)
     print(f"Ground truth: {args.ground_truth} ({n_images} images)")
     print(f"Methods: {', '.join(methods)}")
+    for m in methods:
+        print(f"  {m}: {_describe_run(benchmarks[m].get('config', {}))}")
 
     # Compute all metrics per method
     all_metrics = {}

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -18,8 +18,6 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO
-from rocsync.camera import CameraType
 from rocsync.benchmark.common import (
     STEP_ORDER,
     confusion_metrics,
@@ -27,6 +25,8 @@ from rocsync.benchmark.common import (
     reconstruct_timestamp,
     ring_visible,
 )
+from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO
+from rocsync.camera import CameraType
 
 CORNER_IMAGE_SPACE_THRESHOLD_PX = 3
 # A corner counts as found when it lands within one LED sampling disc of where it belongs.
@@ -37,21 +37,20 @@ LABEL_WIDTH_DEFAULT = 40
 # Map pipeline steps to ground truth visibility checks.
 # Each returns True if the ground truth considers that step's output "positive".
 STEP_GT_POSITIVE = {
-    "aruco":   lambda gt: gt.get("aruco", {}).get("visible", False),
+    "aruco": lambda gt: gt.get("aruco", {}).get("visible", False),
     "corners": lambda gt: any(c.get("visible", False) for c in gt.get("corners", [])),
     "counter": lambda gt: gt.get("counter", {}).get("visible", False),
-    "ring":    ring_visible,
+    "ring": ring_visible,
     # Overall: a timestamp is extractable when both counter and ring are visible
-    "overall": lambda gt: (gt.get("counter", {}).get("visible", False)
-                           and ring_visible(gt)),
+    "overall": lambda gt: gt.get("counter", {}).get("visible", False) and ring_visible(gt),
 }
 
 # Map pipeline steps to prediction visibility checks.
 STEP_PRED_POSITIVE = {
-    "aruco":   lambda p: p.get("aruco", {}).get("visible", False),
+    "aruco": lambda p: p.get("aruco", {}).get("visible", False),
     "corners": lambda p: any(c.get("visible", False) for c in p.get("corners", [])),
     "counter": lambda p: p.get("counter", {}).get("visible", False),
-    "ring":    ring_visible,
+    "ring": ring_visible,
     "overall": lambda p: p.get("success", False),
 }
 
@@ -80,6 +79,7 @@ def load_ground_truth(path):
 
 
 # ── Geometry helpers ─────────────────────────────────────────────────────────
+
 
 def _board_for_gt(gt):
     """Rectified board for a ground truth entry's ArUco marker ID.
@@ -152,6 +152,7 @@ def _pred_corner_positions_image(pred, gt):
 
 # ── Per-step metric computation ──────────────────────────────────────────────
 
+
 def compute_step_detection(benchmark_images, gt_images, step):
     """Compute TP/FP/FN/TN and derived rates for a single step.
 
@@ -183,8 +184,7 @@ def compute_step_detection(benchmark_images, gt_images, step):
                     pred_vis = pred_corners[i].get("visible", False)
 
                     if gt_vis and pred_vis and pred_img[i] is not None:
-                        err = np.linalg.norm(
-                            np.array(pred_img[i]) - np.array(gt_positions[i]))
+                        err = np.linalg.norm(np.array(pred_img[i]) - np.array(gt_positions[i]))
                         if err <= CORNER_IMAGE_SPACE_THRESHOLD_PX:
                             any_tp = True
 
@@ -269,15 +269,15 @@ def compute_corner_metrics(benchmark_images, gt_images):
 
             # Image-space pixel error (on TPs where both are visible with positions)
             if gt_vis and pred_vis and pred_img[i] is not None and gt_positions is not None:
-                err_img = np.linalg.norm(
-                    np.array(pred_img[i]) - np.array(gt_positions[i]))
+                err_img = np.linalg.norm(np.array(pred_img[i]) - np.array(gt_positions[i]))
                 errors_image.append(float(err_img))
 
             # Board-space detection + pixel error
             # Predicted positions are already in board space (from rough rectification)
             if gt_vis and pred_vis and pred_pos is not None and board is not None:
                 err_board = np.linalg.norm(
-                    np.array(pred_pos) - np.array(board.always_on_leds[CameraType.RGB][i]))
+                    np.array(pred_pos) - np.array(board.always_on_leds[CameraType.RGB][i])
+                )
                 errors_board.append(float(err_board))
                 if err_board <= CORNER_BOARD_SPACE_THRESHOLD_PX:
                     tp_board += 1
@@ -397,14 +397,15 @@ def compute_overall_metrics(benchmark_images, gt_images):
 
 # ── Timing statistics ────────────────────────────────────────────────────────
 
+
 def compute_timing(benchmark_images, gt_images):
     """Compute per-step timing statistics for all / positive / negative subsets."""
     step_to_gt_key = {
-        "aruco_detection":   "aruco",
-        "corner_detection":  "corners",
+        "aruco_detection": "aruco",
+        "corner_detection": "corners",
         "fine_rectification": "corners",
-        "counter_reading":   "counter",
-        "ring_reading":      "ring",
+        "counter_reading": "counter",
+        "ring_reading": "ring",
     }
 
     def collect_values(timing_key, gt_positive_fn, subset):
@@ -428,15 +429,18 @@ def compute_timing(benchmark_images, gt_images):
         for step in STEP_ORDER:
             gt_key = step_to_gt_key[step]
             step_stats[step] = descriptive_stats(
-                collect_values(f"{step}_ms", STEP_GT_POSITIVE[gt_key], subset))
+                collect_values(f"{step}_ms", STEP_GT_POSITIVE[gt_key], subset)
+            )
         step_stats["total"] = descriptive_stats(
-            collect_values("total_ms", STEP_GT_POSITIVE["overall"], subset))
+            collect_values("total_ms", STEP_GT_POSITIVE["overall"], subset)
+        )
         result[subset] = step_stats
 
     return result
 
 
 # ── Printing ─────────────────────────────────────────────────────────────────
+
 
 def format_value(val, width=10):
     if val is None:
@@ -470,10 +474,12 @@ def _print_detection(methods, get_det, col_width, label_width=LABEL_WIDTH_DEFAUL
         for m in methods:
             print(f"  {format_value(get_det(m)[key], col_width)}", end="")
         print()
-    for key, label, formatter in [("recall", "TPR (Recall)", format_percent),
-                                   ("fpr", "FPR", format_percent),
-                                   ("precision", "Precision", format_percent),
-                                   ("f1", "F1 Score", format_percent)]:
+    for key, label, formatter in [
+        ("recall", "TPR (Recall)", format_percent),
+        ("fpr", "FPR", format_percent),
+        ("precision", "Precision", format_percent),
+        ("f1", "F1 Score", format_percent),
+    ]:
         print(f"  {label:>{label_width}}", end="")
         for m in methods:
             print(f"  {formatter(get_det(m)[key], col_width)}", end="")
@@ -489,13 +495,15 @@ def _print_error_stats(methods, get_stats, col_width, label_width=LABEL_WIDTH_DE
         print()
 
 
-def _print_value_accuracy(methods, get_n, get_correct, label, col_width, label_width=LABEL_WIDTH_DEFAULT):
+def _print_value_accuracy(
+    methods, get_n, get_correct, label, col_width, label_width=LABEL_WIDTH_DEFAULT
+):
     """Print a single value accuracy row (e.g. '5/7 (71%)')."""
     print(f"  {label:>{label_width}}", end="")
     for m in methods:
         n = get_n(m)
         nc = get_correct(m)
-        text = f"{nc}/{n} ({nc/n:.0%})" if n > 0 else "-"
+        text = f"{nc}/{n} ({nc / n:.0%})" if n > 0 else "-"
         print(f"  {text:>{col_width}}", end="")
     print()
 
@@ -505,50 +513,67 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
 
     # ── ArUco detection ──────────────────────────────────────────────────
     print(f"{'=' * 100}")
-    print(f"  ARUCO DETECTION")
+    print("  ARUCO DETECTION")
     print(f"{'=' * 100}")
 
     print_header(methods, col_width, label_width, "Detection")
-    _print_detection(methods, lambda m: all_metrics[m]["aruco"]["detection"],
-                     col_width, label_width)
+    _print_detection(
+        methods, lambda m: all_metrics[m]["aruco"]["detection"], col_width, label_width
+    )
 
     print()
     print_header(methods, col_width, label_width, "Corner error (px, image space)")
-    _print_error_stats(methods, lambda m: all_metrics[m]["aruco"]["corner_error_px"],
-                       col_width, label_width)
+    _print_error_stats(
+        methods, lambda m: all_metrics[m]["aruco"]["corner_error_px"], col_width, label_width
+    )
 
     # ── Corner LED detection ─────────────────────────────────────────────
     print(f"{'=' * 100}")
-    print(f"  CORNER LED DETECTION")
+    print("  CORNER LED DETECTION")
     print(f"{'=' * 100}")
 
-    print_header(methods, col_width, label_width, f"Detection (thres: {CORNER_IMAGE_SPACE_THRESHOLD_PX}px in image space)")
-    _print_detection(methods, lambda m: all_metrics[m]["corners"]["detection_image"],
-                     col_width, label_width)
+    print_header(
+        methods,
+        col_width,
+        label_width,
+        f"Detection (thres: {CORNER_IMAGE_SPACE_THRESHOLD_PX}px in image space)",
+    )
+    _print_detection(
+        methods, lambda m: all_metrics[m]["corners"]["detection_image"], col_width, label_width
+    )
 
     print()
-    print_header(methods, col_width, label_width, f"Detection (thres: {CORNER_BOARD_SPACE_THRESHOLD_PX}px in board space)")
-    _print_detection(methods, lambda m: all_metrics[m]["corners"]["detection_board"],
-                     col_width, label_width)
+    print_header(
+        methods,
+        col_width,
+        label_width,
+        f"Detection (thres: {CORNER_BOARD_SPACE_THRESHOLD_PX}px in board space)",
+    )
+    _print_detection(
+        methods, lambda m: all_metrics[m]["corners"]["detection_board"], col_width, label_width
+    )
 
     print()
     print_header(methods, col_width, label_width, "Pixel error — image space")
-    _print_error_stats(methods, lambda m: all_metrics[m]["corners"]["error_image_px"],
-                       col_width, label_width)
+    _print_error_stats(
+        methods, lambda m: all_metrics[m]["corners"]["error_image_px"], col_width, label_width
+    )
 
     print()
     print_header(methods, col_width, label_width, "Pixel error — board space")
-    _print_error_stats(methods, lambda m: all_metrics[m]["corners"]["error_board_px"],
-                       col_width, label_width)
+    _print_error_stats(
+        methods, lambda m: all_metrics[m]["corners"]["error_board_px"], col_width, label_width
+    )
 
     # ── Counter reading ──────────────────────────────────────────────────
     print(f"{'=' * 100}")
-    print(f"  COUNTER READING")
+    print("  COUNTER READING")
     print(f"{'=' * 100}")
 
     print_header(methods, col_width, label_width, "Detection")
-    _print_detection(methods, lambda m: all_metrics[m]["counter"]["detection"],
-                     col_width, label_width)
+    _print_detection(
+        methods, lambda m: all_metrics[m]["counter"]["detection"], col_width, label_width
+    )
 
     print()
     print_header(methods, col_width, label_width, "Value accuracy")
@@ -556,16 +581,18 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
         methods,
         lambda m: all_metrics[m]["counter"]["value_compared"],
         lambda m: all_metrics[m]["counter"]["value_correct"],
-        "counter.value correct", col_width, label_width)
+        "counter.value correct",
+        col_width,
+        label_width,
+    )
 
     # ── Ring reading ─────────────────────────────────────────────────────
     print(f"{'=' * 100}")
-    print(f"  RING READING")
+    print("  RING READING")
     print(f"{'=' * 100}")
 
     print_header(methods, col_width, label_width, "Detection")
-    _print_detection(methods, lambda m: all_metrics[m]["ring"]["detection"],
-                     col_width, label_width)
+    _print_detection(methods, lambda m: all_metrics[m]["ring"]["detection"], col_width, label_width)
 
     print()
     print_header(methods, col_width, label_width, "Value accuracy")
@@ -573,21 +600,28 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
         methods,
         lambda m: all_metrics[m]["ring"]["value_compared"],
         lambda m: all_metrics[m]["ring"]["start_correct"],
-        "ring.start correct", col_width, label_width)
+        "ring.start correct",
+        col_width,
+        label_width,
+    )
     _print_value_accuracy(
         methods,
         lambda m: all_metrics[m]["ring"]["value_compared"],
         lambda m: all_metrics[m]["ring"]["end_correct"],
-        "ring.end correct", col_width, label_width)
+        "ring.end correct",
+        col_width,
+        label_width,
+    )
 
     # ── Overall ──────────────────────────────────────────────────────────
     print(f"{'=' * 100}")
-    print(f"  OVERALL (timestamp)")
+    print("  OVERALL (timestamp)")
     print(f"{'=' * 100}")
 
     print_header(methods, col_width, label_width, "Detection")
-    _print_detection(methods, lambda m: all_metrics[m]["overall"]["detection"],
-                     col_width, label_width)
+    _print_detection(
+        methods, lambda m: all_metrics[m]["overall"]["detection"], col_width, label_width
+    )
 
     print()
     print_header(methods, col_width, label_width, "Timestamp accuracy")
@@ -595,13 +629,18 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
         methods,
         lambda m: all_metrics[m]["overall"]["timestamp_compared"],
         lambda m: all_metrics[m]["overall"]["timestamp_correct"],
-        "timestamp exact match", col_width, label_width)
+        "timestamp exact match",
+        col_width,
+        label_width,
+    )
 
     print()
     print_header(methods, col_width, label_width, "Timestamp error (ms)")
-    for err_key, err_label in [("start", "start error"),
-                                ("end", "end error"),
-                                ("exposure", "exposure error")]:
+    for err_key, err_label in [
+        ("start", "start error"),
+        ("end", "end error"),
+        ("exposure", "exposure error"),
+    ]:
         print(f"  {err_label.upper():>{label_width}}")
         for stat in ["mean", "std", "min", "median", "max"]:
             print(f"  {'  ' + stat:>{label_width}}", end="")
@@ -620,10 +659,7 @@ def print_timing(methods, timing, col_width, label_width=LABEL_WIDTH_DEFAULT):
     stat_keys = ["mean", "std", "min", "median", "max"]
 
     for subset_name in ["all", "positive", "negative"]:
-        any_data = any(
-            timing[m][subset_name].get("total", {}).get("n", 0) > 0
-            for m in methods
-        )
+        any_data = any(timing[m][subset_name].get("total", {}).get("n", 0) > 0 for m in methods)
         if not any_data:
             continue
 
@@ -632,7 +668,7 @@ def print_timing(methods, timing, col_width, label_width=LABEL_WIDTH_DEFAULT):
         print(f"{'=' * 100}")
         print_header(methods, col_width, label_width, STEP_ORDER[0])
 
-        for i, step in enumerate(STEP_ORDER + ["total"]):
+        for i, step in enumerate([*STEP_ORDER, "total"]):
             if i > 0:
                 print(f"  {step.upper():-^{label_width}}")
             for stat in stat_keys:
@@ -645,13 +681,22 @@ def print_timing(methods, timing, col_width, label_width=LABEL_WIDTH_DEFAULT):
 
 def main():
     parser = argparse.ArgumentParser(description="Evaluate benchmark results against ground truth")
-    parser.add_argument("paths", nargs="*", default=["output/benchmark"],
-                        help="Directory with benchmark .json files, or one or more .json filepaths "
-                             "(default: output/benchmark)")
-    parser.add_argument("-g", "--ground-truth", default="validation_data/ground_truth.json",
-                        help="Path to ground truth JSON (default: validation_data/ground_truth.json)")
-    parser.add_argument("-t", "--timing", action="store_true",
-                        help="Include per-step timing statistics")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["output/benchmark"],
+        help="Directory with benchmark .json files, or one or more .json filepaths "
+        "(default: output/benchmark)",
+    )
+    parser.add_argument(
+        "-g",
+        "--ground-truth",
+        default="validation_data/ground_truth.json",
+        help="Path to ground truth JSON (default: validation_data/ground_truth.json)",
+    )
+    parser.add_argument(
+        "-t", "--timing", action="store_true", help="Include per-step timing statistics"
+    )
     args = parser.parse_args()
 
     gt = load_ground_truth(args.ground_truth)
@@ -659,7 +704,7 @@ def main():
 
     benchmarks = load_benchmarks(args.paths)
     if not benchmarks:
-        print(f"No benchmark .json files found", file=sys.stderr)
+        print("No benchmark .json files found", file=sys.stderr)
         sys.exit(1)
 
     methods = list(benchmarks.keys())

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -13,6 +13,7 @@ visible flags, not from a global status field.
 import argparse
 import json
 import sys
+from collections import Counter
 from pathlib import Path
 
 import cv2
@@ -426,6 +427,8 @@ def compute_clock_metrics(benchmark, gt) -> dict[str, dict]:
     def described(reference, **fields):
         """Metrics for one video, always carrying what the reference itself says."""
         return {
+            # A reference cut from another video's annotations describes a retimed clip
+            "group": "retimed" if reference.get("source") else "measured",
             "timeline": reference.get("timeline", "measured"),
             "residual_threshold_ms": residual_threshold_ms(reference),
             **fields,
@@ -504,7 +507,7 @@ def compute_clock_metrics(benchmark, gt) -> dict[str, dict]:
             sync_error_first_ms=first,
             sync_error_last_ms=last,
             sync_error_max_ms=max(abs(first), abs(last)),
-            residual_vs_gt_ms=descriptive_stats(residuals),
+            residuals_ms=residuals,
             false_rejections=false_rejections,
             false_acceptances=false_acceptances,
             n_flagged=n_flagged,
@@ -515,6 +518,69 @@ def compute_clock_metrics(benchmark, gt) -> dict[str, dict]:
             n_dropped_frames=pred.get("n_dropped_frames"),
         )
     return metrics
+
+
+# ── Clock fit aggregation ────────────────────────────────────────────────────
+
+CLOCK_GROUPS = ("measured", "retimed")
+
+# Frame counters describe how much work a fit did, so a group reports their totals.
+CLOCK_COUNT_KEYS = (
+    "false_rejections",
+    "false_acceptances",
+    "n_flagged",
+    "n_considered_frames",
+    "n_rejected_frames",
+    "n_dropped_frames",
+)
+
+
+def _mean(values):
+    return float(np.mean(values))
+
+
+def aggregate_clock_metrics(per_video) -> dict[str, dict]:
+    """Summarize the per-video clock scores once per group of videos.
+
+    Per-video rows say little a reader can act on once there are more than a handful of
+    videos, and the two groups answer different questions: a measured timeline scores the
+    whole chain including the camera's own timestamps, a retimed one only the parts under
+    test. Videos are the samples for the fit errors, frames for the residuals.
+    """
+    groups: dict[str, list] = {}
+    for metrics in per_video.values():
+        groups.setdefault(metrics["group"], []).append(metrics)
+    return {group: _aggregate_group(videos) for group, videos in groups.items()}
+
+
+def _aggregate_group(videos):
+    """Video-level spreads, frame-level totals, and residuals pooled over every frame."""
+    scored = [v for v in videos if v.get("status") is None]
+    unscored = Counter(v["status"] for v in videos if v.get("status") is not None)
+
+    def over_videos(key, reduce, transform=lambda value: value):
+        values = [transform(v[key]) for v in scored if v.get(key) is not None]
+        return reduce(values) if values else None
+
+    aggregate = {
+        "n_videos": len(videos),
+        "n_scored": len(scored),
+        "unscored": "; ".join(f"{status} ({n})" for status, n in unscored.most_common()),
+        "residual_threshold_ms_max": over_videos("residual_threshold_ms", max),
+        "clock_rate_error_ppm_mean_abs": over_videos("clock_rate_error_ppm", _mean, abs),
+        "clock_rate_error_ppm_max_abs": over_videos("clock_rate_error_ppm", max, abs),
+        "clock_offset_error_ms_mean_abs": over_videos("clock_offset_error_ms", _mean, abs),
+        "clock_offset_error_ms_max_abs": over_videos("clock_offset_error_ms", max, abs),
+        "sync_error_mean_ms": over_videos("sync_error_max_ms", _mean),
+        "sync_error_max_ms": over_videos("sync_error_max_ms", max),
+        "rmse_after_mean": over_videos("rmse_after", _mean),
+        "rmse_after_max": over_videos("rmse_after", max),
+        "r2_after_min": over_videos("r2_after", min),
+        "residual_vs_gt_ms": descriptive_stats([r for v in scored for r in v["residuals_ms"]]),
+    }
+    for key in CLOCK_COUNT_KEYS:
+        aggregate[key] = over_videos(key, sum)
+    return aggregate
 
 
 # ── Timing statistics ────────────────────────────────────────────────────────
@@ -639,58 +705,67 @@ def _print_metric_rows(methods, rows, get_video, col_width, label_width=LABEL_WI
         print()
 
 
+CLOCK_GROUP_LABELS = {"measured": "measured videos", "retimed": "retimed videos"}
+
+CLOCK_AGGREGATE_ROWS = [
+    ("residual_threshold_ms_max", "reference tolerance, loosest [ms]", format_value),
+    ("clock_rate_error_ppm_mean_abs", "clock rate error, mean |err| [ppm]", format_value),
+    ("clock_rate_error_ppm_max_abs", "clock rate error, worst |err| [ppm]", format_value),
+    ("clock_offset_error_ms_mean_abs", "clock offset error, mean |err| [ms]", format_value),
+    ("clock_offset_error_ms_max_abs", "clock offset error, worst |err| [ms]", format_value),
+    ("sync_error_mean_ms", "sync error, mean over videos [ms]", format_value),
+    ("sync_error_max_ms", "sync error, worst over videos [ms]", format_value),
+    ("rmse_after_mean", "fit RMSE, mean over videos [ms]", format_value),
+    ("rmse_after_max", "fit RMSE, worst over videos [ms]", format_value),
+    ("r2_after_min", "fit R2, worst over videos", format_value),
+    ("false_rejections", "outliers rejected in error", format_value),
+    ("false_acceptances", "misdecodes kept as inliers", format_value),
+    ("n_flagged", "frames with both a fit and an annotation", format_value),
+    ("n_considered_frames", "frames in the fit", format_value),
+    ("n_rejected_frames", "frames rejected by the fit", format_value),
+    ("n_dropped_frames", "frames missing from the container", format_value),
+]
+
+
 def print_clock_report(methods, clock_metrics, col_width, label_width=LABEL_WIDTH_DEFAULT):
-    """Print the clock-fit section, one block per video with a reference clock."""
-    rel_paths = sorted({rel for m in methods for rel in clock_metrics[m]})
-    if not rel_paths:
+    """Print the clock-fit section, one aggregated block per group of videos."""
+    aggregates = {m: aggregate_clock_metrics(clock_metrics[m]) for m in methods}
+    groups = [g for g in CLOCK_GROUPS if any(g in aggregates[m] for m in methods)]
+    if not groups:
         return
 
     print(f"{'=' * 100}")
-    print("  CLOCK FIT (per video)")
+    print("  CLOCK FIT (aggregated over videos)")
     print(f"{'=' * 100}")
 
-    for rel_path in rel_paths:
+    for group in groups:
 
-        def get_video(m, rel_path=rel_path):
-            return clock_metrics[m].get(rel_path, {"status": "not in this run"})
+        def get_group(m, group=group):
+            return aggregates[m].get(group, {})
 
-        print_header(methods, col_width, label_width, rel_path)
+        print_header(methods, col_width, label_width, CLOCK_GROUP_LABELS[group])
 
-        for label, key, default in (("status", "status", "scored"), ("timeline", "timeline", "?")):
-            print(f"  {label:>{label_width}}", end="")
-            for m in methods:
-                text = get_video(m).get(key) or default
-                print(f"  {text[:col_width]:>{col_width}}", end="")
-            print()
+        print(f"  {'videos scored':>{label_width}}", end="")
+        for m in methods:
+            aggregate = get_group(m)
+            n_videos = aggregate.get("n_videos", 0)
+            text = f"{aggregate['n_scored']}/{n_videos}" if n_videos else "-"
+            print(f"  {text:>{col_width}}", end="")
+        print()
 
-        _print_metric_rows(
-            methods,
-            [
-                ("residual_threshold_ms", "reference tolerance [ms]", format_value),
-                ("clock_rate_error_ppm", "clock rate error [ppm]", format_value),
-                ("clock_offset_error_ms", "clock offset error [ms]", format_value),
-                ("sync_error_first_ms", "sync error, first frame [ms]", format_value),
-                ("sync_error_last_ms", "sync error, last frame [ms]", format_value),
-                ("sync_error_max_ms", "sync error, worst [ms]", format_value),
-                ("false_rejections", "outliers rejected in error", format_value),
-                ("false_acceptances", "misdecodes kept as inliers", format_value),
-                ("n_flagged", "frames with both a fit and an annotation", format_value),
-                ("rmse_after", "fit RMSE after rejection [ms]", format_value),
-                ("r2_after", "fit R2 after rejection", format_value),
-                ("n_considered_frames", "frames in the fit", format_value),
-                ("n_rejected_frames", "frames rejected by the fit", format_value),
-                ("n_dropped_frames", "frames missing from the container", format_value),
-            ],
-            get_video,
-            col_width,
-            label_width,
-        )
+        # Reasons are sentences, so they get their own line rather than a clipped column
+        for m in methods:
+            unscored = get_group(m).get("unscored")
+            if unscored:
+                print(f"  {'unscored':>{label_width}}  {m}: {unscored}")
+
+        _print_metric_rows(methods, CLOCK_AGGREGATE_ROWS, get_group, col_width, label_width)
 
         print()
-        print_header(methods, col_width, label_width, "Residual vs annotations (ms)")
+        print_header(methods, col_width, label_width, "Residual vs annotations (ms), pooled")
         _print_error_stats(
             methods,
-            lambda m, rel_path=rel_path: get_video(m, rel_path).get("residual_vs_gt_ms") or {},
+            lambda m: get_group(m).get("residual_vs_gt_ms") or {},
             col_width,
             label_width,
         )

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -25,7 +25,10 @@ from rocsync.benchmark.common import (
     descriptive_stats,
     parse_frame_key,
     reconstruct_timestamp,
+    residual_threshold_ms,
+    retimed_videos,
     ring_visible,
+    source_key,
 )
 from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO
 
@@ -77,6 +80,20 @@ def load_ground_truth(path):
     """Load ground truth JSON file."""
     with open(path) as f:
         return json.load(f)
+
+
+def resolve_retimed_keys(benchmark, retimed):
+    """Move a run's per-frame predictions onto the keys the annotations use.
+
+    A retimed clip carries no annotations of its own, so a prediction about its frame
+    j is a prediction about frame j + offset of the recording it was cut from. Doing
+    this once at load leaves every per-frame metric comparing keys as it always has.
+    The `videos` section needs no such move: both sides key it by the retimed clip.
+    """
+    if not retimed:
+        return benchmark
+    images = {source_key(key, retimed): value for key, value in benchmark["images"].items()}
+    return {**benchmark, "images": images}
 
 
 # ── Geometry helpers ─────────────────────────────────────────────────────────
@@ -405,19 +422,40 @@ def compute_clock_metrics(benchmark, gt) -> dict[str, dict]:
     predictions = benchmark.get("videos")
     if not references:
         return {}
+
+    def described(reference, **fields):
+        """Metrics for one video, always carrying what the reference itself says."""
+        return {
+            "timeline": reference.get("timeline", "measured"),
+            "residual_threshold_ms": residual_threshold_ms(reference),
+            **fields,
+        }
+
     if predictions is None:
-        return {rel_path: {"status": "no video timeline recorded"} for rel_path in references}
+        return {
+            rel_path: described(reference, status="no video timeline recorded")
+            for rel_path, reference in references.items()
+        }
+
+    # A recording whose retimed clip this run scored is not separately unscored
+    shadowed = {
+        reference["source"]
+        for path, reference in references.items()
+        if reference.get("source") and path in predictions
+    }
 
     gt_images = gt["images"]
     bm_images = benchmark["images"]
     metrics: dict[str, dict] = {}
     for rel_path, reference in references.items():
+        if rel_path in shadowed:
+            continue
         pred = predictions.get(rel_path)
         if pred is None:
-            metrics[rel_path] = {"status": "not in this run"}
+            metrics[rel_path] = described(reference, status="not in this run")
             continue
         if pred.get("error") is not None:
-            metrics[rel_path] = {"status": pred["error"]}
+            metrics[rel_path] = described(reference, status=pred["error"])
             continue
 
         ref = ReferenceClock.from_dict(reference)
@@ -433,9 +471,10 @@ def compute_clock_metrics(benchmark, gt) -> dict[str, dict]:
         # own outlier rejection agrees with them
         residuals = []
         false_rejections = false_acceptances = n_flagged = 0
+        annotated_path = reference.get("source", rel_path)  # retimed clips borrow theirs
         for key, annotation in gt_images.items():
             path, index = parse_frame_key(key)
-            if index is None or path != rel_path:
+            if index is None or path != annotated_path:
                 continue
             prediction = bm_images.get(key)
             if prediction is None:
@@ -457,23 +496,24 @@ def compute_clock_metrics(benchmark, gt) -> dict[str, dict]:
             elif not decoded_correctly and fit["inlier"]:
                 false_acceptances += 1
 
-        metrics[rel_path] = {
-            "status": None,
-            "clock_rate_error_ppm": (rate - ref.clock_rate) * 1e6,
-            "clock_offset_error_ms": offset - ref.clock_offset_ms,
-            "sync_error_first_ms": first,
-            "sync_error_last_ms": last,
-            "sync_error_max_ms": max(abs(first), abs(last)),
-            "residual_vs_gt_ms": descriptive_stats(residuals),
-            "false_rejections": false_rejections,
-            "false_acceptances": false_acceptances,
-            "n_flagged": n_flagged,
-            "rmse_after": pred.get("rmse_after"),
-            "r2_after": pred.get("r2_after"),
-            "n_considered_frames": pred.get("n_considered_frames"),
-            "n_rejected_frames": pred.get("n_rejected_frames"),
-            "n_dropped_frames": pred.get("n_dropped_frames"),
-        }
+        metrics[rel_path] = described(
+            reference,
+            status=None,
+            clock_rate_error_ppm=(rate - ref.clock_rate) * 1e6,
+            clock_offset_error_ms=offset - ref.clock_offset_ms,
+            sync_error_first_ms=first,
+            sync_error_last_ms=last,
+            sync_error_max_ms=max(abs(first), abs(last)),
+            residual_vs_gt_ms=descriptive_stats(residuals),
+            false_rejections=false_rejections,
+            false_acceptances=false_acceptances,
+            n_flagged=n_flagged,
+            rmse_after=pred.get("rmse_after"),
+            r2_after=pred.get("r2_after"),
+            n_considered_frames=pred.get("n_considered_frames"),
+            n_rejected_frames=pred.get("n_rejected_frames"),
+            n_dropped_frames=pred.get("n_dropped_frames"),
+        )
     return metrics
 
 
@@ -595,9 +635,7 @@ def _print_metric_rows(methods, rows, get_video, col_width, label_width=LABEL_WI
     for key, label, formatter in rows:
         print(f"  {label:>{label_width}}", end="")
         for m in methods:
-            video = get_video(m)
-            value = video.get(key) if video.get("status") is None else None
-            print(f"  {formatter(value, col_width)}", end="")
+            print(f"  {formatter(get_video(m).get(key), col_width)}", end="")
         print()
 
 
@@ -618,15 +656,17 @@ def print_clock_report(methods, clock_metrics, col_width, label_width=LABEL_WIDT
 
         print_header(methods, col_width, label_width, rel_path)
 
-        print(f"  {'status':>{label_width}}", end="")
-        for m in methods:
-            status = get_video(m).get("status") or "scored"
-            print(f"  {status[:col_width]:>{col_width}}", end="")
-        print()
+        for label, key, default in (("status", "status", "scored"), ("timeline", "timeline", "?")):
+            print(f"  {label:>{label_width}}", end="")
+            for m in methods:
+                text = get_video(m).get(key) or default
+                print(f"  {text[:col_width]:>{col_width}}", end="")
+            print()
 
         _print_metric_rows(
             methods,
             [
+                ("residual_threshold_ms", "reference tolerance [ms]", format_value),
                 ("clock_rate_error_ppm", "clock rate error [ppm]", format_value),
                 ("clock_offset_error_ms", "clock offset error [ms]", format_value),
                 ("sync_error_first_ms", "sync error, first frame [ms]", format_value),
@@ -874,6 +914,9 @@ def main():
     if not benchmarks:
         print("No benchmark .json files found", file=sys.stderr)
         sys.exit(1)
+
+    retimed = retimed_videos(gt)
+    benchmarks = {m: resolve_retimed_keys(bm, retimed) for m, bm in benchmarks.items()}
 
     methods = list(benchmarks.keys())
     col_width = max(14, max(len(m) for m in methods) + 2)

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -20,8 +20,10 @@ import numpy as np
 
 from rocsync.benchmark.common import (
     STEP_ORDER,
+    ReferenceClock,
     confusion_metrics,
     descriptive_stats,
+    parse_frame_key,
     reconstruct_timestamp,
     ring_visible,
 )
@@ -377,6 +379,92 @@ def compute_overall_metrics(benchmark_images, gt_images):
     }
 
 
+# ── Clock fit ────────────────────────────────────────────────────────────────
+
+
+def compute_clock_metrics(benchmark, gt) -> dict[str, dict]:
+    """Score each video's fitted clock against the reference frozen in the ground truth.
+
+    The reference is read, never re-fitted: deriving it here with the code under test
+    would let a change to that code move the ground truth along with the errors
+    measured against it.
+    """
+    references = gt.get("videos", {})
+    predictions = benchmark.get("videos")
+    if not references:
+        return {}
+    if predictions is None:
+        return {rel_path: {"status": "no video timeline recorded"} for rel_path in references}
+
+    gt_images = gt["images"]
+    bm_images = benchmark["images"]
+    metrics: dict[str, dict] = {}
+    for rel_path, reference in references.items():
+        pred = predictions.get(rel_path)
+        if pred is None:
+            metrics[rel_path] = {"status": "not in this run"}
+            continue
+        if pred.get("error") is not None:
+            metrics[rel_path] = {"status": pred["error"]}
+            continue
+
+        ref = ReferenceClock.from_dict(reference)
+        rate, offset = pred["clock_rate"], pred["clock_offset_ms"]
+
+        def predict(pts, rate=rate, offset=offset):
+            return rate * pts + offset
+
+        first = predict(ref.pts_min_ms) - float(ref.predict(ref.pts_min_ms))
+        last = predict(ref.pts_max_ms) - float(ref.predict(ref.pts_max_ms))
+
+        # Per-frame accuracy against the annotations themselves, and whether the fit's
+        # own outlier rejection agrees with them
+        residuals = []
+        false_rejections = false_acceptances = n_flagged = 0
+        for key, annotation in gt_images.items():
+            path, index = parse_frame_key(key)
+            if index is None or path != rel_path:
+                continue
+            prediction = bm_images.get(key)
+            if prediction is None:
+                continue
+
+            board = _board_for_gt(annotation)
+            gt_ts = reconstruct_timestamp(annotation, board) if board is not None else None
+            pts = prediction.get("pts_ms")
+            if gt_ts is not None and pts is not None:
+                residuals.append(predict(pts) - gt_ts[0])
+
+            fit = prediction.get("fit")
+            if fit is None or gt_ts is None:
+                continue
+            n_flagged += 1
+            decoded_correctly = reconstruct_timestamp(prediction, board) == gt_ts
+            if decoded_correctly and not fit["inlier"]:
+                false_rejections += 1
+            elif not decoded_correctly and fit["inlier"]:
+                false_acceptances += 1
+
+        metrics[rel_path] = {
+            "status": None,
+            "clock_rate_error_ppm": (rate - ref.clock_rate) * 1e6,
+            "clock_offset_error_ms": offset - ref.clock_offset_ms,
+            "sync_error_first_ms": first,
+            "sync_error_last_ms": last,
+            "sync_error_max_ms": max(abs(first), abs(last)),
+            "residual_vs_gt_ms": descriptive_stats(residuals),
+            "false_rejections": false_rejections,
+            "false_acceptances": false_acceptances,
+            "n_flagged": n_flagged,
+            "rmse_after": pred.get("rmse_after"),
+            "r2_after": pred.get("r2_after"),
+            "n_considered_frames": pred.get("n_considered_frames"),
+            "n_rejected_frames": pred.get("n_rejected_frames"),
+            "n_dropped_frames": pred.get("n_dropped_frames"),
+        }
+    return metrics
+
+
 # ── Timing statistics ────────────────────────────────────────────────────────
 
 
@@ -488,6 +576,73 @@ def _print_value_accuracy(
         text = f"{nc}/{n} ({nc / n:.0%})" if n > 0 else "-"
         print(f"  {text:>{col_width}}", end="")
     print()
+
+
+def _print_metric_rows(methods, rows, get_video, col_width, label_width=LABEL_WIDTH_DEFAULT):
+    """Print one row per (key, label, formatter), '-' where a column has no value."""
+    for key, label, formatter in rows:
+        print(f"  {label:>{label_width}}", end="")
+        for m in methods:
+            video = get_video(m)
+            value = video.get(key) if video.get("status") is None else None
+            print(f"  {formatter(value, col_width)}", end="")
+        print()
+
+
+def print_clock_report(methods, clock_metrics, col_width, label_width=LABEL_WIDTH_DEFAULT):
+    """Print the clock-fit section, one block per video with a reference clock."""
+    rel_paths = sorted({rel for m in methods for rel in clock_metrics[m]})
+    if not rel_paths:
+        return
+
+    print(f"{'=' * 100}")
+    print("  CLOCK FIT (per video)")
+    print(f"{'=' * 100}")
+
+    for rel_path in rel_paths:
+
+        def get_video(m, rel_path=rel_path):
+            return clock_metrics[m].get(rel_path, {"status": "not in this run"})
+
+        print_header(methods, col_width, label_width, rel_path)
+
+        print(f"  {'status':>{label_width}}", end="")
+        for m in methods:
+            status = get_video(m).get("status") or "scored"
+            print(f"  {status[:col_width]:>{col_width}}", end="")
+        print()
+
+        _print_metric_rows(
+            methods,
+            [
+                ("clock_rate_error_ppm", "clock rate error [ppm]", format_value),
+                ("clock_offset_error_ms", "clock offset error [ms]", format_value),
+                ("sync_error_first_ms", "sync error, first frame [ms]", format_value),
+                ("sync_error_last_ms", "sync error, last frame [ms]", format_value),
+                ("sync_error_max_ms", "sync error, worst [ms]", format_value),
+                ("false_rejections", "outliers rejected in error", format_value),
+                ("false_acceptances", "misdecodes kept as inliers", format_value),
+                ("n_flagged", "frames with both a fit and an annotation", format_value),
+                ("rmse_after", "fit RMSE after rejection [ms]", format_value),
+                ("r2_after", "fit R2 after rejection", format_value),
+                ("n_considered_frames", "frames in the fit", format_value),
+                ("n_rejected_frames", "frames rejected by the fit", format_value),
+                ("n_dropped_frames", "frames missing from the container", format_value),
+            ],
+            get_video,
+            col_width,
+            label_width,
+        )
+
+        print()
+        print_header(methods, col_width, label_width, "Residual vs annotations (ms)")
+        _print_error_stats(
+            methods,
+            lambda m, rel_path=rel_path: get_video(m, rel_path).get("residual_vs_gt_ms") or {},
+            col_width,
+            label_width,
+        )
+        print()
 
 
 def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAULT):
@@ -733,6 +888,9 @@ def main():
         }
 
     print_report(methods, all_metrics, col_width)
+
+    clock_metrics = {m: compute_clock_metrics(benchmarks[m], gt) for m in methods}
+    print_clock_report(methods, clock_metrics, col_width)
 
     if args.timing:
         timing = {}

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -1,0 +1,696 @@
+#!/usr/bin/env python3
+"""Compare benchmark results against ground truth annotations.
+
+Loads validation result JSON files and compares them against
+validation_data/ground_truth.json. Accepts either a directory (loads all .json
+files in it) or one or more explicit .json filepaths. Prints detection metrics
+(TPR, FPR, F1), result accuracy, and per-step timing statistics.
+
+Positive/negative annotation is determined per-step from the ground truth
+visible flags, not from a global status field.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO
+from rocsync.camera import CameraType
+from rocsync.benchmark.common import (
+    STEP_ORDER,
+    confusion_metrics,
+    descriptive_stats,
+    reconstruct_timestamp,
+    ring_visible,
+)
+
+CORNER_IMAGE_SPACE_THRESHOLD_PX = 3
+# A corner counts as found when it lands within one LED sampling disc of where it belongs.
+CORNER_BOARD_SPACE_THRESHOLD_PX = BOARD_V1.rectify().led_sample_radius
+LABEL_WIDTH_DEFAULT = 40
+
+
+# Map pipeline steps to ground truth visibility checks.
+# Each returns True if the ground truth considers that step's output "positive".
+STEP_GT_POSITIVE = {
+    "aruco":   lambda gt: gt.get("aruco", {}).get("visible", False),
+    "corners": lambda gt: any(c.get("visible", False) for c in gt.get("corners", [])),
+    "counter": lambda gt: gt.get("counter", {}).get("visible", False),
+    "ring":    ring_visible,
+    # Overall: a timestamp is extractable when both counter and ring are visible
+    "overall": lambda gt: (gt.get("counter", {}).get("visible", False)
+                           and ring_visible(gt)),
+}
+
+# Map pipeline steps to prediction visibility checks.
+STEP_PRED_POSITIVE = {
+    "aruco":   lambda p: p.get("aruco", {}).get("visible", False),
+    "corners": lambda p: any(c.get("visible", False) for c in p.get("corners", [])),
+    "counter": lambda p: p.get("counter", {}).get("visible", False),
+    "ring":    ring_visible,
+    "overall": lambda p: p.get("success", False),
+}
+
+
+def load_benchmarks(paths):
+    """Load benchmark JSON files, keyed by stem name.
+
+    If *paths* is a single directory, loads all .json files from it.
+    Otherwise, each element is treated as a filepath to a .json file.
+    """
+    benchmarks = {}
+    if len(paths) == 1 and Path(paths[0]).is_dir():
+        files = sorted(Path(paths[0]).glob("*.json"))
+    else:
+        files = [Path(p) for p in paths]
+    for path in files:
+        with open(path) as f:
+            benchmarks[path.stem] = json.load(f)
+    return benchmarks
+
+
+def load_ground_truth(path):
+    """Load ground truth JSON file."""
+    with open(path) as f:
+        return json.load(f)
+
+
+# ── Geometry helpers ─────────────────────────────────────────────────────────
+
+def _board_for_gt(gt):
+    """Rectified board for a ground truth entry's ArUco marker ID.
+
+    Rectified, because every comparison below is in board pixel space.
+    """
+    aruco_id = gt.get("aruco", {}).get("id")
+    if aruco_id is not None and aruco_id in PROFILES_BY_ARUCO:
+        return PROFILES_BY_ARUCO[aruco_id].rectify()
+    return None
+
+
+def _gt_aruco_corners(gt):
+    """Derive ground-truth ArUco corners in original image space.
+
+    Inverse-transforms the known board-space ArUco corner coordinates through
+    the ground-truth homography.  Returns a (4, 2) array or None.
+    """
+    H = gt.get("homography")
+    if H is None or not gt.get("aruco", {}).get("visible", False):
+        return None
+    board = _board_for_gt(gt)
+    if board is None:
+        return None
+    inv_H = np.linalg.inv(np.array(H, dtype=np.float64))
+    pts = np.array([board.aruco_corners_coords], dtype=np.float64)
+    return cv2.perspectiveTransform(pts, inv_H).reshape(4, 2)
+
+
+def _gt_corner_positions(gt):
+    """Derive ground-truth corner LED positions in original image space.
+
+    Inverse-transforms the known board-space corner LED coordinates through
+    the ground-truth homography.  Returns list of [x, y] or None.
+    """
+    H = gt.get("homography")
+    if H is None:
+        return None
+    board = _board_for_gt(gt)
+    if board is None:
+        return None
+    inv_H = np.linalg.inv(np.array(H, dtype=np.float64))
+    pts = np.array([board.always_on_leds[CameraType.RGB]], dtype=np.float64)
+    return cv2.perspectiveTransform(pts, inv_H).reshape(-1, 2).tolist()
+
+
+def _pred_corner_positions_image(pred, gt):
+    """Transform predicted corner positions from board space to image space.
+
+    The pipeline detects corners in the rough-rectified (board-space) image,
+    so positions need to be inverse-transformed through the GT homography to
+    get image-space coordinates for comparison with GT image-space positions.
+
+    Returns a list of 4 image-space [x, y] positions (or None per corner).
+    """
+    H = gt.get("homography")
+    if H is None:
+        return [None] * 4
+    inv_H = np.linalg.inv(np.array(H, dtype=np.float64))
+    result = []
+    for c in pred.get("corners", []):
+        if c.get("visible") and c.get("position") is not None:
+            pt = np.array([[c["position"]]], dtype=np.float64)
+            img_pt = cv2.perspectiveTransform(pt, inv_H).reshape(2)
+            result.append(img_pt.tolist())
+        else:
+            result.append(None)
+    return result
+
+
+# ── Per-step metric computation ──────────────────────────────────────────────
+
+def compute_step_detection(benchmark_images, gt_images, step):
+    """Compute TP/FP/FN/TN and derived rates for a single step.
+
+    Corner detection uses per-corner matching with a position error threshold
+    of CORNER_MAX_ERROR_PX in image coordinates.
+    """
+    gt_pos_fn = STEP_GT_POSITIVE[step]
+    pred_pos_fn = STEP_PRED_POSITIVE[step]
+    tp = fp = fn = tn = 0
+
+    for img_key, gt in gt_images.items():
+        pred = benchmark_images.get(img_key)
+        if pred is None:
+            continue
+
+        if step == "corners":
+            gt_corners = gt.get("corners", [])
+            pred_corners = pred.get("corners", [])
+            gt_positions = _gt_corner_positions(gt)
+
+            gt_any_visible = any(c.get("visible", False) for c in gt_corners)
+            pred_any_visible = any(c.get("visible", False) for c in pred_corners)
+            any_tp = False
+
+            if gt_positions is not None:
+                pred_img = _pred_corner_positions_image(pred, gt)
+                for i in range(min(len(gt_corners), len(pred_corners), 4)):
+                    gt_vis = gt_corners[i].get("visible", False)
+                    pred_vis = pred_corners[i].get("visible", False)
+
+                    if gt_vis and pred_vis and pred_img[i] is not None:
+                        err = np.linalg.norm(
+                            np.array(pred_img[i]) - np.array(gt_positions[i]))
+                        if err <= CORNER_IMAGE_SPACE_THRESHOLD_PX:
+                            any_tp = True
+
+            if gt_any_visible and any_tp:
+                tp += 1
+            elif not gt_any_visible and pred_any_visible:
+                fp += 1
+            elif gt_any_visible and not any_tp:
+                fn += 1
+            else:
+                tn += 1
+        else:
+            gt_positive = gt_pos_fn(gt)
+            pred_positive = pred_pos_fn(pred)
+
+            if gt_positive and pred_positive:
+                tp += 1
+            elif not gt_positive and pred_positive:
+                fp += 1
+            elif gt_positive and not pred_positive:
+                fn += 1
+            else:
+                tn += 1
+
+    return confusion_metrics(tp, fp, fn, tn)
+
+
+def compute_aruco_metrics(benchmark_images, gt_images):
+    """Compute ArUco-specific metrics: detection + corner pixel error."""
+    detection = compute_step_detection(benchmark_images, gt_images, "aruco")
+
+    mean_errors = []
+    for img_key, gt in gt_images.items():
+        pred = benchmark_images.get(img_key)
+        if pred is None:
+            continue
+        if not gt.get("aruco", {}).get("visible", False):
+            continue
+        if not pred.get("aruco", {}).get("visible", False):
+            continue
+
+        gt_corners = _gt_aruco_corners(gt)
+        pred_corners = pred.get("aruco", {}).get("corners")
+        if gt_corners is None or pred_corners is None:
+            continue
+
+        pred_corners = np.array(pred_corners, dtype=np.float64).reshape(4, 2)
+        dists = np.linalg.norm(pred_corners - gt_corners, axis=1)
+        mean_errors.append(float(np.mean(dists)))
+
+    return {
+        "detection": detection,
+        "corner_error_px": descriptive_stats(mean_errors),
+    }
+
+
+def compute_corner_metrics(benchmark_images, gt_images):
+    """Compute corner LED metrics: image-space and board-space detection + errors."""
+    detection_image = compute_step_detection(benchmark_images, gt_images, "corners")
+
+    # Per-corner board-space detection and pixel errors in both spaces
+    tp_board = fp_board = fn_board = tn_board = 0
+    errors_image = []
+    errors_board = []
+
+    for img_key, gt in gt_images.items():
+        pred = benchmark_images.get(img_key)
+        if pred is None:
+            continue
+
+        board = _board_for_gt(gt)
+        gt_corners = gt.get("corners", [])
+        pred_corners = pred.get("corners", [])
+        gt_positions = _gt_corner_positions(gt)
+        pred_img = _pred_corner_positions_image(pred, gt)
+        n_corners = min(len(gt_corners), len(pred_corners))
+
+        for i in range(n_corners):
+            gt_vis = gt_corners[i].get("visible", False)
+            pred_vis = pred_corners[i].get("visible", False)
+            pred_pos = pred_corners[i].get("position") if pred_vis else None
+
+            # Image-space pixel error (on TPs where both are visible with positions)
+            if gt_vis and pred_vis and pred_img[i] is not None and gt_positions is not None:
+                err_img = np.linalg.norm(
+                    np.array(pred_img[i]) - np.array(gt_positions[i]))
+                errors_image.append(float(err_img))
+
+            # Board-space detection + pixel error
+            # Predicted positions are already in board space (from rough rectification)
+            if gt_vis and pred_vis and pred_pos is not None and board is not None:
+                err_board = np.linalg.norm(
+                    np.array(pred_pos) - np.array(board.always_on_leds[CameraType.RGB][i]))
+                errors_board.append(float(err_board))
+                if err_board <= CORNER_BOARD_SPACE_THRESHOLD_PX:
+                    tp_board += 1
+                else:
+                    fn_board += 1
+            elif gt_vis:
+                fn_board += 1
+            elif pred_vis:
+                fp_board += 1
+            else:
+                tn_board += 1
+
+    return {
+        "detection_image": detection_image,
+        "detection_board": confusion_metrics(tp_board, fp_board, fn_board, tn_board),
+        "error_image_px": descriptive_stats(errors_image),
+        "error_board_px": descriptive_stats(errors_board),
+    }
+
+
+def compute_counter_metrics(benchmark_images, gt_images):
+    """Compute counter detection + value accuracy."""
+    detection = compute_step_detection(benchmark_images, gt_images, "counter")
+
+    n_compared = 0
+    n_correct = 0
+    for img_key, gt in gt_images.items():
+        pred = benchmark_images.get(img_key)
+        if pred is None:
+            continue
+        if not gt.get("counter", {}).get("visible", False):
+            continue
+        if not pred.get("counter", {}).get("visible", False):
+            continue
+        n_compared += 1
+        if pred.get("counter", {}).get("value") == gt.get("counter", {}).get("value"):
+            n_correct += 1
+
+    return {
+        "detection": detection,
+        "value_correct": n_correct,
+        "value_compared": n_compared,
+    }
+
+
+def compute_ring_metrics(benchmark_images, gt_images):
+    """Compute ring detection + start/end value accuracy."""
+    detection = compute_step_detection(benchmark_images, gt_images, "ring")
+
+    n_compared = 0
+    start_correct = 0
+    end_correct = 0
+    for img_key, gt in gt_images.items():
+        pred = benchmark_images.get(img_key)
+        if pred is None:
+            continue
+        if not ring_visible(gt) or not ring_visible(pred):
+            continue
+        n_compared += 1
+        if pred.get("ring", {}).get("start") == gt.get("ring", {}).get("start"):
+            start_correct += 1
+        if pred.get("ring", {}).get("end") == gt.get("ring", {}).get("end"):
+            end_correct += 1
+
+    return {
+        "detection": detection,
+        "start_correct": start_correct,
+        "end_correct": end_correct,
+        "value_compared": n_compared,
+    }
+
+
+def compute_overall_metrics(benchmark_images, gt_images):
+    """Compute overall detection + timestamp accuracy + error stats."""
+    detection = compute_step_detection(benchmark_images, gt_images, "overall")
+
+    n_compared = 0
+    n_correct = 0
+    start_errors = []
+    end_errors = []
+    exposure_errors = []
+
+    for img_key, gt in gt_images.items():
+        pred = benchmark_images.get(img_key)
+        if pred is None:
+            continue
+        if not STEP_GT_POSITIVE["overall"](gt) or not STEP_PRED_POSITIVE["overall"](pred):
+            continue
+
+        board = _board_for_gt(gt)
+        if board is None:
+            continue
+
+        n_compared += 1
+        gt_ts = reconstruct_timestamp(gt, board)
+        pred_ts = reconstruct_timestamp(pred, board)
+        if pred_ts == gt_ts:
+            n_correct += 1
+        if pred_ts is not None and gt_ts is not None:
+            start_errors.append(abs(pred_ts[0] - gt_ts[0]))
+            end_errors.append(abs(pred_ts[1] - gt_ts[1]))
+            pred_exposure = pred_ts[1] - pred_ts[0]
+            gt_exposure = gt_ts[1] - gt_ts[0]
+            exposure_errors.append(abs(pred_exposure - gt_exposure))
+
+    return {
+        "detection": detection,
+        "timestamp_correct": n_correct,
+        "timestamp_compared": n_compared,
+        "timestamp_error": {
+            "start": descriptive_stats(start_errors),
+            "end": descriptive_stats(end_errors),
+            "exposure": descriptive_stats(exposure_errors),
+        },
+    }
+
+
+# ── Timing statistics ────────────────────────────────────────────────────────
+
+def compute_timing(benchmark_images, gt_images):
+    """Compute per-step timing statistics for all / positive / negative subsets."""
+    step_to_gt_key = {
+        "aruco_detection":   "aruco",
+        "corner_detection":  "corners",
+        "fine_rectification": "corners",
+        "counter_reading":   "counter",
+        "ring_reading":      "ring",
+    }
+
+    def collect_values(timing_key, gt_positive_fn, subset):
+        """Collect timing values filtered by ground-truth subset."""
+        values = []
+        for img_key, pred in benchmark_images.items():
+            value = pred.get("timing", {}).get(timing_key)
+            if value is None:
+                continue
+            gt = gt_images.get(img_key)
+            if gt is None:
+                continue
+            gt_positive = gt_positive_fn(gt)
+            if subset == "all" or (subset == "positive") == gt_positive:
+                values.append(value)
+        return values
+
+    result = {}
+    for subset in ["all", "positive", "negative"]:
+        step_stats = {}
+        for step in STEP_ORDER:
+            gt_key = step_to_gt_key[step]
+            step_stats[step] = descriptive_stats(
+                collect_values(f"{step}_ms", STEP_GT_POSITIVE[gt_key], subset))
+        step_stats["total"] = descriptive_stats(
+            collect_values("total_ms", STEP_GT_POSITIVE["overall"], subset))
+        result[subset] = step_stats
+
+    return result
+
+
+# ── Printing ─────────────────────────────────────────────────────────────────
+
+def format_value(val, width=10):
+    if val is None:
+        return "-".rjust(width)
+    if isinstance(val, float):
+        return f"{val:.2f}".rjust(width)
+    return str(val).rjust(width)
+
+
+def format_percent(val, width=10):
+    if val is None:
+        return "-".rjust(width)
+    return f"{val:.1%}".rjust(width)
+
+
+def print_header(methods, col_width, label_width=LABEL_WIDTH_DEFAULT, label=""):
+    print(f"  {'':>{label_width}}", end="")
+    for m in methods:
+        print(f"  {m:>{col_width}}", end="")
+    print()
+    print(f"    {label.upper():-^{label_width - 2}}", end="")
+    for _ in methods:
+        print(f"  {'-' * col_width}", end="")
+    print()
+
+
+def _print_detection(methods, get_det, col_width, label_width=LABEL_WIDTH_DEFAULT):
+    """Print TP/FP/FN/TN and derived rates from a detection dict."""
+    for key, label in [("tp", "TP"), ("fp", "FP"), ("fn", "FN"), ("tn", "TN")]:
+        print(f"  {label:>{label_width}}", end="")
+        for m in methods:
+            print(f"  {format_value(get_det(m)[key], col_width)}", end="")
+        print()
+    for key, label, formatter in [("recall", "TPR (Recall)", format_percent),
+                                   ("fpr", "FPR", format_percent),
+                                   ("precision", "Precision", format_percent),
+                                   ("f1", "F1 Score", format_percent)]:
+        print(f"  {label:>{label_width}}", end="")
+        for m in methods:
+            print(f"  {formatter(get_det(m)[key], col_width)}", end="")
+        print()
+
+
+def _print_error_stats(methods, get_stats, col_width, label_width=LABEL_WIDTH_DEFAULT):
+    """Print descriptive statistics (mean/median/std/min/max/n)."""
+    for stat in ["mean", "std", "min", "median", "max", "n"]:
+        print(f"  {stat:>{label_width}}", end="")
+        for m in methods:
+            print(f"  {format_value(get_stats(m).get(stat), col_width)}", end="")
+        print()
+
+
+def _print_value_accuracy(methods, get_n, get_correct, label, col_width, label_width=LABEL_WIDTH_DEFAULT):
+    """Print a single value accuracy row (e.g. '5/7 (71%)')."""
+    print(f"  {label:>{label_width}}", end="")
+    for m in methods:
+        n = get_n(m)
+        nc = get_correct(m)
+        text = f"{nc}/{n} ({nc/n:.0%})" if n > 0 else "-"
+        print(f"  {text:>{col_width}}", end="")
+    print()
+
+
+def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAULT):
+    """Print the full evaluation report, grouped by pipeline step."""
+
+    # ── ArUco detection ──────────────────────────────────────────────────
+    print(f"{'=' * 100}")
+    print(f"  ARUCO DETECTION")
+    print(f"{'=' * 100}")
+
+    print_header(methods, col_width, label_width, "Detection")
+    _print_detection(methods, lambda m: all_metrics[m]["aruco"]["detection"],
+                     col_width, label_width)
+
+    print()
+    print_header(methods, col_width, label_width, "Corner error (px, image space)")
+    _print_error_stats(methods, lambda m: all_metrics[m]["aruco"]["corner_error_px"],
+                       col_width, label_width)
+
+    # ── Corner LED detection ─────────────────────────────────────────────
+    print(f"{'=' * 100}")
+    print(f"  CORNER LED DETECTION")
+    print(f"{'=' * 100}")
+
+    print_header(methods, col_width, label_width, f"Detection (thres: {CORNER_IMAGE_SPACE_THRESHOLD_PX}px in image space)")
+    _print_detection(methods, lambda m: all_metrics[m]["corners"]["detection_image"],
+                     col_width, label_width)
+
+    print()
+    print_header(methods, col_width, label_width, f"Detection (thres: {CORNER_BOARD_SPACE_THRESHOLD_PX}px in board space)")
+    _print_detection(methods, lambda m: all_metrics[m]["corners"]["detection_board"],
+                     col_width, label_width)
+
+    print()
+    print_header(methods, col_width, label_width, "Pixel error — image space")
+    _print_error_stats(methods, lambda m: all_metrics[m]["corners"]["error_image_px"],
+                       col_width, label_width)
+
+    print()
+    print_header(methods, col_width, label_width, "Pixel error — board space")
+    _print_error_stats(methods, lambda m: all_metrics[m]["corners"]["error_board_px"],
+                       col_width, label_width)
+
+    # ── Counter reading ──────────────────────────────────────────────────
+    print(f"{'=' * 100}")
+    print(f"  COUNTER READING")
+    print(f"{'=' * 100}")
+
+    print_header(methods, col_width, label_width, "Detection")
+    _print_detection(methods, lambda m: all_metrics[m]["counter"]["detection"],
+                     col_width, label_width)
+
+    print()
+    print_header(methods, col_width, label_width, "Value accuracy")
+    _print_value_accuracy(
+        methods,
+        lambda m: all_metrics[m]["counter"]["value_compared"],
+        lambda m: all_metrics[m]["counter"]["value_correct"],
+        "counter.value correct", col_width, label_width)
+
+    # ── Ring reading ─────────────────────────────────────────────────────
+    print(f"{'=' * 100}")
+    print(f"  RING READING")
+    print(f"{'=' * 100}")
+
+    print_header(methods, col_width, label_width, "Detection")
+    _print_detection(methods, lambda m: all_metrics[m]["ring"]["detection"],
+                     col_width, label_width)
+
+    print()
+    print_header(methods, col_width, label_width, "Value accuracy")
+    _print_value_accuracy(
+        methods,
+        lambda m: all_metrics[m]["ring"]["value_compared"],
+        lambda m: all_metrics[m]["ring"]["start_correct"],
+        "ring.start correct", col_width, label_width)
+    _print_value_accuracy(
+        methods,
+        lambda m: all_metrics[m]["ring"]["value_compared"],
+        lambda m: all_metrics[m]["ring"]["end_correct"],
+        "ring.end correct", col_width, label_width)
+
+    # ── Overall ──────────────────────────────────────────────────────────
+    print(f"{'=' * 100}")
+    print(f"  OVERALL (timestamp)")
+    print(f"{'=' * 100}")
+
+    print_header(methods, col_width, label_width, "Detection")
+    _print_detection(methods, lambda m: all_metrics[m]["overall"]["detection"],
+                     col_width, label_width)
+
+    print()
+    print_header(methods, col_width, label_width, "Timestamp accuracy")
+    _print_value_accuracy(
+        methods,
+        lambda m: all_metrics[m]["overall"]["timestamp_compared"],
+        lambda m: all_metrics[m]["overall"]["timestamp_correct"],
+        "timestamp exact match", col_width, label_width)
+
+    print()
+    print_header(methods, col_width, label_width, "Timestamp error (ms)")
+    for err_key, err_label in [("start", "start error"),
+                                ("end", "end error"),
+                                ("exposure", "exposure error")]:
+        print(f"  {err_label.upper():>{label_width}}")
+        for stat in ["mean", "std", "min", "median", "max"]:
+            print(f"  {'  ' + stat:>{label_width}}", end="")
+            for m in methods:
+                val = all_metrics[m]["overall"]["timestamp_error"].get(err_key, {}).get(stat)
+                print(f"  {format_value(val, col_width)}", end="")
+            print()
+
+
+def print_timing(methods, timing, col_width, label_width=LABEL_WIDTH_DEFAULT):
+    subset_labels = {
+        "all": "ALL IMAGES",
+        "positive": "POSITIVE ANNOTATIONS (per-step)",
+        "negative": "NEGATIVE ANNOTATIONS (per-step)",
+    }
+    stat_keys = ["mean", "std", "min", "median", "max"]
+
+    for subset_name in ["all", "positive", "negative"]:
+        any_data = any(
+            timing[m][subset_name].get("total", {}).get("n", 0) > 0
+            for m in methods
+        )
+        if not any_data:
+            continue
+
+        print(f"{'=' * 100}")
+        print(f"  TIMING — {subset_labels[subset_name]} (ms)")
+        print(f"{'=' * 100}")
+        print_header(methods, col_width, label_width, STEP_ORDER[0])
+
+        for i, step in enumerate(STEP_ORDER + ["total"]):
+            if i > 0:
+                print(f"  {step.upper():-^{label_width}}")
+            for stat in stat_keys:
+                print(f"  {'  ' + stat:>{label_width}}", end="")
+                for m in methods:
+                    val = timing[m][subset_name].get(step, {}).get(stat)
+                    print(f"  {format_value(val, col_width)}", end="")
+                print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate benchmark results against ground truth")
+    parser.add_argument("paths", nargs="*", default=["output/benchmark"],
+                        help="Directory with benchmark .json files, or one or more .json filepaths "
+                             "(default: output/benchmark)")
+    parser.add_argument("-g", "--ground-truth", default="validation_data/ground_truth.json",
+                        help="Path to ground truth JSON (default: validation_data/ground_truth.json)")
+    parser.add_argument("-t", "--timing", action="store_true",
+                        help="Include per-step timing statistics")
+    args = parser.parse_args()
+
+    gt = load_ground_truth(args.ground_truth)
+    gt_images = gt["images"]
+
+    benchmarks = load_benchmarks(args.paths)
+    if not benchmarks:
+        print(f"No benchmark .json files found", file=sys.stderr)
+        sys.exit(1)
+
+    methods = list(benchmarks.keys())
+    col_width = max(14, max(len(m) for m in methods) + 2)
+
+    n_images = len(gt_images)
+    print(f"Ground truth: {args.ground_truth} ({n_images} images)")
+    print(f"Methods: {', '.join(methods)}")
+
+    # Compute all metrics per method
+    all_metrics = {}
+    for m in methods:
+        bm = benchmarks[m]["images"]
+        all_metrics[m] = {
+            "aruco": compute_aruco_metrics(bm, gt_images),
+            "corners": compute_corner_metrics(bm, gt_images),
+            "counter": compute_counter_metrics(bm, gt_images),
+            "ring": compute_ring_metrics(bm, gt_images),
+            "overall": compute_overall_metrics(bm, gt_images),
+        }
+
+    print_report(methods, all_metrics, col_width)
+
+    if args.timing:
+        timing = {}
+        for m in methods:
+            timing[m] = compute_timing(benchmarks[m]["images"], gt_images)
+        print_timing(methods, timing, col_width)
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -84,6 +84,26 @@ def load_ground_truth(path):
         return json.load(f)
 
 
+def coverage_report(gt_images, benchmarks):
+    """Which ground truth frames each column scores, and where the columns disagree.
+
+    Returns `(scored, uncovered, missing)`: the key set per column, the ground truth
+    frames no column scores at all, and per column the frames another column scores and
+    it does not. A prediction a run never made is skipped by every metric below, so a
+    column with a different key set answers a different question than its neighbours.
+    """
+    scored = {method: set(gt_images) & set(bm["images"]) for method, bm in benchmarks.items()}
+    covered = set().union(*scored.values()) if scored else set()
+    missing = {method: covered - keys for method, keys in scored.items() if covered - keys}
+    return scored, set(gt_images) - covered, missing
+
+
+def describe_keys(keys, indent="    "):
+    """One line per input file behind a set of frame keys, with how many it contributes."""
+    counts = Counter(parse_frame_key(key)[0] for key in keys)
+    return "\n".join(f"{indent}{path}: {n} frame(s)" for path, n in sorted(counts.items()))
+
+
 def resolve_retimed_keys(benchmark, retimed):
     """Move a run's per-frame predictions onto the keys the annotations use.
 
@@ -1080,6 +1100,12 @@ def main():
         "-t", "--timing", action="store_true", help="Include per-step timing statistics"
     )
     parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Report instead of refusing when columns cover different frames, scoring "
+        "each over its own coverage",
+    )
+    parser.add_argument(
         "--color",
         choices=["auto", "always", "never"],
         default="auto",
@@ -1105,13 +1131,39 @@ def main():
     col_width = max(14, max(len(m) for m in methods) + 2)
 
     n_images = len(gt_images)
+    scored, uncovered, missing = coverage_report(gt_images, benchmarks)
     print(f"Ground truth: {args.ground_truth} ({n_images} frames)")
     print(f"Methods: {', '.join(methods)}")
     for m in methods:
         # A prediction the run never made is skipped silently, so say how many it covers
-        n_scored = len(set(gt_images) & set(benchmarks[m]["images"]))
-        scope = f"scores {n_scored}/{n_images}"
+        scope = f"scores {len(scored[m])}/{n_images}"
         print(f"  {m}: {_describe_run(benchmarks[m].get('config', {}))}, {scope}")
+
+    if uncovered:
+        print(
+            f"\nWARNING: {len(uncovered)} ground truth frame(s) no column scores. If those "
+            f"inputs are gone, prune them:\n"
+            f"  rocsync-annotate <data_dir> --prune\n"
+            f"{describe_keys(uncovered)}",
+            file=sys.stderr,
+        )
+
+    if missing:
+        detail = "\n".join(
+            f"  {m} does not score {len(keys)} frame(s) another column does:\n{describe_keys(keys)}"
+            for m, keys in sorted(missing.items())
+        )
+        # Every metric skips a frame a run has no prediction for, so columns over
+        # different frame sets are different populations, counts and winner alike
+        print(f"\nColumns cover different frames:\n{detail}", file=sys.stderr)
+        if not args.allow_partial:
+            print(
+                "\nRe-run rocsync-validate for the columns above, or pass --allow-partial "
+                "to score each column over its own coverage.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print("--allow-partial: each column is scored over its own frames.", file=sys.stderr)
 
     # Compute all metrics per method
     all_metrics = {}

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -712,10 +712,13 @@ def main():
     col_width = max(14, max(len(m) for m in methods) + 2)
 
     n_images = len(gt_images)
-    print(f"Ground truth: {args.ground_truth} ({n_images} images)")
+    print(f"Ground truth: {args.ground_truth} ({n_images} frames)")
     print(f"Methods: {', '.join(methods)}")
     for m in methods:
-        print(f"  {m}: {_describe_run(benchmarks[m].get('config', {}))}")
+        # A prediction the run never made is skipped silently, so say how many it covers
+        n_scored = len(set(gt_images) & set(benchmarks[m]["images"]))
+        scope = f"scores {n_scored}/{n_images}"
+        print(f"  {m}: {_describe_run(benchmarks[m].get('config', {}))}, {scope}")
 
     # Compute all metrics per method
     all_metrics = {}

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -12,6 +12,7 @@ visible flags, not from a global status field.
 
 import argparse
 import json
+import os
 import sys
 from collections import Counter
 from pathlib import Path
@@ -629,6 +630,45 @@ def compute_timing(benchmark_images, gt_images):
 
 # ── Printing ─────────────────────────────────────────────────────────────────
 
+GREEN = "\033[32m"
+RESET = "\033[0m"
+
+# Which direction wins a row. LOWER ranks by magnitude, so a signed error is judged by
+# how far from zero it sits rather than by its sign.
+LOWER, HIGHER = "lower", "higher"
+
+_use_color = False
+
+
+def set_color(mode, stream=None):
+    """Turn ANSI coloring on, off, or on only when a terminal is reading."""
+    global _use_color
+    stream = stream or sys.stdout
+    if mode == "always":
+        _use_color = True
+    elif mode == "never":
+        _use_color = False
+    else:
+        _use_color = stream.isatty() and not os.environ.get("NO_COLOR")
+
+
+def highlight(text):
+    return f"{GREEN}{text}{RESET}" if _use_color else text
+
+
+def _best_index(values, better):
+    """The one method that beats every other on this row, or None if none stands alone.
+
+    A tie leaves the row unmarked rather than painting every column: the mark says
+    "pick this one", which a tie cannot. So does a row where only one method has a
+    value — there is nothing it won against.
+    """
+    rank = abs if better == LOWER else (lambda v: -v)
+    candidates = sorted((rank(v), i) for i, v in enumerate(values) if v is not None)
+    if better is None or len(candidates) < 2 or candidates[0][0] == candidates[1][0]:
+        return None
+    return candidates[0][1]
+
 
 def format_value(val, width=10):
     if val is None:
@@ -644,6 +684,24 @@ def format_percent(val, width=10):
     return f"{val:.1%}".rjust(width)
 
 
+def print_row(
+    label,
+    values,
+    col_width,
+    label_width=LABEL_WIDTH_DEFAULT,
+    formatter=format_value,
+    better=None,
+    texts=None,
+):
+    """Print one labelled row of per-method values, the leading method in green."""
+    best = _best_index(values, better)
+    print(f"  {label:>{label_width}}", end="")
+    for i, value in enumerate(values):
+        text = texts[i].rjust(col_width) if texts else formatter(value, col_width)
+        print(f"  {highlight(text) if i == best else text}", end="")
+    print()
+
+
 def print_header(methods, col_width, label_width=LABEL_WIDTH_DEFAULT, label=""):
     print(f"  {'':>{label_width}}", end="")
     for m in methods:
@@ -657,73 +715,96 @@ def print_header(methods, col_width, label_width=LABEL_WIDTH_DEFAULT, label=""):
 
 def _print_detection(methods, get_det, col_width, label_width=LABEL_WIDTH_DEFAULT):
     """Print TP/FP/FN/TN and derived rates from a detection dict."""
-    for key, label in [("tp", "TP"), ("fp", "FP"), ("fn", "FN"), ("tn", "TN")]:
-        print(f"  {label:>{label_width}}", end="")
-        for m in methods:
-            print(f"  {format_value(get_det(m)[key], col_width)}", end="")
-        print()
-    for key, label, formatter in [
-        ("recall", "TPR (Recall)", format_percent),
-        ("fpr", "FPR", format_percent),
-        ("precision", "Precision", format_percent),
-        ("f1", "F1 Score", format_percent),
+    for key, label, better in [
+        ("tp", "TP", HIGHER),
+        ("fp", "FP", LOWER),
+        ("fn", "FN", LOWER),
+        ("tn", "TN", HIGHER),
     ]:
-        print(f"  {label:>{label_width}}", end="")
-        for m in methods:
-            print(f"  {formatter(get_det(m)[key], col_width)}", end="")
-        print()
+        print_row(label, [get_det(m)[key] for m in methods], col_width, label_width, better=better)
+    for key, label, better in [
+        ("recall", "TPR (Recall)", HIGHER),
+        ("fpr", "FPR", LOWER),
+        ("precision", "Precision", HIGHER),
+        ("f1", "F1 Score", HIGHER),
+    ]:
+        print_row(
+            label,
+            [get_det(m)[key] for m in methods],
+            col_width,
+            label_width,
+            formatter=format_percent,
+            better=better,
+        )
 
 
 def _print_error_stats(methods, get_stats, col_width, label_width=LABEL_WIDTH_DEFAULT):
     """Print descriptive statistics (mean/median/std/min/max/n)."""
     for stat in ["mean", "std", "min", "median", "max", "n"]:
-        print(f"  {stat:>{label_width}}", end="")
-        for m in methods:
-            print(f"  {format_value(get_stats(m).get(stat), col_width)}", end="")
-        print()
+        print_row(
+            stat,
+            [get_stats(m).get(stat) for m in methods],
+            col_width,
+            label_width,
+            # The smallest error wins; a sample count is not a score, and neither is the
+            # best case a method happened to get.
+            better=None if stat in ("min", "n") else LOWER,
+        )
 
 
 def _print_value_accuracy(
     methods, get_n, get_correct, label, col_width, label_width=LABEL_WIDTH_DEFAULT
 ):
     """Print a single value accuracy row (e.g. '5/7 (71%)')."""
-    print(f"  {label:>{label_width}}", end="")
+    fractions, texts = [], []
     for m in methods:
-        n = get_n(m)
-        nc = get_correct(m)
-        text = f"{nc}/{n} ({nc / n:.0%})" if n > 0 else "-"
-        print(f"  {text:>{col_width}}", end="")
-    print()
+        n, nc = get_n(m), get_correct(m)
+        fractions.append(nc / n if n > 0 else None)
+        texts.append(f"{nc}/{n} ({nc / n:.0%})" if n > 0 else "-")
+    print_row(
+        label,
+        fractions,
+        col_width,
+        label_width,
+        better=HIGHER,
+        texts=texts,
+    )
 
 
 def _print_metric_rows(methods, rows, get_video, col_width, label_width=LABEL_WIDTH_DEFAULT):
-    """Print one row per (key, label, formatter), '-' where a column has no value."""
-    for key, label, formatter in rows:
-        print(f"  {label:>{label_width}}", end="")
-        for m in methods:
-            print(f"  {formatter(get_video(m).get(key), col_width)}", end="")
-        print()
+    """Print one row per (key, label, formatter, better), '-' where a column has no value."""
+    for key, label, formatter, better in rows:
+        print_row(
+            label,
+            [get_video(m).get(key) for m in methods],
+            col_width,
+            label_width,
+            formatter=formatter,
+            better=better,
+        )
 
 
 CLOCK_GROUP_LABELS = {"measured": "measured videos", "retimed": "retimed videos"}
 
+# The last column says which direction wins the row, or None for a row that reports what
+# a fit did rather than how well it did it.
 CLOCK_AGGREGATE_ROWS = [
-    ("residual_threshold_ms_max", "reference tolerance, loosest [ms]", format_value),
-    ("clock_rate_error_ppm_mean_abs", "clock rate error, mean |err| [ppm]", format_value),
-    ("clock_rate_error_ppm_max_abs", "clock rate error, worst |err| [ppm]", format_value),
-    ("clock_offset_error_ms_mean_abs", "clock offset error, mean |err| [ms]", format_value),
-    ("clock_offset_error_ms_max_abs", "clock offset error, worst |err| [ms]", format_value),
-    ("sync_error_mean_ms", "sync error, mean over videos [ms]", format_value),
-    ("sync_error_max_ms", "sync error, worst over videos [ms]", format_value),
-    ("rmse_after_mean", "fit RMSE, mean over videos [ms]", format_value),
-    ("rmse_after_max", "fit RMSE, worst over videos [ms]", format_value),
-    ("r2_after_min", "fit R2, worst over videos", format_value),
-    ("false_rejections", "outliers rejected in error", format_value),
-    ("false_acceptances", "misdecodes kept as inliers", format_value),
-    ("n_flagged", "frames with both a fit and an annotation", format_value),
-    ("n_considered_frames", "frames in the fit", format_value),
-    ("n_rejected_frames", "frames rejected by the fit", format_value),
-    ("n_dropped_frames", "frames missing from the container", format_value),
+    ("residual_threshold_ms_max", "reference tolerance, loosest [ms]", format_value, None),
+    ("clock_rate_error_ppm_mean_abs", "clock rate error, mean |err| [ppm]", format_value, LOWER),
+    ("clock_rate_error_ppm_max_abs", "clock rate error, worst |err| [ppm]", format_value, LOWER),
+    ("clock_offset_error_ms_mean_abs", "clock offset error, mean |err| [ms]", format_value, LOWER),
+    ("clock_offset_error_ms_max_abs", "clock offset error, worst |err| [ms]", format_value, LOWER),
+    ("sync_error_mean_ms", "sync error, mean over videos [ms]", format_value, LOWER),
+    ("sync_error_max_ms", "sync error, worst over videos [ms]", format_value, LOWER),
+    ("rmse_after_mean", "fit RMSE, mean over videos [ms]", format_value, LOWER),
+    ("rmse_after_max", "fit RMSE, worst over videos [ms]", format_value, LOWER),
+    ("r2_after_min", "fit R2, worst over videos", format_value, HIGHER),
+    ("false_rejections", "outliers rejected in error", format_value, LOWER),
+    ("false_acceptances", "misdecodes kept as inliers", format_value, LOWER),
+    ("n_flagged", "frames with both a fit and an annotation", format_value, None),
+    ("n_considered_frames", "frames in the fit", format_value, None),
+    ("n_rejected_frames", "frames rejected by the fit", format_value, None),
+    ("n_dropped_frames", "frames missing from the container", format_value, None),
 ]
 
 
@@ -788,7 +869,10 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
     print()
     print_header(methods, col_width, label_width, "Corner error (px, image space)")
     _print_error_stats(
-        methods, lambda m: all_metrics[m]["aruco"]["corner_error_px"], col_width, label_width
+        methods,
+        lambda m: all_metrics[m]["aruco"]["corner_error_px"],
+        col_width,
+        label_width,
     )
 
     # ── Corner LED detection ─────────────────────────────────────────────
@@ -820,13 +904,19 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
     print()
     print_header(methods, col_width, label_width, "Pixel error — image space")
     _print_error_stats(
-        methods, lambda m: all_metrics[m]["corners"]["error_image_px"], col_width, label_width
+        methods,
+        lambda m: all_metrics[m]["corners"]["error_image_px"],
+        col_width,
+        label_width,
     )
 
     print()
     print_header(methods, col_width, label_width, "Pixel error — board space")
     _print_error_stats(
-        methods, lambda m: all_metrics[m]["corners"]["error_board_px"], col_width, label_width
+        methods,
+        lambda m: all_metrics[m]["corners"]["error_board_px"],
+        col_width,
+        label_width,
     )
 
     # ── Counter reading ──────────────────────────────────────────────────
@@ -907,11 +997,17 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
     ]:
         print(f"  {err_label.upper():>{label_width}}")
         for stat in ["mean", "std", "min", "median", "max"]:
-            print(f"  {'  ' + stat:>{label_width}}", end="")
-            for m in methods:
-                val = all_metrics[m]["overall"]["timestamp_error"].get(err_key, {}).get(stat)
-                print(f"  {format_value(val, col_width)}", end="")
-            print()
+            values = [
+                all_metrics[m]["overall"]["timestamp_error"].get(err_key, {}).get(stat)
+                for m in methods
+            ]
+            print_row(
+                "  " + stat,
+                values,
+                col_width,
+                label_width,
+                better=LOWER,
+            )
 
 
 def print_timing(methods, timing, col_width, label_width=LABEL_WIDTH_DEFAULT):
@@ -936,11 +1032,14 @@ def print_timing(methods, timing, col_width, label_width=LABEL_WIDTH_DEFAULT):
             if i > 0:
                 print(f"  {step.upper():-^{label_width}}")
             for stat in stat_keys:
-                print(f"  {'  ' + stat:>{label_width}}", end="")
-                for m in methods:
-                    val = timing[m][subset_name].get(step, {}).get(stat)
-                    print(f"  {format_value(val, col_width)}", end="")
-                print()
+                print_row(
+                    "  " + stat,
+                    [timing[m][subset_name].get(step, {}).get(stat) for m in methods],
+                    col_width,
+                    label_width,
+                    # The best case a method got says little; the rest is speed, so faster wins
+                    better=None if stat == "min" else LOWER,
+                )
 
 
 def _describe_run(config):
@@ -980,7 +1079,16 @@ def main():
     parser.add_argument(
         "-t", "--timing", action="store_true", help="Include per-step timing statistics"
     )
+    parser.add_argument(
+        "--color",
+        choices=["auto", "always", "never"],
+        default="auto",
+        help="Highlight the leading method for each metric in green "
+        "(default: auto, i.e. only when writing to a terminal)",
+    )
     args = parser.parse_args()
+
+    set_color(args.color)
 
     gt = load_ground_truth(args.ground_truth)
     gt_images = gt["images"]

--- a/sw/rocsync/benchmark/retime.py
+++ b/sw/rocsync/benchmark/retime.py
@@ -52,6 +52,7 @@ OUTPUT_TIME_BASE = Fraction(1, 90000)
 CLOCK_RATE_SPREAD = 0.05  # stays inside process_video's own 5% sanity warning
 MUX_PAD_MS = 1000.0  # headroom so reordered decode timestamps stay above zero
 MAX_MARGIN_FRAMES = 5  # frames the codec may force outside the annotated window
+MAX_REPORTED_CONFLICTS = 5  # enough to see the pattern without burying the message
 
 
 class RetimeError(Exception):
@@ -94,8 +95,23 @@ def build_timeline(anchors, pts_by_index, clock_rate):
     """
     old = np.array([pts_by_index[index] for index, _ in anchors], dtype=float)
     board = np.array([board_ms for _, board_ms in anchors], dtype=float)
-    if np.any(np.diff(old) <= 0) or np.any(np.diff(board) <= 0):
-        raise RetimeError("annotated board times do not increase with the recording")
+    # Naming the frames, because the fix is to re-annotate them and a bare refusal
+    # leaves that search to the reader
+    conflicts = [
+        f"{anchors[i][0]}->{anchors[i + 1][0]} ({board[i]:.0f} -> {board[i + 1]:.0f} ms)"
+        for i in range(len(anchors) - 1)
+        if board[i + 1] <= board[i] or old[i + 1] <= old[i]
+    ]
+    if conflicts:
+        raise RetimeError(
+            "annotated board times do not increase with the recording at frames "
+            + ", ".join(conflicts[:MAX_REPORTED_CONFLICTS])
+            + (
+                f" and {len(conflicts) - MAX_REPORTED_CONFLICTS} more"
+                if len(conflicts) > MAX_REPORTED_CONFLICTS
+                else ""
+            )
+        )
     new = (board - board[0]) / clock_rate
     slope = (new[-1] - new[0]) / (old[-1] - old[0])
 

--- a/sw/rocsync/benchmark/retime.py
+++ b/sw/rocsync/benchmark/retime.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Rewrite a benchmark video's timestamps onto a clock derived from its annotations.
+
+A camera's container timestamps are not a record of when it exposed. The phone clips in
+the dataset write a near-nominal grid while the sensor wanders +/-7 ms around it, which
+puts a floor under any clock fitted against them -- fitting the undecimated original over
+650 frames gives the same 3.2 ms as the decimated copy, so the information was never
+written rather than lost in processing.
+
+That floor is the honest answer to how well a phone can be synchronized, and far too
+coarse to catch a regression in decoding or fitting. So this tool produces the other kind
+of benchmark video: the annotated board times become the timeline, and the clock the
+pipeline is supposed to recover is known exactly instead of fitted. Only the container's
+timestamps change -- packets are copied through untouched, so the pixels every existing
+annotation describes are still the same pixels.
+
+Usage:
+    python -m rocsync.benchmark.retime [data_dir] [-o ground_truth.json]
+"""
+
+import argparse
+import hashlib
+import json
+import random
+import sys
+from datetime import datetime, timezone
+from fractions import Fraction
+from pathlib import Path
+
+import numpy as np
+
+from rocsync.benchmark.common import (
+    MIN_REFERENCE_FRAMES,
+    SYNTHESIZED_RESIDUAL_THRESHOLD_MS,
+    annotated_board_time,
+    collect_frames,
+    is_retimed,
+    parse_frame_key,
+    retimed_path,
+    source_frame_period_ms,
+)
+from rocsync.timeline import frame_pts
+
+try:
+    import av
+except ImportError:  # pragma: no cover - exercised only without the dev group
+    av = None
+
+# Enough that the anchors' rounding is negligible against the 2 ms they are held to
+OUTPUT_TIME_BASE = Fraction(1, 90000)
+
+CLOCK_RATE_SPREAD = 0.05  # stays inside process_video's own 5% sanity warning
+MUX_PAD_MS = 1000.0  # headroom so reordered decode timestamps stay above zero
+MAX_MARGIN_FRAMES = 5  # frames the codec may force outside the annotated window
+
+
+class RetimeError(Exception):
+    """A video that cannot be retimed, with a reason worth printing."""
+
+
+# ── The synthesized clock ───────────────────────────────────────────────────
+
+
+def draw_clock(rel_path):
+    """The clock rate to build one video's timeline on, drawn but reproducible.
+
+    Seeded on the source path so regenerating a clip lands on the same rate, and drawn
+    rather than fixed so a rate of exactly 1.0 -- which several kinds of bug would
+    produce by accident -- never counts as a pass. The offset needs no drawing: it comes
+    out as the board time of the clip's first frame, tens of seconds from zero already.
+    """
+    rng = random.Random(hashlib.sha256(str(rel_path).encode()).hexdigest())
+    return rng.uniform(1 - CLOCK_RATE_SPREAD, 1 + CLOCK_RATE_SPREAD)
+
+
+def anchors_digest(anchors):
+    """Fingerprint of the annotations a retimed clip was built from."""
+    payload = ";".join(f"{index}:{board_ms:.6f}" for index, board_ms in anchors)
+    return "sha256:" + hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def build_timeline(anchors, pts_by_index, clock_rate):
+    """A monotonic map from old presentation time to new, in ms, zeroed on the first anchor.
+
+    Interpolates between the anchors, so `board time == clock_rate * new + offset` holds
+    exactly at every one of them once the caller adds its shift. Interpolating in old
+    presentation time rather than frame index keeps the recording's own shape, including
+    any gap where frames were dropped.
+
+    Timestamps outside the anchored span do occur -- a stream copy cannot start mid-GOP
+    or orphan a reference, and a B-frame's decode timestamp precedes the first frame it
+    is shown after -- so the map extends past both ends at the overall anchor slope
+    rather than flattening out, which is what `np.interp` alone would do.
+    """
+    old = np.array([pts_by_index[index] for index, _ in anchors], dtype=float)
+    board = np.array([board_ms for _, board_ms in anchors], dtype=float)
+    if np.any(np.diff(old) <= 0) or np.any(np.diff(board) <= 0):
+        raise RetimeError("annotated board times do not increase with the recording")
+    new = (board - board[0]) / clock_rate
+    slope = (new[-1] - new[0]) / (old[-1] - old[0])
+
+    def remap(old_ms):
+        if old_ms < old[0]:
+            return float(new[0] + (old_ms - old[0]) * slope)
+        if old_ms > old[-1]:
+            return float(new[-1] + (old_ms - old[-1]) * slope)
+        return float(np.interp(old_ms, old, new))
+
+    return remap
+
+
+# ── Reading what is already there ───────────────────────────────────────────
+
+
+def video_anchors(images, rel_path):
+    """[(frame index, board start ms)] for the frames that pin down a timeline.
+
+    Only annotations a board time follows from anchor anything: a ring arc that wraps the
+    end of the period was exposed across a counter increment and names no single time.
+    """
+    anchors = []
+    for key, entry in images.items():
+        path, index = parse_frame_key(key)
+        if index is None or path != rel_path:
+            continue
+        board_ms = annotated_board_time(entry)
+        if board_ms is not None:
+            anchors.append((index, board_ms))
+    return sorted(anchors)
+
+
+def is_current(entry, output_path, digest):
+    """Whether a retimed clip already reflects the annotations it was cut from."""
+    return (
+        entry is not None and entry.get("anchors_digest") == digest and Path(output_path).is_file()
+    )
+
+
+# ── Writing the clip ────────────────────────────────────────────────────────
+
+
+def remux(
+    source, destination, first_index, last_index, remap, anchor_indices, jitter_ms, rng, pad_ms
+):
+    """Copy the frames covering [first_index, last_index] across, with new timestamps.
+
+    Returns (frames written, display index of the first frame kept, shift applied in ms).
+    Packets are copied, never re-encoded, so every pixel an annotation describes survives
+    untouched.
+
+    Frames are selected by display index but written in decode order, which is not the
+    same order once B-frames are involved. A copy also cannot start mid-GOP or orphan a
+    reference that a retained frame needs, so the span is widened to the enclosing
+    keyframe and to whatever decode order drags in. That can pull a few frames past the
+    annotated window; they follow the overall anchor slope, which over a handful of
+    frames costs far less than the tolerance they are never checked against anyway.
+
+    `remap` is zeroed on the first anchor, so everything is shifted up by at least
+    `pad_ms` before it is written -- far enough that no decode timestamp lands below
+    zero, which MP4 will not mux.
+    """
+    assert av is not None, "main() refuses to run without PyAV"
+    with av.open(str(source)) as inp, av.open(str(destination), "w") as out:
+        in_stream = inp.streams.video[0]
+        out_stream = out.add_stream_from_template(in_stream)
+        out_stream.time_base = OUTPUT_TIME_BASE
+
+        # Decode order, which is the order they must be written back in
+        packets = [p for p in inp.demux(in_stream) if p.pts is not None and p.dts is not None]
+        # Display order: the n-th smallest presentation timestamp is frame n
+        display_of = {
+            decode_pos: display
+            for display, decode_pos in enumerate(
+                sorted(range(len(packets)), key=lambda i: packets[i].pts)
+            )
+        }
+
+        wanted = [i for i in range(len(packets)) if first_index <= display_of[i] <= last_index]
+        if not wanted:
+            raise RetimeError("no packet covers the annotated window")
+        lo, hi = min(wanted), max(wanted)
+        while lo > 0 and not packets[lo].is_keyframe:
+            lo -= 1
+
+        kept = sorted(display_of[i] for i in range(lo, hi + 1))
+        if kept != list(range(kept[0], kept[0] + len(kept))):
+            raise RetimeError("the frames a stream copy needs are not contiguous")
+
+        # `remap` speaks the decoder's start-relative timestamps, packets the raw ones
+        start_ts = in_stream.start_time or 0
+
+        def old_ms(stamp):
+            return float((stamp - start_ts) * in_stream.time_base * 1000)
+
+        jitter = {
+            i: rng.gauss(0, jitter_ms) if jitter_ms and display_of[i] not in anchor_indices else 0.0
+            for i in range(lo, hi + 1)
+        }
+        shift = pad_ms - min(
+            min(remap(old_ms(packets[i].pts)) + jitter[i], remap(old_ms(packets[i].dts)))
+            for i in range(lo, hi + 1)
+        )
+        shift = max(shift, pad_ms)
+
+        def stamp(ms):
+            return round((ms + shift) / 1000 / OUTPUT_TIME_BASE)
+
+        for i in range(lo, hi + 1):
+            packet = packets[i]
+            packet.pts = stamp(remap(old_ms(packet.pts)) + jitter[i])
+            packet.dts = stamp(remap(old_ms(packet.dts)))
+            packet.time_base = OUTPUT_TIME_BASE
+            packet.stream = out_stream
+            out.mux(packet)
+
+    return len(kept), kept[0], shift
+
+
+# ── Per-video driver ────────────────────────────────────────────────────────
+
+
+def retime_video(data_dir, rel_path, ground_truth, jitter_ms=0.0, force=False):
+    """Retime one source video, returning a status line for it.
+
+    Raises RetimeError when the clip cannot be built; the caller decides how loud that is.
+    """
+    anchors = video_anchors(ground_truth["images"], rel_path)
+    if len(anchors) < MIN_REFERENCE_FRAMES:
+        return f"{rel_path}: {len(anchors)} anchors, needs {MIN_REFERENCE_FRAMES}, skipped"
+
+    out_rel = str(retimed_path(rel_path))
+    digest = anchors_digest(anchors)
+    entry = (ground_truth.get("videos") or {}).get(out_rel)
+    if not force and is_current(entry, data_dir / out_rel, digest):
+        return f"{rel_path}: up to date"
+
+    pts_by_index = dict(enumerate(frame_pts(data_dir / rel_path)))
+    missing = [i for i, _ in anchors if i not in pts_by_index]
+    if missing:
+        raise RetimeError(f"{rel_path}: annotated frames {missing[:5]} are not in the file")
+
+    clock_rate = draw_clock(rel_path)
+    remap = build_timeline(anchors, pts_by_index, clock_rate)
+
+    first_index, last_index = anchors[0][0], anchors[-1][0]
+    rng = random.Random(hashlib.sha256(f"jitter:{rel_path}".encode()).hexdigest())
+    n_frames, start_index, _shift_ms = remux(
+        data_dir / rel_path,
+        data_dir / out_rel,
+        first_index,
+        last_index,
+        remap,
+        {i for i, _ in anchors},
+        jitter_ms,
+        rng,
+        MUX_PAD_MS,
+    )
+
+    margin = (first_index - start_index) + (start_index + n_frames - 1 - last_index)
+    if margin > MAX_MARGIN_FRAMES:
+        Path(data_dir / out_rel).unlink(missing_ok=True)
+        raise RetimeError(
+            f"{rel_path}: the codec forces {margin} frames outside the annotated window, "
+            f"more than the {MAX_MARGIN_FRAMES} that stay within tolerance"
+        )
+
+    # Read the clip back the way the pipeline will: OpenCV reports timestamps relative
+    # to the stream's start time, so the offset that actually holds is only measurable
+    # from the written file, not from what was handed to the muxer.
+    written_pts = frame_pts(data_dir / out_rel)
+    if len(written_pts) != n_frames:
+        raise RetimeError(f"{rel_path}: wrote {n_frames} frames but reads back {len(written_pts)}")
+    anchor_pts = [written_pts[index - start_index] for index, _ in anchors]
+    boards = [board_ms for _, board_ms in anchors]
+    clock_offset_ms = float(
+        np.mean([b - clock_rate * p for p, b in zip(anchor_pts, boards, strict=True)])
+    )
+    residuals = np.array(
+        [clock_rate * p + clock_offset_ms - b for p, b in zip(anchor_pts, boards, strict=True)]
+    )
+    if np.abs(residuals).max() > SYNTHESIZED_RESIDUAL_THRESHOLD_MS:
+        Path(data_dir / out_rel).unlink(missing_ok=True)
+        raise RetimeError(
+            f"{rel_path}: the muxed timeline misses its anchors by up to "
+            f"{np.abs(residuals).max():.3f} ms"
+        )
+    # The recording keeps its own measured reference: the two describe different
+    # questions, and the report picks between them rather than needing one deleted.
+    ground_truth.setdefault("videos", {})[out_rel] = {
+        "timeline": "synthesized",
+        "source": rel_path,
+        "source_frame_offset": start_index,
+        "n_frames": n_frames,
+        "anchors_digest": digest,
+        "clock_rate": clock_rate,
+        "clock_offset_ms": clock_offset_ms,
+        "pts_min_ms": min(anchor_pts),
+        "pts_max_ms": max(anchor_pts),
+        "n_frames_fitted": len(anchors),
+        "rmse_ms": float(np.sqrt(np.mean(residuals**2))),
+        "max_residual_ms": float(np.abs(residuals).max()),
+        "residual_threshold_ms": SYNTHESIZED_RESIDUAL_THRESHOLD_MS,
+        "source_frame_period_ms": source_frame_period_ms(data_dir / rel_path),
+        "derived_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    return (
+        f"{rel_path}: {len(anchors)} anchors, frames {start_index}-{start_index + n_frames - 1} "
+        f"of {len(pts_by_index)}, rate {clock_rate:.6f}, offset {clock_offset_ms:.1f} ms"
+    )
+
+
+def _retime_one(data_dir, rel_path, ground_truth, args):
+    """(message, ok) for one video, so a bad clip does not abandon the rest."""
+    try:
+        return retime_video(data_dir, rel_path, ground_truth, args.jitter_ms, args.force), True
+    except (RetimeError, OSError) as e:
+        return f"ERROR: {e}", False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Rewrite benchmark video timestamps onto a clock built from annotations"
+    )
+    parser.add_argument(
+        "data_dir",
+        nargs="?",
+        default="validation_data",
+        help="Path to validation data directory (default: validation_data)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Ground truth JSON to read and update (default: <data_dir>/ground_truth.json)",
+    )
+    parser.add_argument(
+        "--jitter-ms",
+        type=float,
+        default=0.0,
+        help="Noise added to frames without an annotation; anchors stay exact (default: 0)",
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Rebuild clips even when already up to date"
+    )
+    args = parser.parse_args()
+
+    if av is None:
+        print(
+            "rocsync-retime needs PyAV, which ships in the dev dependency group.\n"
+            "Run `uv sync` from RocSync/sw, then try again.",
+            file=sys.stderr,
+        )
+        return 1
+
+    data_dir = Path(args.data_dir)
+    output_path = Path(args.output) if args.output else data_dir / "ground_truth.json"
+    if not output_path.is_file():
+        print(f"No ground truth at {output_path}", file=sys.stderr)
+        return 1
+    with open(output_path) as f:
+        ground_truth = json.load(f)
+    ground_truth.setdefault("images", {})
+    ground_truth.setdefault("videos", {})
+
+    sources = sorted(
+        {
+            parse_frame_key(ref.key)[0]
+            for ref in collect_frames(data_dir, sources_only=True)
+            if ref.index is not None and not is_retimed(ref.path)
+        }
+    )
+    if not sources:
+        print(f"No source videos found in {data_dir}", file=sys.stderr)
+        return 1
+
+    failed = False
+    for rel_path in sources:
+        message, ok = _retime_one(data_dir, rel_path, ground_truth, args)
+        print(message) if ok else print(message, file=sys.stderr)
+        failed |= not ok
+
+    with open(output_path, "w") as f:
+        json.dump(ground_truth, f, indent=2)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/rocsync/benchmark/validate.py
+++ b/sw/rocsync/benchmark/validate.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import subprocess
 import sys
+from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -24,9 +25,12 @@ from rocsync.benchmark.common import (
     FrameSource,
     collect_frames,
     corner_positions_in_image,
+    frame_key,
+    parse_frame_key,
 )
 from rocsync.board_profiles import PROFILES_BY_ARUCO
 from rocsync.camera import CameraType
+from rocsync.timeline import frame_pts, summarize_timeline
 from rocsync.vision import process_frame
 
 
@@ -155,6 +159,68 @@ def run_benchmark(frames, debug_dir=None):
     return results
 
 
+def fit_videos(frames, results):
+    """Fit a clock per video and fold the per-frame outcome back into `results`.
+
+    Runs the production summarization over every frame that decoded, rather than the
+    one-per-second sample a real run takes: the benchmark has already paid to decode
+    them all, and using all of them keeps fit quality separate from sampling policy.
+    """
+    by_path = defaultdict(list)
+    for ref in frames:
+        if ref.index is not None:
+            by_path[ref.path].append(ref)
+
+    videos = {}
+    for path in sorted(by_path):
+        refs = by_path[path]
+        rel_path, _ = parse_frame_key(refs[0].key)
+        frame_times = dict(enumerate(frame_pts(path)))
+
+        cap = cv2.VideoCapture(str(path), cv2.CAP_FFMPEG)
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        cap.release()
+
+        # A frame's presentation timestamp is its own, whether or not the fit succeeds
+        for ref in refs:
+            if ref.key in results and ref.index in frame_times:
+                results[ref.key]["pts_ms"] = frame_times[ref.index]
+
+        timestamps = {
+            ref.index: tuple(results[ref.key]["timestamp"])
+            for ref in refs
+            if results.get(ref.key, {}).get("timestamp") is not None
+        }
+
+        try:
+            statistics, _, considered, rejected, _ = summarize_timeline(
+                timestamps, frame_times, len(frame_times), fps
+            )
+        except ValueError as e:
+            videos[rel_path] = {
+                "n_frames": len(frame_times),
+                "n_timestamped_frames": len(timestamps),
+                "error": str(e),
+            }
+            print(f"  WARNING: no clock for {rel_path}: {e}", file=sys.stderr)
+            continue
+
+        for index, (*_, residual) in {**considered, **rejected}.items():
+            key = frame_key(rel_path, index)
+            if key in results:
+                results[key]["fit"] = {
+                    "residual_ms": float(residual),
+                    "inlier": index in considered,
+                }
+
+        record = statistics.to_dict()
+        # The per-frame residuals now live next to the frames they belong to
+        del record["considered_timestamps"], record["rejected_timestamps"]
+        videos[rel_path] = {**record, "n_timestamped_frames": len(timestamps), "error": None}
+
+    return videos
+
+
 def main():
     parser = argparse.ArgumentParser(description="Benchmark rocsync on validation data")
     parser.add_argument(
@@ -192,8 +258,21 @@ def main():
     n_success = sum(1 for r in results.values() if r["success"])
     print(f"Detection rate: {n_success}/{len(results)} ({n_success / len(results):.1%})")
 
+    videos = fit_videos(frames, results)
+    for rel_path, video in videos.items():
+        if video["error"] is not None:
+            print(f"{rel_path}: no clock ({video['error']})")
+            continue
+        print(
+            f"{rel_path}: {video['clock_rate']:.6f}x, "
+            f"offset {video['clock_offset_ms']:.1f} ms, "
+            f"RMSE {video['rmse_after']:.2f} ms, "
+            f"{video['n_considered_frames']}/{video['n_timestamped_frames']} inliers"
+        )
+
     output = {
         "config": run_provenance(data_dir, len(results)),
+        "videos": videos,
         "images": results,
     }
     with open(args.output, "w") as f:

--- a/sw/rocsync/benchmark/validate.py
+++ b/sw/rocsync/benchmark/validate.py
@@ -15,10 +15,10 @@ from pathlib import Path
 import cv2
 from tqdm import tqdm
 
+from rocsync.benchmark.common import STEP_ORDER, collect_images
 from rocsync.board_profiles import PROFILES_BY_ARUCO
 from rocsync.camera import CameraType
 from rocsync.vision import process_frame
-from rocsync.benchmark.common import STEP_ORDER, collect_images
 
 
 def extract_pipeline_result(stats):
@@ -100,7 +100,9 @@ def run_benchmark(data_dir, images, debug_dir=None):
 
         stats = {}
         success, timestamp = process_frame(
-            image, CameraType.RGB, i,
+            image,
+            CameraType.RGB,
+            i,
             debug_dir=debug_dir,
             stats=stats,
         )
@@ -120,12 +122,19 @@ def run_benchmark(data_dir, images, debug_dir=None):
 
 def main():
     parser = argparse.ArgumentParser(description="Benchmark rocsync on validation data")
-    parser.add_argument("data_dir", nargs="?", default="validation_data",
-                        help="Path to validation data directory (default: validation_data)")
-    parser.add_argument("-o", "--output", default="benchmark_results.json",
-                        help="Output JSON file (default: benchmark_results.json)")
-    parser.add_argument("--debug", default=None,
-                        help="Directory for debug images")
+    parser.add_argument(
+        "data_dir",
+        nargs="?",
+        default="validation_data",
+        help="Path to validation data directory (default: validation_data)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="benchmark_results.json",
+        help="Output JSON file (default: benchmark_results.json)",
+    )
+    parser.add_argument("--debug", default=None, help="Directory for debug images")
     args = parser.parse_args()
 
     data_dir = Path(args.data_dir)
@@ -141,7 +150,7 @@ def main():
     results = run_benchmark(data_dir, images, debug_dir=args.debug)
 
     n_success = sum(1 for r in results.values() if r["success"])
-    print(f"Detection rate: {n_success}/{len(results)} ({n_success/len(results):.1%})")
+    print(f"Detection rate: {n_success}/{len(results)} ({n_success / len(results):.1%})")
 
     output = {
         "config": {"data_dir": str(data_dir)},

--- a/sw/rocsync/benchmark/validate.py
+++ b/sw/rocsync/benchmark/validate.py
@@ -3,19 +3,23 @@
 
 Runs process_frame on all images, collects per-image results in a structure
 mirroring the ground truth format (aruco, corners, counter, ring), plus
-per-step timing. Saves results as JSON without aggregate statistics — those
-are computed by the evaluate tool.
+per-step timing. Positions are in original image coordinates, matching the
+annotations. Saves results as JSON without aggregate statistics — those are
+computed by the evaluate tool.
 """
 
 import argparse
 import json
+import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import cv2
+import numpy as np
 from tqdm import tqdm
 
-from rocsync.benchmark.common import STEP_ORDER, collect_images
+from rocsync.benchmark.common import STEP_ORDER, collect_images, corner_positions_in_image
 from rocsync.board_profiles import PROFILES_BY_ARUCO
 from rocsync.camera import CameraType
 from rocsync.vision import process_frame
@@ -40,11 +44,10 @@ def extract_pipeline_result(stats):
     }
     board = PROFILES_BY_ARUCO[aruco_id] if aruco_id is not None else None
 
-    # -- Corners --
-    corner_positions = stats.get("corner_positions")
-    if corner_positions is None:
-        corner_positions = [None] * 4
-    corners = [{"visible": pos is not None, "position": pos} for pos in corner_positions]
+    # -- Corners (original image coordinates, as annotated) --
+    corners = [
+        {"visible": pos is not None, "position": pos} for pos in corner_positions_in_image(stats)
+    ]
 
     # -- Counter --
     counter_step = steps.get("counter_reading", {})
@@ -87,6 +90,33 @@ def extract_pipeline_timing(stats):
             timing[f"{step}_ms"] = steps[step]["time_ms"]
     timing["total_ms"] = stats.get("total_time_ms")
     return timing
+
+
+def run_provenance(data_dir, n_images):
+    """Identify the checkout that produced a result file, so columns are self-describing."""
+
+    def git(*args):
+        try:
+            return subprocess.run(
+                ["git", *args],
+                cwd=Path(__file__).parent,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        except (OSError, subprocess.CalledProcessError):
+            return None
+
+    return {
+        "data_dir": str(data_dir),
+        "n_images": n_images,
+        "branch": git("rev-parse", "--abbrev-ref", "HEAD"),
+        "commit": git("rev-parse", "--short", "HEAD"),
+        "dirty": bool(git("status", "--porcelain")),
+        "run_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "opencv": cv2.__version__,
+        "numpy": np.__version__,
+    }
 
 
 def run_benchmark(data_dir, images, debug_dir=None):
@@ -153,7 +183,7 @@ def main():
     print(f"Detection rate: {n_success}/{len(results)} ({n_success / len(results):.1%})")
 
     output = {
-        "config": {"data_dir": str(data_dir)},
+        "config": run_provenance(data_dir, len(results)),
         "images": results,
     }
     with open(args.output, "w") as f:

--- a/sw/rocsync/benchmark/validate.py
+++ b/sw/rocsync/benchmark/validate.py
@@ -67,17 +67,17 @@ def extract_pipeline_result(stats):
     }
 
     # -- Ring --
-    ring_step = steps.get("ring_reading", {})
-    ring_visible = ring_step.get("success", False)
+    # Read off the arc rather than the timestamp, so an arc that wraps the period
+    # end is still scored: the pipeline reads it correctly and then refuses to time
+    # it, and those are two different things to be right or wrong about.
+    ring_window = stats.get("ring_window")
     timestamp = stats.get("timestamp")
 
-    if ring_visible and timestamp is not None:
-        # read_ring returns inclusive end (last ON LED); convert to half-open
-        # (first OFF LED) to match ground truth convention.
-        ring = {
-            "start": timestamp[0] % board.period if board is not None else timestamp[0],
-            "end": (timestamp[1] + 1) % board.period if board is not None else timestamp[1] + 1,
-        }
+    if ring_window is not None and board is not None:
+        # read_ring returns an inclusive end (last ON LED); convert to half-open
+        # (first OFF LED) to match the ground truth convention.
+        start, end = ring_window
+        ring = {"start": start % board.period, "end": (end + 1) % board.period}
     else:
         ring = {"start": 0, "end": 0}
 

--- a/sw/rocsync/benchmark/validate.py
+++ b/sw/rocsync/benchmark/validate.py
@@ -19,7 +19,12 @@ import cv2
 import numpy as np
 from tqdm import tqdm
 
-from rocsync.benchmark.common import STEP_ORDER, collect_images, corner_positions_in_image
+from rocsync.benchmark.common import (
+    STEP_ORDER,
+    FrameSource,
+    collect_frames,
+    corner_positions_in_image,
+)
 from rocsync.board_profiles import PROFILES_BY_ARUCO
 from rocsync.camera import CameraType
 from rocsync.vision import process_frame
@@ -119,33 +124,33 @@ def run_provenance(data_dir, n_images):
     }
 
 
-def run_benchmark(data_dir, images, debug_dir=None):
-    """Run pipeline on all images, returning results dict keyed by relative path."""
+def run_benchmark(frames, debug_dir=None):
+    """Run pipeline on all frames, returning results dict keyed by frame key."""
     results = {}
-    for i, path in enumerate(tqdm(images)):
-        image = cv2.imread(str(path))
-        if image is None:
-            print(f"  WARNING: could not read {path}", file=sys.stderr)
-            continue
+    with FrameSource() as source:
+        for i, ref in enumerate(tqdm(frames)):
+            image = source.read(ref)
+            if image is None:
+                print(f"  WARNING: could not read {ref.key}", file=sys.stderr)
+                continue
 
-        stats = {}
-        success, timestamp = process_frame(
-            image,
-            CameraType.RGB,
-            i,
-            debug_dir=debug_dir,
-            stats=stats,
-        )
+            stats = {}
+            success, timestamp = process_frame(
+                image,
+                CameraType.RGB,
+                i,
+                debug_dir=debug_dir,
+                stats=stats,
+            )
 
-        rel_path = str(path.relative_to(data_dir))
-        result = extract_pipeline_result(stats)
-        timing = extract_pipeline_timing(stats)
+            result = extract_pipeline_result(stats)
+            timing = extract_pipeline_timing(stats)
 
-        results[rel_path] = {
-            **result,
-            "success": success and timestamp is not None,
-            "timing": timing,
-        }
+            results[ref.key] = {
+                **result,
+                "success": success and timestamp is not None,
+                "timing": timing,
+            }
 
     return results
 
@@ -168,16 +173,21 @@ def main():
     args = parser.parse_args()
 
     data_dir = Path(args.data_dir)
-    images = collect_images(data_dir)
-    if not images:
-        print(f"No images found in {data_dir}", file=sys.stderr)
+    frames = collect_frames(data_dir)
+    if not frames:
+        print(f"No images or videos found in {data_dir}", file=sys.stderr)
         sys.exit(1)
 
     if args.debug:
         Path(args.debug).mkdir(parents=True, exist_ok=True)
 
-    print(f"Found {len(images)} images")
-    results = run_benchmark(data_dir, images, debug_dir=args.debug)
+    n_stills = sum(1 for ref in frames if ref.index is None)
+    n_videos = len({ref.path for ref in frames if ref.index is not None})
+    print(
+        f"Found {len(frames)} frames: {n_stills} images and "
+        f"{len(frames) - n_stills} frames from {n_videos} videos"
+    )
+    results = run_benchmark(frames, debug_dir=args.debug)
 
     n_success = sum(1 for r in results.values() if r["success"])
     print(f"Detection rate: {n_success}/{len(results)} ({n_success / len(results):.1%})")

--- a/sw/rocsync/benchmark/validate.py
+++ b/sw/rocsync/benchmark/validate.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Benchmark rocsync pipeline on validation data.
+
+Runs process_frame on all images, collects per-image results in a structure
+mirroring the ground truth format (aruco, corners, counter, ring), plus
+per-step timing. Saves results as JSON without aggregate statistics — those
+are computed by the evaluate tool.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+from tqdm import tqdm
+
+from rocsync.board_profiles import PROFILES_BY_ARUCO
+from rocsync.camera import CameraType
+from rocsync.vision import process_frame
+from rocsync.benchmark.common import STEP_ORDER, collect_images
+
+
+def extract_pipeline_result(stats):
+    """Extract a ground-truth-compatible result dict from pipeline stats.
+
+    Returns a dict with keys: aruco, corners, counter, ring, timestamp.
+    Structure mirrors ground_truth.json to simplify comparison.
+    """
+    steps = stats.get("steps", {})
+
+    # -- ArUco --
+    aruco_id = stats.get("aruco_id", None)
+    aruco_step = steps.get("aruco_detection", {})
+    aruco_visible = aruco_step.get("success", False)
+    aruco = {
+        "visible": aruco_visible,
+        "id": stats.get("aruco_id") if aruco_visible else None,
+        "corners": stats.get("aruco_corners") if aruco_visible else None,
+    }
+    board = PROFILES_BY_ARUCO[aruco_id] if aruco_id is not None else None
+
+    # -- Corners --
+    corner_positions = stats.get("corner_positions")
+    if corner_positions is None:
+        corner_positions = [None] * 4
+    corners = [{"visible": pos is not None, "position": pos} for pos in corner_positions]
+
+    # -- Counter --
+    counter_step = steps.get("counter_reading", {})
+    counter_value = counter_step.get("value")
+    counter = {
+        "visible": counter_value is not None,
+        "value": counter_value,
+    }
+
+    # -- Ring --
+    ring_step = steps.get("ring_reading", {})
+    ring_visible = ring_step.get("success", False)
+    timestamp = stats.get("timestamp")
+
+    if ring_visible and timestamp is not None:
+        # read_ring returns inclusive end (last ON LED); convert to half-open
+        # (first OFF LED) to match ground truth convention.
+        ring = {
+            "start": timestamp[0] % board.period if board is not None else timestamp[0],
+            "end": (timestamp[1] + 1) % board.period if board is not None else timestamp[1] + 1,
+        }
+    else:
+        ring = {"start": 0, "end": 0}
+
+    return {
+        "aruco": aruco,
+        "corners": corners,
+        "counter": counter,
+        "ring": ring,
+        "timestamp": timestamp,
+    }
+
+
+def extract_pipeline_timing(stats):
+    """Extract per-step timing from pipeline stats."""
+    steps = stats.get("steps", {})
+    timing = {}
+    for step in STEP_ORDER:
+        if step in steps:
+            timing[f"{step}_ms"] = steps[step]["time_ms"]
+    timing["total_ms"] = stats.get("total_time_ms")
+    return timing
+
+
+def run_benchmark(data_dir, images, debug_dir=None):
+    """Run pipeline on all images, returning results dict keyed by relative path."""
+    results = {}
+    for i, path in enumerate(tqdm(images)):
+        image = cv2.imread(str(path))
+        if image is None:
+            print(f"  WARNING: could not read {path}", file=sys.stderr)
+            continue
+
+        stats = {}
+        success, timestamp = process_frame(
+            image, CameraType.RGB, i,
+            debug_dir=debug_dir,
+            stats=stats,
+        )
+
+        rel_path = str(path.relative_to(data_dir))
+        result = extract_pipeline_result(stats)
+        timing = extract_pipeline_timing(stats)
+
+        results[rel_path] = {
+            **result,
+            "success": success and timestamp is not None,
+            "timing": timing,
+        }
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark rocsync on validation data")
+    parser.add_argument("data_dir", nargs="?", default="validation_data",
+                        help="Path to validation data directory (default: validation_data)")
+    parser.add_argument("-o", "--output", default="benchmark_results.json",
+                        help="Output JSON file (default: benchmark_results.json)")
+    parser.add_argument("--debug", default=None,
+                        help="Directory for debug images")
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir)
+    images = collect_images(data_dir)
+    if not images:
+        print(f"No images found in {data_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.debug:
+        Path(args.debug).mkdir(parents=True, exist_ok=True)
+
+    print(f"Found {len(images)} images")
+    results = run_benchmark(data_dir, images, debug_dir=args.debug)
+
+    n_success = sum(1 for r in results.values() if r["success"])
+    print(f"Detection rate: {n_success}/{len(results)} ({n_success/len(results):.1%})")
+
+    output = {
+        "config": {"data_dir": str(data_dir)},
+        "images": results,
+    }
+    with open(args.output, "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"Results saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sw/rocsync/board_profiles.py
+++ b/sw/rocsync/board_profiles.py
@@ -114,6 +114,7 @@ class BoardProfile:
     always_on_leds: dict  # {CameraType: np.ndarray Nx2}, N >= 4
     counter_led_coords: dict  # {CameraType: np.ndarray Nx2}, most significant bit first
     counter_bg_y: dict  # {CameraType: float} background sample row
+    # TODO the ~10 mm offset is inherited from the pixel-based layout; verify against the PCB
 
     def __hash__(self):
         return hash(self.name)

--- a/sw/rocsync/board_profiles.py
+++ b/sw/rocsync/board_profiles.py
@@ -114,7 +114,6 @@ class BoardProfile:
     always_on_leds: dict  # {CameraType: np.ndarray Nx2}, N >= 4
     counter_led_coords: dict  # {CameraType: np.ndarray Nx2}, most significant bit first
     counter_bg_y: dict  # {CameraType: float} background sample row
-    # TODO the ~10 mm offset is inherited from the pixel-based layout; verify against the PCB
 
     def __hash__(self):
         return hash(self.name)

--- a/sw/rocsync/clips.py
+++ b/sw/rocsync/clips.py
@@ -12,6 +12,7 @@ import numpy as np
 from tqdm import tqdm
 
 from rocsync.timecode import ms_to_timecode, timecode_to_ms, timecode_to_path_part
+from rocsync.timeline import frame_pts
 
 
 class Clip:
@@ -106,6 +107,20 @@ def select_frame_indices(
 # with the clip.
 MAX_FRAMES_IN_FLIGHT = 8
 
+SEEK_BACKOFF_FRAMES = 32  # retry margin for a seek that landed past the frame wanted
+
+
+def _grabbed_index(cap, timestamps, default):
+    """Index of the frame just grabbed, read off its own timestamp.
+
+    `default` stands in when there are no timestamps to compare against, which leaves
+    the seek trusted the way it always was.
+    """
+    if not timestamps:
+        return default
+    now = cap.get(cv2.CAP_PROP_POS_MSEC)
+    return min(range(len(timestamps)), key=lambda i: abs(timestamps[i] - now))
+
 
 def read_frames_at_indices(
     video_path: str,
@@ -126,6 +141,13 @@ def read_frames_at_indices(
     rather than re-reading them. Frames are not copied -- consumers that keep a
     frame beyond its iteration must copy it themselves.
 
+    Where the one seek lands is confirmed against the frame timestamps rather than
+    assumed: `CAP_PROP_POS_FRAMES` converts the index through the stream's average
+    frame rate, so a recording whose frames are not spaced at that rate -- anything
+    variable-rate, or cut from a faster source -- lands on a neighbour while still
+    reporting the index that was asked for, and every frame after it would then be
+    handed out under the wrong index.
+
     Stops early and warns if the source runs out of frames.
     """
     if not frame_indices:
@@ -138,13 +160,17 @@ def read_frames_at_indices(
     try:
         # Skipping to the first requested frame is the one seek worth doing.
         first = max(0, frame_indices[0])
+        starts = iter((first, max(first - SEEK_BACKOFF_FRAMES, 0), 0))
+        source_index = first
+        timestamps = []
         if first > 0:
-            cap.set(cv2.CAP_PROP_POS_FRAMES, first)
+            timestamps = frame_pts(video_path)
+            cap.set(cv2.CAP_PROP_POS_FRAMES, next(starts))
+            source_index = None  # where the seek landed, resolved off the first grab
 
         pbar = tqdm(total=len(frame_indices), desc=desc)
         try:
             out_index = 0
-            source_index = first
             while out_index < len(frame_indices):
                 if not cap.grab():
                     print(
@@ -152,6 +178,14 @@ def read_frames_at_indices(
                         f"{out_index}/{len(frame_indices)} requested frames"
                     )
                     return
+
+                if source_index is None:
+                    source_index = _grabbed_index(cap, timestamps, first)
+                    if source_index > first:
+                        # Overshot: seek again from further back, or give up and scan
+                        cap.set(cv2.CAP_PROP_POS_FRAMES, next(starts, 0))
+                        source_index = None
+                        continue
 
                 # Frames between two wanted ones are grabbed but never retrieved,
                 # which skips converting and copying them into an image. Sampling

--- a/sw/rocsync/timeline.py
+++ b/sw/rocsync/timeline.py
@@ -20,6 +20,8 @@ import numpy as np
 from sklearn.linear_model import LinearRegression, RANSACRegressor
 from sklearn.metrics import root_mean_squared_error
 
+from rocsync.video_statistics import VideoStatistics
+
 
 @dataclass
 class TimelineFit:
@@ -170,6 +172,104 @@ def fit_timeline(
         source_time_min=source_time_min,
         source_time_max=source_time_max,
     )
+
+
+def summarize_timeline(
+    timestamps,
+    frame_times,
+    n_frames,
+    fps,
+    window_frame_times=None,
+    timeline_windowed=False,
+):
+    """Fit board time against the container clock and describe the result.
+
+    Everything between a set of decoded timestamps and a finished `VideoStatistics`:
+    the frame period, the fit, the dropouts, each frame's residual and the split into
+    inliers and outliers. Shared with the benchmark, so what it measures is the
+    summary a real run produces rather than a copy of it.
+
+    `window_frame_times` lists the frames of each search window separately, because a
+    gap between two disjoint windows is not a dropout. Callers that scanned the whole
+    file can leave it out.
+
+    Returns (statistics, fit, considered, rejected, gaps). Raises ValueError when the
+    timeline cannot be fitted.
+    """
+    if len(timestamps) < 2:
+        raise ValueError("Insufficient number of timestamped frames.")
+    if not frame_times:
+        raise ValueError("No frames could be read.")
+
+    # Last-resort frame period only; the span is measured off the frames themselves
+    nominal_period = 1000 / fps if fps > 0 else None
+    period = median_frame_period(frame_times.values(), fallback=nominal_period)
+    if not period:
+        raise ValueError("Unable to determine the frame period.")
+
+    try:
+        fit = fit_timeline(frame_times, timestamps, fallback_period=nominal_period)
+    except ValueError as e:
+        raise ValueError(f"Unable to fit the frame timeline: {e}") from e
+
+    # Counted per window, so the span between disjoint windows is not a dropout
+    n_gaps = n_dropped_frames = 0
+    largest_gap_ms = 0.0
+    gaps = []
+    for window_times in window_frame_times or [frame_times]:
+        window_gaps, window_dropped, window_largest, found = detect_dropouts(
+            window_times.values(), period
+        )
+        n_gaps += window_gaps
+        n_dropped_frames += window_dropped
+        largest_gap_ms = max(largest_gap_ms, window_largest)
+        gaps.extend(found)
+
+    # Add error to timestamps, following the order the fit used
+    x = np.array([frame_times[k] for k in fit.order])
+    y = np.array([timestamps[k][0] for k in fit.order])
+    errors = fit.predict(x) - y
+    annotated_timestamps = {
+        frame_number: (*timestamps[frame_number], error)
+        for frame_number, error in zip(fit.order, errors, strict=True)
+    }
+
+    # Remove outliers
+    considered = {
+        k: annotated_timestamps[k]
+        for k, is_inlier in zip(fit.order, fit.inlier_mask, strict=True)
+        if is_inlier
+    }
+    rejected = {
+        k: annotated_timestamps[k]
+        for k, is_inlier in zip(fit.order, fit.inlier_mask, strict=True)
+        if not is_inlier
+    }
+
+    # Span anchored on frames actually present, so nothing is extrapolated
+    fit_stats = fit.to_dict()
+    pts_min, pts_max = min(frame_times.values()), max(frame_times.values())
+    exposure_times = [end - start for start, end, _ in considered.values()]
+    statistics = VideoStatistics(
+        n_frames=n_frames,
+        container_duration=pts_max - pts_min,
+        board_duration=fit_stats["last_frame"] - fit_stats["first_frame"],
+        nominal_fps=fps,
+        measured_fps=1000 / period,
+        median_frame_period=period,
+        n_gaps=n_gaps,
+        n_dropped_frames=n_dropped_frames,
+        largest_gap_ms=largest_gap_ms,
+        timeline_windowed=timeline_windowed,
+        mean_exposure_time=float(np.mean(exposure_times)),
+        min_exposure_time=float(np.min(exposure_times)),
+        max_exposure_time=float(np.max(exposure_times)),
+        std_exposure_time=float(np.std(exposure_times)),
+        considered_timestamps=considered,
+        rejected_timestamps=rejected,
+        **fit_stats,
+    )
+    return statistics, fit, considered, rejected, gaps
 
 
 def frame_pts(video_path):

--- a/sw/rocsync/timeline.py
+++ b/sw/rocsync/timeline.py
@@ -11,6 +11,7 @@ The result is a plain affine map, board_ms = clock_rate * pts_ms + clock_offset_
 is all any consumer needs in order to time a frame it has just decoded.
 """
 
+import subprocess
 from dataclasses import dataclass, field
 from itertools import pairwise
 from typing import cast
@@ -272,17 +273,97 @@ def summarize_timeline(
     return statistics, fit, considered, rejected, gaps
 
 
+def run_ffprobe(video_path, *args):
+    """stdout of an ffprobe query about a video's first video stream, or None.
+
+    None means ffprobe is missing or refused the file, which is what makes every caller
+    keep a way of its own to answer the question it asked.
+    """
+    try:
+        return subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0", *args, str(video_path)],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def probe_packet_field(video_path, field):
+    """Values of one ffprobe packet field, in packet order, as floats.
+
+    A packet carries the numbers the container already stores, so reading it needs no
+    decoder: ffprobe's `frame=` entries decode the file and cost seconds per video,
+    `packet=` does not.
+    """
+    output = run_ffprobe(video_path, "-show_entries", f"packet={field}", "-of", "csv=p=0")
+    # A packet the container left blank prints as 'N/A', which is not a number
+    fields = (line.strip().rstrip(",") for line in (output or "").splitlines())
+    return [float(f) for f in fields if _is_float(f)]
+
+
+def _is_float(text):
+    try:
+        float(text)
+    except ValueError:
+        return False
+    return True
+
+
+def _parse_ratio(text):
+    """A 'num/den' ffprobe ratio as a float, or None if it is not one."""
+    num, _, den = (text or "").partition("/")
+    try:
+        num, den = float(num), float(den)
+    except ValueError:
+        return None
+    return num / den if den else None
+
+
 def frame_pts(video_path):
     """Presentation timestamp in ms of every frame, indexed by frame number.
 
-    Uses grab() so frames are demuxed without decoding pixels, which makes this
-    cheap enough to run before picking frames out of a video.
+    Read off the container's packets, so no frame is decoded -- which is what makes this
+    cheap enough to run before picking frames out of a video. Decoding the whole file,
+    the fallback for a container ffprobe cannot read the packet timestamps of, costs
+    seconds per video.
 
-    OpenCV reports timestamps relative to the stream's start time, so a clip whose
-    container starts at 47 s still begins at 0.0 here. `clock_offset_ms` is defined
-    against this view, which is also the one `read_frames_async` feeds the pipeline; an
-    absolute container timestamp has to have the start time subtracted first.
+    The timestamps are stored as integer ticks of the stream's time base, and are turned
+    into ms here exactly the way the decoder does it, so the two agree bit for bit rather
+    than to within the microsecond that ffprobe prints seconds to.
+
+    Timestamps are relative to the stream's start time, so a clip whose container starts
+    at 47 s still begins at 0.0 here. `clock_offset_ms` is defined against this view,
+    which is also the one `read_frames_async` feeds the pipeline; an absolute container
+    timestamp has to have the start time subtracted first.
     """
+    output = run_ffprobe(
+        video_path,
+        "-show_entries",
+        "stream=time_base,start_pts:packet=pts",
+        "-of",
+        "default=noprint_wrappers=1",
+    )
+    ticks, stream = [], {}
+    for line in (output or "").splitlines():
+        name, _, value = line.partition("=")
+        if name == "pts" and _is_float(value):
+            ticks.append(float(value))
+        elif value and value != "N/A":
+            stream[name] = value
+
+    time_base = _parse_ratio(stream.get("time_base"))
+    if ticks and time_base is not None:
+        # Packets arrive in decode order, which B-frames make differ from display order
+        ticks.sort()
+        start = float(stream.get("start_pts", ticks[0]))
+        return [(t - start) * time_base * 1000 for t in ticks]
+    return _decoded_frame_pts(video_path)
+
+
+def _decoded_frame_pts(video_path):
+    """`frame_pts` the slow way, for a file ffprobe could not read the packets of."""
     cap = cv2.VideoCapture(str(video_path), cv2.CAP_FFMPEG)
     if not cap.isOpened():
         raise OSError(f"Could not open video: {video_path}")

--- a/sw/rocsync/timeline.py
+++ b/sw/rocsync/timeline.py
@@ -277,6 +277,11 @@ def frame_pts(video_path):
 
     Uses grab() so frames are demuxed without decoding pixels, which makes this
     cheap enough to run before picking frames out of a video.
+
+    OpenCV reports timestamps relative to the stream's start time, so a clip whose
+    container starts at 47 s still begins at 0.0 here. `clock_offset_ms` is defined
+    against this view, which is also the one `read_frames_async` feeds the pipeline; an
+    absolute container timestamp has to have the start time subtracted first.
     """
     cap = cv2.VideoCapture(str(video_path), cv2.CAP_FFMPEG)
     if not cap.isOpened():

--- a/sw/rocsync/video.py
+++ b/sw/rocsync/video.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 
 from rocsync.clips import MAX_FRAMES_IN_FLIGHT
 from rocsync.printer import errprint, print, printresult, warnprint
-from rocsync.timeline import detect_dropouts, fit_timeline, median_frame_period
+from rocsync.timeline import summarize_timeline
 from rocsync.video_statistics import VideoStatistics
 from rocsync.vision import CameraType, process_frame
 
@@ -270,9 +270,6 @@ def process_video(
     n_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
     cap.release()
 
-    # Last-resort frame period only; the span is measured off the frames themselves
-    nominal_period = 1000 / fps if fps > 0 else None
-
     # Whether the reported span and dropouts describe the file or just the windows
     timeline_windowed = bool(windows)
 
@@ -300,22 +297,18 @@ def process_video(
         frame_times.update(window_times)
         window_frame_times.append(window_times)
 
-    if len(timestamps) < 2:
-        errprint("Error: Insufficient number of timestamped frames.")
-        return
-    if not frame_times:
-        errprint("Error: No frames could be read.")
-        return
-
     # Fit board time against the frames' own presentation timestamps, both in ms
-    period = median_frame_period(frame_times.values(), fallback=nominal_period)
-    if not period:
-        errprint("Error: Unable to determine the frame period.")
-        return
     try:
-        fit = fit_timeline(frame_times, timestamps, fallback_period=nominal_period)
+        statistics, fit, filtered_timestamps, rejected_timestamps, gaps = summarize_timeline(
+            timestamps,
+            frame_times,
+            n_frames,
+            fps,
+            window_frame_times=window_frame_times,
+            timeline_windowed=timeline_windowed,
+        )
     except ValueError as e:
-        errprint(f"Error: Unable to fit the frame timeline: {e}")
+        errprint(f"Error: {e}")
         return
 
     if len(fit.order) < len(timestamps):
@@ -335,72 +328,16 @@ def process_video(
             f"expected approximately 1x."
         )
 
-    # Counted per window, so the span between disjoint windows is not a dropout
-    n_gaps = n_dropped_frames = 0
-    largest_gap_ms = 0.0
-    gaps = []
-    for window_times in window_frame_times:
-        window_gaps, window_dropped, window_largest, found = detect_dropouts(
-            window_times.values(), period
-        )
-        n_gaps += window_gaps
-        n_dropped_frames += window_dropped
-        largest_gap_ms = max(largest_gap_ms, window_largest)
-        gaps.extend(found)
-    if n_dropped_frames:
+    if statistics.n_dropped_frames:
         warnprint(
-            f"WARNING: {n_dropped_frames} frames missing from the container in "
-            f"{n_gaps} gap(s), largest {largest_gap_ms / 1000:.3f} s."
+            f"WARNING: {statistics.n_dropped_frames} frames missing from the container in "
+            f"{statistics.n_gaps} gap(s), largest {statistics.largest_gap_ms / 1000:.3f} s."
         )
-
-    # Add error to timestamps, following the order the fit used
-    x = np.array([frame_times[k] for k in fit.order])
-    y = np.array([timestamps[k][0] for k in fit.order])
-    errors = fit.predict(x) - y
-    annotated_timestamps = {
-        frame_number: (*timestamps[frame_number], error)
-        for frame_number, error in zip(fit.order, errors, strict=True)
-    }
-
-    # Remove outliers
-    filtered_timestamps = {
-        k: annotated_timestamps[k]
-        for k, is_inlier in zip(fit.order, fit.inlier_mask, strict=True)
-        if is_inlier
-    }
-    rejected_timestamps = {
-        k: annotated_timestamps[k]
-        for k, is_inlier in zip(fit.order, fit.inlier_mask, strict=True)
-        if not is_inlier
-    }
-
-    # Span anchored on frames actually present, so nothing is extrapolated
-    fit_stats = fit.to_dict()
-    pts_min, pts_max = min(frame_times.values()), max(frame_times.values())
-    exposure_times = [end - start for start, end, _ in filtered_timestamps.values()]
-    statistics = VideoStatistics(
-        n_frames=n_frames,
-        container_duration=pts_max - pts_min,
-        board_duration=fit_stats["last_frame"] - fit_stats["first_frame"],
-        nominal_fps=fps,
-        measured_fps=1000 / period,
-        median_frame_period=period,
-        n_gaps=n_gaps,
-        n_dropped_frames=n_dropped_frames,
-        largest_gap_ms=largest_gap_ms,
-        timeline_windowed=timeline_windowed,
-        mean_exposure_time=np.mean(exposure_times),
-        min_exposure_time=np.min(exposure_times),
-        max_exposure_time=np.max(exposure_times),
-        std_exposure_time=np.std(exposure_times),
-        considered_timestamps=filtered_timestamps,
-        rejected_timestamps=rejected_timestamps,
-        **fit_stats,
-    )
 
     print_statistics(statistics)
 
     if debug_dir:
+        exposure_times = [end - start for start, end, _ in filtered_timestamps.values()]
         plot_timechart(
             fit,
             filtered_timestamps,

--- a/sw/rocsync/vision.py
+++ b/sw/rocsync/vision.py
@@ -1,3 +1,5 @@
+import time
+
 import cv2
 import numpy as np
 
@@ -10,6 +12,42 @@ from rocsync.camera import CameraType
 from rocsync.printer import print
 
 MIN_ARUCO_AREA_FRACTION = 0.002  # smallest marker area, as a fraction of the frame
+
+ARUCO_DICTIONARY = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_50)
+
+# Keys `rocsync.benchmark` expects to find in a stats dict, whether or not the frame decoded.
+_STATS_KEYS = (
+    "aruco_id",
+    "aruco_corners",
+    "corner_positions",
+    "homography",
+    "rectified",
+    "counter_leds",
+    "ring_leds",
+    "timestamp",
+)
+
+
+def _init_stats(stats):
+    """Give the benchmark a fully populated dict even when the frame fails early."""
+    if stats is not None:
+        stats.setdefault("steps", {})
+        for key in _STATS_KEYS:
+            stats.setdefault(key, None)
+
+
+def _record_step(stats, name, t0, **fields):
+    """Record one pipeline step's wall time and outcome."""
+    if stats is not None:
+        stats["steps"][name] = {"time_ms": (time.perf_counter() - t0) * 1000, **fields}
+
+
+def _finalize_stats(stats, t0, success, timestamp):
+    """Close out a stats dict with the total wall time and the frame's result."""
+    if stats is not None:
+        stats["total_time_ms"] = (time.perf_counter() - t0) * 1000
+        stats["success"] = success
+        stats["timestamp"] = list(timestamp) if timestamp else None
 
 
 def _make_blob_detector():
@@ -29,10 +67,9 @@ def _make_blob_detector():
 
 def _make_aruco_detector():
     """ArUco detector for the board's identifying marker."""
-    dictionary = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_50)
     parameters = cv2.aruco.DetectorParameters()
     parameters.cornerRefinementMethod = cv2.aruco.CORNER_REFINE_NONE
-    return cv2.aruco.ArucoDetector(dictionary, parameters)
+    return cv2.aruco.ArucoDetector(ARUCO_DICTIONARY, parameters)
 
 
 blob_detector = _make_blob_detector()
@@ -58,8 +95,9 @@ def read_led(img, x, y, radius):
     return led_intensity
 
 
-def read_ring(extracted_board, camera_type, board, draw_on=None):
+def read_ring(extracted_board, camera_type, board, draw_on=None, stats=None):
     """Ring reading of a rectified board: first and last lit LED, or None."""
+    t_start = time.perf_counter()
     radius = board.led_sample_radius
     led_coords = board.ring_led_coords(camera_type).astype(int)
     bg_coords = board.ring_led_coords(camera_type, RING_BG_OFFSET_MM).astype(int)
@@ -80,11 +118,16 @@ def read_ring(extracted_board, camera_type, board, draw_on=None):
             color = (0, 0, 255) if state else (255, 0, 0)
             cv2.circle(draw_on, (x, y), radius, color, 1)
 
-    return board.decode_ring(leds)
+    ring = board.decode_ring(leds)
+    if stats is not None:
+        stats["ring_leds"] = leds
+    _record_step(stats, "ring_reading", t_start, success=ring is not None)
+    return ring
 
 
-def read_counter(extracted_board, camera_type, board, draw_on=None):
+def read_counter(extracted_board, camera_type, board, draw_on=None, stats=None):
     """Counter reading of a rectified board."""
+    t_start = time.perf_counter()
     led_coords = board.counter_led_coords[camera_type].astype(int)
     bg_y = int(board.counter_bg_y[camera_type])
     radius = board.led_sample_radius
@@ -111,7 +154,11 @@ def read_counter(extracted_board, camera_type, board, draw_on=None):
                 1,
             )
 
-    return board.decode_counter(leds)
+    counter = board.decode_counter(leds)
+    if stats is not None:
+        stats["counter_leds"] = leds
+    _record_step(stats, "counter_reading", t_start, value=counter)
+    return counter
 
 
 def find_corners_convexhull(mask, frame_number, debug_dir=None):
@@ -208,6 +255,7 @@ def rectify_board(
     board=None,
     debug_dir=None,
     board_size=DEFAULT_BOARD_SIZE,
+    stats=None,
 ):
     """Locate the board in a frame and warp it onto a square pixel grid.
 
@@ -215,10 +263,13 @@ def rectify_board(
     rectified single-channel image or None if it could not be squared up, and the
     RectifiedBoard the reading should be decoded against.
     """
+    _init_stats(stats)
     match camera_type:
         case CameraType.RGB:
             # Detect ArUco markers
+            t0 = time.perf_counter()
             markers = find_corners_aruco(image, frame_number, debug_dir)
+            _record_step(stats, "aruco_detection", t0, success=bool(markers), count=len(markers))
             if not markers:
                 return False, None, None
 
@@ -237,6 +288,10 @@ def rectify_board(
                     return False, None, board
                 aruco_corners = markers[board.aruco_marker_id]
 
+            if stats is not None:
+                stats["aruco_id"] = board.aruco_marker_id
+                stats["aruco_corners"] = aruco_corners.tolist()
+
             # Check if aruco marker fills x % of the image to make sure the PCB was held close enough
             area = 0
             for i in range(4):
@@ -247,6 +302,8 @@ def rectify_board(
             height, width = image.shape[:2]
             image_area = width * height
             area_percentage = area / image_area
+            if stats is not None:
+                stats["aruco_area_fraction"] = area_percentage
             if area_percentage < MIN_ARUCO_AREA_FRACTION:
                 print(
                     f"Rejected {frame_number}: aruco marker only fills {area_percentage:.2%} of the image"
@@ -263,9 +320,19 @@ def rectify_board(
             rough_pcb = cv2.warpPerspective(
                 mask, rough_transformation_matrix, (board_size, board_size)
             )
+            t0 = time.perf_counter()
             corners = find_corners_dots(rough_pcb, frame_number, board, debug_dir)
+            _record_step(
+                stats,
+                "corner_detection",
+                t0,
+                success=corners is not None,
+                count=0 if corners is None else len(corners),
+            )
             if corners is None:
                 return True, None, board
+            if stats is not None:
+                stats["corner_positions"] = corners.tolist()
 
             # Only the four anchors define the transform; any extra always-on dots were
             # matched purely as a sanity check.
@@ -273,7 +340,11 @@ def rectify_board(
                 cv2.getPerspectiveTransform(corners[:4], board.transform_corners(CameraType.RGB)),
                 rough_transformation_matrix,
             )
+            t0 = time.perf_counter()
             pcb = cv2.warpPerspective(mask, transformation_matrix, (board_size, board_size))
+            _record_step(stats, "fine_rectification", t0)
+            if stats is not None:
+                stats["homography"] = transformation_matrix
 
         case CameraType.INFRARED:
             if board is None:
@@ -301,6 +372,8 @@ def rectify_board(
         case _:
             raise ValueError(f"Unsupported camera type: {camera_type!r}")
 
+    if stats is not None:
+        stats["rectified"] = pcb
     return True, pcb, board
 
 
@@ -311,23 +384,27 @@ def process_frame(
     board=None,
     debug_dir=None,
     board_size=DEFAULT_BOARD_SIZE,
+    stats=None,
 ):
     """Board time (start_ms, end_ms) read off one frame, and whether a board was seen."""
+    t_start = time.perf_counter()
+    _init_stats(stats)
     detected, pcb, board = rectify_board(
-        image, camera_type, frame_number, board, debug_dir, board_size
+        image, camera_type, frame_number, board, debug_dir, board_size, stats
     )
     if pcb is None or board is None:
+        _finalize_stats(stats, t_start, detected, None)
         return detected, None
 
     # Sample the pristine board; overlays go onto a separate canvas
     debug_canvas = cv2.cvtColor(pcb, cv2.COLOR_GRAY2BGR) if debug_dir else None
 
-    counter = read_counter(pcb, camera_type, board, draw_on=debug_canvas)
-    ring = read_ring(pcb, camera_type, board, draw_on=debug_canvas)
+    counter = read_counter(pcb, camera_type, board, draw_on=debug_canvas, stats=stats)
+    ring = read_ring(pcb, camera_type, board, draw_on=debug_canvas, stats=stats)
 
     if debug_canvas is not None:
         cv2.imwrite(f"{debug_dir}/leds_{frame_number}.png", debug_canvas)
 
-    if ring is None:
-        return True, None
-    return True, board.board_time_from_ring(counter, ring)
+    board_time = board.board_time_from_ring(counter, ring) if ring is not None else None
+    _finalize_stats(stats, t_start, True, board_time)
+    return True, board_time

--- a/sw/rocsync/vision.py
+++ b/sw/rocsync/vision.py
@@ -61,8 +61,8 @@ def _make_blob_detector():
     params.blobColor = 255
 
     # Exclude elongated blobs caused by motion blur
-    params.filterByInertia = True
-    params.minInertiaRatio = 0.5
+    #params.filterByInertia = True
+    #params.minInertiaRatio = 0.5
 
     return cv2.SimpleBlobDetector.create(params)
 

--- a/sw/rocsync/vision.py
+++ b/sw/rocsync/vision.py
@@ -60,8 +60,8 @@ def _make_blob_detector():
     params.filterByColor = True
     params.blobColor = 255
 
-    # Exclude elongated blobs caused by motion blur
-    #params.filterByInertia = True
+    # Disabled: Exclude elongated blobs caused by motion blur
+    params.filterByInertia = False
     #params.minInertiaRatio = 0.5
 
     return cv2.SimpleBlobDetector.create(params)

--- a/sw/rocsync/vision.py
+++ b/sw/rocsync/vision.py
@@ -20,6 +20,7 @@ _STATS_KEYS = (
     "aruco_id",
     "aruco_corners",
     "corner_positions",
+    "rough_homography",
     "homography",
     "rectified",
     "counter_leds",
@@ -47,7 +48,8 @@ def _finalize_stats(stats, t0, success, timestamp):
     if stats is not None:
         stats["total_time_ms"] = (time.perf_counter() - t0) * 1000
         stats["success"] = success
-        stats["timestamp"] = list(timestamp) if timestamp else None
+        # int(): the readers work in numpy scalars, which json cannot serialize
+        stats["timestamp"] = [int(v) for v in timestamp] if timestamp else None
 
 
 def _make_blob_detector():
@@ -320,6 +322,9 @@ def rectify_board(
             rough_pcb = cv2.warpPerspective(
                 mask, rough_transformation_matrix, (board_size, board_size)
             )
+            if stats is not None:
+                # Corners are detected in this grid; the benchmark needs it to get back to image space
+                stats["rough_homography"] = rough_transformation_matrix
             t0 = time.perf_counter()
             corners = find_corners_dots(rough_pcb, frame_number, board, debug_dir)
             _record_step(

--- a/sw/rocsync/vision.py
+++ b/sw/rocsync/vision.py
@@ -61,9 +61,9 @@ def _make_blob_detector():
     params.filterByColor = True
     params.blobColor = 255
 
-    # Disabled: Exclude elongated blobs caused by motion blur
-    params.filterByInertia = False
-    # params.minInertiaRatio = 0.5
+    # Exclude elongated blobs caused by motion blur
+    params.filterByInertia = True
+    params.minInertiaRatio = 0.5
 
     return cv2.SimpleBlobDetector.create(params)
 

--- a/sw/rocsync/vision.py
+++ b/sw/rocsync/vision.py
@@ -25,6 +25,7 @@ _STATS_KEYS = (
     "rectified",
     "counter_leds",
     "ring_leds",
+    "ring_window",
     "timestamp",
 )
 
@@ -62,7 +63,7 @@ def _make_blob_detector():
 
     # Disabled: Exclude elongated blobs caused by motion blur
     params.filterByInertia = False
-    #params.minInertiaRatio = 0.5
+    # params.minInertiaRatio = 0.5
 
     return cv2.SimpleBlobDetector.create(params)
 
@@ -123,6 +124,10 @@ def read_ring(extracted_board, camera_type, board, draw_on=None, stats=None):
     ring = board.decode_ring(leds)
     if stats is not None:
         stats["ring_leds"] = leds
+        # The arc itself, so the benchmark can score reading it apart from the
+        # timestamp: an arc that wraps the period end is read correctly and still
+        # yields no time, because the counter changed while it was being exposed.
+        stats["ring_window"] = tuple(int(v) for v in ring) if ring is not None else None
     _record_step(stats, "ring_reading", t_start, success=ring is not None)
     return ring
 

--- a/sw/rocsync/vision.py
+++ b/sw/rocsync/vision.py
@@ -263,12 +263,16 @@ def rectify_board(
     debug_dir=None,
     board_size=DEFAULT_BOARD_SIZE,
     stats=None,
+    min_aruco_area_fraction=MIN_ARUCO_AREA_FRACTION,
 ):
     """Locate the board in a frame and warp it onto a square pixel grid.
 
     Returns (detected, pcb, board): whether the board was seen at all, the
     rectified single-channel image or None if it could not be squared up, and the
     RectifiedBoard the reading should be decoded against.
+
+    `min_aruco_area_fraction` rejects frames where the board was held too far away; pass 0
+    to read whatever the marker detector found, however small.
     """
     _init_stats(stats)
     match camera_type:
@@ -311,7 +315,7 @@ def rectify_board(
             area_percentage = area / image_area
             if stats is not None:
                 stats["aruco_area_fraction"] = area_percentage
-            if area_percentage < MIN_ARUCO_AREA_FRACTION:
+            if area_percentage < min_aruco_area_fraction:
                 print(
                     f"Rejected {frame_number}: aruco marker only fills {area_percentage:.2%} of the image"
                 )
@@ -395,12 +399,20 @@ def process_frame(
     debug_dir=None,
     board_size=DEFAULT_BOARD_SIZE,
     stats=None,
+    min_aruco_area_fraction=MIN_ARUCO_AREA_FRACTION,
 ):
     """Board time (start_ms, end_ms) read off one frame, and whether a board was seen."""
     t_start = time.perf_counter()
     _init_stats(stats)
     detected, pcb, board = rectify_board(
-        image, camera_type, frame_number, board, debug_dir, board_size, stats
+        image,
+        camera_type,
+        frame_number,
+        board,
+        debug_dir,
+        board_size,
+        stats,
+        min_aruco_area_fraction,
     )
     if pcb is None or board is None:
         _finalize_stats(stats, t_start, detected, None)

--- a/sw/tests/test_annotate.py
+++ b/sw/tests/test_annotate.py
@@ -1,0 +1,97 @@
+"""The annotation tool's corner fit.
+
+The rectified board view follows the corner LEDs the user has annotated, and four of
+them are enough — a v2 board hides one of its five often enough that waiting for all of
+them would leave the counter and ring unannotatable. What four is *not* enough for is a
+set whose board coordinates are collinear, which v2's LEDs 0, 1 and 4 are.
+"""
+
+import cv2
+import numpy as np
+import pytest
+
+from rocsync.benchmark.annotate import MIN_HOMOGRAPHY_CORNERS, fit_corner_homography
+from rocsync.board_profiles import PROFILES_BY_ARUCO
+from rocsync.camera import CameraType
+
+BOARDS = {p.name: p.rectify() for p in PROFILES_BY_ARUCO.values()}
+
+# An arbitrary but firmly perspective board pose, as image ← board.
+POSE = np.array(
+    [
+        [0.9, 0.15, 120.0],
+        [-0.1, 0.85, 260.0],
+        [2.0e-4, 1.5e-4, 1.0],
+    ]
+)
+
+
+def annotation_corners(board, visible):
+    """Corner annotations for `board` under POSE, with `visible` the visible indices."""
+    coords = np.array(board.always_on_leds[CameraType.RGB], dtype=np.float64)
+    image_pts = cv2.perspectiveTransform(coords.reshape(1, -1, 2), POSE).reshape(-1, 2)
+    return [
+        {"visible": i in visible, "position": [float(x), float(y)]}
+        for i, (x, y) in enumerate(image_pts)
+    ]
+
+
+def board_error(H, board, indices):
+    """Largest distance, in board pixels, between H's mapping and the modelled layout."""
+    corners = annotation_corners(board, set(indices))
+    src = np.array([corners[i]["position"] for i in indices], dtype=np.float64)
+    mapped = cv2.perspectiveTransform(src.reshape(1, -1, 2), H).reshape(-1, 2)
+    want = np.array([board.always_on_leds[CameraType.RGB][i] for i in indices])
+    return float(np.abs(mapped - want).max())
+
+
+@pytest.mark.parametrize("name", sorted(BOARDS))
+def test_too_few_corners_have_no_fit(name):
+    """Three points leave a projective map undetermined, so no fit is offered."""
+    board = BOARDS[name]
+    assert fit_corner_homography(annotation_corners(board, {0, 1, 2}), board) is None
+
+
+@pytest.mark.parametrize("name", sorted(BOARDS))
+def test_four_corners_fit_exactly(name):
+    """The minimum the tool now accepts, and it reproduces the pose it was built from."""
+    board = BOARDS[name]
+    indices = [0, 1, 2, 3]
+    H = fit_corner_homography(annotation_corners(board, set(indices)), board)
+    assert H is not None
+    assert board_error(H, board, indices) < 1e-3
+
+
+def test_a_collinear_corner_set_has_no_fit():
+    """v2's LEDs 0, 1 and 4 sit on one line: four points, but only three constraints."""
+    board = BOARDS["v2"]
+    indices = {0, 1, 2, 4}
+    assert len(indices) == MIN_HOMOGRAPHY_CORNERS
+    assert fit_corner_homography(annotation_corners(board, indices), board) is None
+
+
+def test_all_five_corners_fit_by_least_squares():
+    """The over-determined case still lands on the modelled layout."""
+    board = BOARDS["v2"]
+    indices = [0, 1, 2, 3, 4]
+    H = fit_corner_homography(annotation_corners(board, set(indices)), board)
+    assert H is not None
+    assert board_error(H, board, indices) < 1.0
+
+
+@pytest.mark.parametrize("hidden", [0, 1, 4])
+def test_one_hidden_corner_still_fits(hidden):
+    """v2 keeps a usable board view through the occlusions that leave a proper quad."""
+    board = BOARDS["v2"]
+    indices = [i for i in range(5) if i != hidden]
+    H = fit_corner_homography(annotation_corners(board, set(indices)), board)
+    assert H is not None
+    assert board_error(H, board, indices) < 1.0
+
+
+@pytest.mark.parametrize("hidden", [2, 3])
+def test_hiding_a_far_corner_leaves_a_collinear_set(hidden):
+    """Losing 2 or 3 leaves LEDs 0, 1 and 4 plus one — one line and a point, no fit."""
+    board = BOARDS["v2"]
+    indices = {i for i in range(5) if i != hidden}
+    assert fit_corner_homography(annotation_corners(board, indices), board) is None

--- a/sw/tests/test_benchmark_timeline.py
+++ b/sw/tests/test_benchmark_timeline.py
@@ -1,0 +1,142 @@
+"""The benchmark's video clock: fitting it, and scoring it against the reference.
+
+`summarize_timeline` is the production summarization the benchmark reuses, so the
+first case pins that the extraction still recovers a planted clock. The rest cover
+what `rocsync-evaluate` reports about it: an error is measured against the reference
+frozen in the ground truth, never against a fit recomputed here.
+"""
+
+import pytest
+
+from rocsync.benchmark.common import fit_reference_clock, frame_key
+from rocsync.benchmark.evaluate import compute_clock_metrics
+from rocsync.timeline import summarize_timeline
+
+VIDEO = "clips/take.mp4"
+PERIOD = 500.0  # ms between frames, i.e. 2 fps
+FPS = 2.0
+CLOCK_RATE = 1.000074
+CLOCK_OFFSET_MS = -4333.2
+EXPOSURE_MS = 8
+ARUCO_ID = 21
+BOARD_PERIOD = 100  # ring LEDs, so board time is counter * 100 + ring start
+
+
+def board_time(index):
+    return CLOCK_RATE * index * PERIOD + CLOCK_OFFSET_MS
+
+
+def as_annotation(start_ms):
+    """A ground truth entry whose counter and ring reconstruct to `start_ms`."""
+    counter, ring_start = divmod(round(start_ms), BOARD_PERIOD)
+    return {
+        "aruco": {"visible": True, "id": ARUCO_ID},
+        "counter": {"visible": True, "value": counter},
+        "ring": {"start": ring_start, "end": (ring_start + EXPOSURE_MS) % BOARD_PERIOD},
+    }
+
+
+def dataset(n=20, offset_error_ms=0.0, misdecoded=(), rejected=()):
+    """A ground truth and a matching results file, keyed the way the tools key them.
+
+    `offset_error_ms` shifts the results' fitted clock away from the reference,
+    `misdecoded` names frames the run read wrongly and `rejected` frames its fit threw
+    out, so outlier-rejection agreement can be checked both ways.
+    """
+    pts = {i: i * PERIOD for i in range(n)}
+    starts = {i: board_time(i) for i in range(n)}
+    reference = fit_reference_clock(starts, pts)
+    assert reference is not None
+
+    images = {}
+    predictions = {}
+    for i in range(n):
+        key = frame_key(VIDEO, i)
+        images[key] = as_annotation(starts[i])
+        decoded = starts[i] + (37 if i in misdecoded else 0)
+        predictions[key] = {
+            **as_annotation(decoded),
+            "pts_ms": pts[i],
+            "fit": {"residual_ms": 0.0, "inlier": i not in rejected},
+        }
+
+    ground_truth = {"images": images, "videos": {VIDEO: reference.to_dict()}}
+    benchmark = {
+        "images": predictions,
+        "videos": {
+            VIDEO: {
+                "clock_rate": reference.clock_rate,
+                "clock_offset_ms": reference.clock_offset_ms + offset_error_ms,
+                "rmse_after": 0.4,
+                "r2_after": 1.0,
+                "n_considered_frames": n - len(rejected),
+                "n_rejected_frames": len(rejected),
+                "n_dropped_frames": 0,
+                "error": None,
+            }
+        },
+    }
+    return ground_truth, benchmark
+
+
+def test_summarize_timeline_recovers_a_planted_clock():
+    frame_times = {i: i * PERIOD for i in range(60)}
+    timestamps = {i: (board_time(i), board_time(i) + EXPOSURE_MS) for i in range(60)}
+
+    statistics, fit, considered, rejected, gaps = summarize_timeline(
+        timestamps, frame_times, len(frame_times), FPS
+    )
+
+    assert fit.clock_rate == pytest.approx(CLOCK_RATE, abs=1e-9)
+    assert statistics.clock_offset_ms == pytest.approx(CLOCK_OFFSET_MS, abs=1e-6)
+    assert statistics.measured_fps == pytest.approx(FPS)
+    assert statistics.mean_exposure_time == pytest.approx(EXPOSURE_MS)
+    assert (len(considered), len(rejected), gaps) == (60, 0, [])
+
+
+def test_summarize_timeline_needs_two_timestamped_frames():
+    with pytest.raises(ValueError, match="Insufficient number of timestamped frames"):
+        summarize_timeline({0: (0.0, 1.0)}, {0: 0.0, 1: PERIOD}, 2, FPS)
+
+
+def test_a_matching_clock_scores_no_error():
+    ground_truth, benchmark = dataset()
+
+    metrics = compute_clock_metrics(benchmark, ground_truth)[VIDEO]
+
+    assert metrics["status"] is None
+    assert metrics["clock_rate_error_ppm"] == pytest.approx(0.0, abs=1e-6)
+    assert metrics["clock_offset_error_ms"] == pytest.approx(0.0, abs=1e-9)
+    assert metrics["sync_error_max_ms"] == pytest.approx(0.0, abs=1e-9)
+    assert metrics["residual_vs_gt_ms"]["n"] == 20
+
+
+def test_a_shifted_clock_is_off_by_that_shift_everywhere():
+    ground_truth, benchmark = dataset(offset_error_ms=12.5)
+
+    metrics = compute_clock_metrics(benchmark, ground_truth)[VIDEO]
+
+    assert metrics["clock_offset_error_ms"] == pytest.approx(12.5)
+    # A pure offset error does not decay along the recording
+    assert metrics["sync_error_first_ms"] == pytest.approx(12.5)
+    assert metrics["sync_error_last_ms"] == pytest.approx(12.5)
+    assert metrics["residual_vs_gt_ms"]["mean"] == pytest.approx(12.5, abs=0.5)
+
+
+def test_outlier_rejection_is_scored_against_the_annotations():
+    ground_truth, benchmark = dataset(misdecoded=(3, 4), rejected=(4, 9))
+
+    metrics = compute_clock_metrics(benchmark, ground_truth)[VIDEO]
+
+    assert metrics["false_rejections"] == 1  # frame 9 decoded correctly but was thrown out
+    assert metrics["false_acceptances"] == 1  # frame 3 was misdecoded but kept
+    assert metrics["n_flagged"] == 20
+
+
+def test_a_run_without_a_timeline_is_reported_rather_than_scored():
+    ground_truth, benchmark = dataset()
+    del benchmark["videos"]
+
+    assert compute_clock_metrics(benchmark, ground_truth) == {
+        VIDEO: {"status": "no video timeline recorded"}
+    }

--- a/sw/tests/test_benchmark_timeline.py
+++ b/sw/tests/test_benchmark_timeline.py
@@ -9,11 +9,16 @@ frozen in the ground truth, never against a fit recomputed here.
 import pytest
 
 from rocsync.benchmark.common import (
+    descriptive_stats,
     fit_reference_clock,
     frame_key,
     retimed_videos,
 )
-from rocsync.benchmark.evaluate import compute_clock_metrics, resolve_retimed_keys
+from rocsync.benchmark.evaluate import (
+    aggregate_clock_metrics,
+    compute_clock_metrics,
+    resolve_retimed_keys,
+)
 from rocsync.timeline import summarize_timeline
 
 VIDEO = "clips/take.mp4"
@@ -142,7 +147,7 @@ def test_a_matching_clock_scores_no_error():
     assert metrics["clock_rate_error_ppm"] == pytest.approx(0.0, abs=1e-6)
     assert metrics["clock_offset_error_ms"] == pytest.approx(0.0, abs=1e-9)
     assert metrics["sync_error_max_ms"] == pytest.approx(0.0, abs=1e-9)
-    assert metrics["residual_vs_gt_ms"]["n"] == 20
+    assert len(metrics["residuals_ms"]) == 20
 
 
 def test_a_shifted_clock_is_off_by_that_shift_everywhere():
@@ -154,7 +159,7 @@ def test_a_shifted_clock_is_off_by_that_shift_everywhere():
     # A pure offset error does not decay along the recording
     assert metrics["sync_error_first_ms"] == pytest.approx(12.5)
     assert metrics["sync_error_last_ms"] == pytest.approx(12.5)
-    assert metrics["residual_vs_gt_ms"]["mean"] == pytest.approx(12.5, abs=0.5)
+    assert descriptive_stats(metrics["residuals_ms"])["mean"] == pytest.approx(12.5, abs=0.5)
 
 
 def test_outlier_rejection_is_scored_against_the_annotations():
@@ -173,6 +178,7 @@ def test_a_run_without_a_timeline_is_reported_rather_than_scored():
 
     assert compute_clock_metrics(benchmark, ground_truth) == {
         VIDEO: {
+            "group": "measured",
             "status": "no video timeline recorded",
             "timeline": "measured",
             "residual_threshold_ms": THRESHOLD_MS,
@@ -189,7 +195,7 @@ def test_a_retimed_clip_is_scored_through_the_annotations_it_was_cut_from():
     assert metrics[RETIMED]["timeline"] == "synthesized"
     assert metrics[RETIMED]["sync_error_max_ms"] == pytest.approx(0.0, abs=1e-9)
     # The frames the trim cut have no prediction, so they are skipped rather than missed
-    assert metrics[RETIMED]["residual_vs_gt_ms"]["n"] == 20 - TRIMMED
+    assert len(metrics[RETIMED]["residuals_ms"]) == 20 - TRIMMED
 
 
 def test_a_misdecode_is_attributed_through_the_retiming():
@@ -201,3 +207,46 @@ def test_a_misdecode_is_attributed_through_the_retiming():
     assert metrics["false_acceptances"] == 1  # frame 7 was misdecoded but kept
     assert metrics["false_rejections"] == 1  # frame 9 decoded correctly but was thrown out
     assert metrics["n_flagged"] == 20 - TRIMMED
+
+
+def test_aggregation_splits_measured_from_retimed_videos():
+    """The two timelines answer different questions, so they never share a row."""
+    measured_gt, measured_bm = dataset()
+    retimed_gt, retimed_bm = retimed_dataset()
+    per_video = {
+        **compute_clock_metrics(measured_bm, measured_gt),
+        **compute_clock_metrics(retimed_bm, retimed_gt),
+    }
+
+    groups = aggregate_clock_metrics(per_video)
+
+    assert set(groups) == {"measured", "retimed"}
+    assert groups["measured"]["residual_vs_gt_ms"]["n"] == 20
+    assert groups["retimed"]["residual_vs_gt_ms"]["n"] == 20 - TRIMMED
+
+
+def test_aggregation_keeps_the_worst_video_and_sums_the_frame_counts():
+    per_video = {}
+    for name, offset_error_ms in (("a", 4.0), ("b", -12.5)):
+        ground_truth, benchmark = dataset(offset_error_ms=offset_error_ms, rejected=(9,))
+        per_video[name] = compute_clock_metrics(benchmark, ground_truth)[VIDEO]
+
+    group = aggregate_clock_metrics(per_video)["measured"]
+
+    assert (group["n_scored"], group["n_videos"]) == (2, 2)
+    assert group["clock_offset_error_ms_max_abs"] == pytest.approx(12.5)
+    assert group["clock_offset_error_ms_mean_abs"] == pytest.approx(8.25)
+    assert group["n_rejected_frames"] == 2  # one frame per video
+    assert group["n_flagged"] == 40
+    assert group["residual_vs_gt_ms"]["n"] == 40
+
+
+def test_aggregation_names_the_videos_it_could_not_score():
+    ground_truth, benchmark = dataset()
+    del benchmark["videos"]
+
+    group = aggregate_clock_metrics(compute_clock_metrics(benchmark, ground_truth))["measured"]
+
+    assert (group["n_scored"], group["n_videos"]) == (0, 1)
+    assert group["unscored"] == "no video timeline recorded (1)"
+    assert group["sync_error_max_ms"] is None

--- a/sw/tests/test_benchmark_timeline.py
+++ b/sw/tests/test_benchmark_timeline.py
@@ -8,15 +8,22 @@ frozen in the ground truth, never against a fit recomputed here.
 
 import pytest
 
-from rocsync.benchmark.common import fit_reference_clock, frame_key
-from rocsync.benchmark.evaluate import compute_clock_metrics
+from rocsync.benchmark.common import (
+    fit_reference_clock,
+    frame_key,
+    retimed_videos,
+)
+from rocsync.benchmark.evaluate import compute_clock_metrics, resolve_retimed_keys
 from rocsync.timeline import summarize_timeline
 
 VIDEO = "clips/take.mp4"
+RETIMED = "clips/take.retimed.mp4"
+TRIMMED = 4  # leading frames the retimed clip does not span
 PERIOD = 500.0  # ms between frames, i.e. 2 fps
 FPS = 2.0
 CLOCK_RATE = 1.000074
 CLOCK_OFFSET_MS = -4333.2
+THRESHOLD_MS = 2.0
 EXPOSURE_MS = 8
 ARUCO_ID = 21
 BOARD_PERIOD = 100  # ring LEDs, so board time is counter * 100 + ring start
@@ -60,7 +67,10 @@ def dataset(n=20, offset_error_ms=0.0, misdecoded=(), rejected=()):
             "fit": {"residual_ms": 0.0, "inlier": i not in rejected},
         }
 
-    ground_truth = {"images": images, "videos": {VIDEO: reference.to_dict()}}
+    ground_truth = {
+        "images": images,
+        "videos": {VIDEO: {**reference.to_dict(THRESHOLD_MS), "timeline": "measured"}},
+    }
     benchmark = {
         "images": predictions,
         "videos": {
@@ -77,6 +87,30 @@ def dataset(n=20, offset_error_ms=0.0, misdecoded=(), rejected=()):
         },
     }
     return ground_truth, benchmark
+
+
+def retimed_dataset(**kwargs):
+    """The same run, scored through a retimed clip that carries no annotations.
+
+    Its frames are the recording's from `TRIMMED` on, renumbered from zero, which is
+    what the stored mapping has to undo. The annotations stay exactly where they were.
+    """
+    ground_truth, benchmark = dataset(**kwargs)
+    ground_truth["videos"] = {
+        RETIMED: {
+            **ground_truth["videos"][VIDEO],
+            "timeline": "synthesized",
+            "source": VIDEO,
+            "source_frame_offset": TRIMMED,
+        }
+    }
+    benchmark["videos"] = {RETIMED: benchmark["videos"][VIDEO]}
+    source_images = benchmark["images"]
+    benchmark["images"] = {
+        frame_key(RETIMED, index - TRIMMED): source_images[frame_key(VIDEO, index)]
+        for index in range(TRIMMED, len(source_images))
+    }
+    return ground_truth, resolve_retimed_keys(benchmark, retimed_videos(ground_truth))
 
 
 def test_summarize_timeline_recovers_a_planted_clock():
@@ -138,5 +172,32 @@ def test_a_run_without_a_timeline_is_reported_rather_than_scored():
     del benchmark["videos"]
 
     assert compute_clock_metrics(benchmark, ground_truth) == {
-        VIDEO: {"status": "no video timeline recorded"}
+        VIDEO: {
+            "status": "no video timeline recorded",
+            "timeline": "measured",
+            "residual_threshold_ms": THRESHOLD_MS,
+        }
     }
+
+
+def test_a_retimed_clip_is_scored_through_the_annotations_it_was_cut_from():
+    ground_truth, benchmark = retimed_dataset()
+
+    metrics = compute_clock_metrics(benchmark, ground_truth)
+
+    assert VIDEO not in metrics  # scored once, through the clip that stands in for it
+    assert metrics[RETIMED]["timeline"] == "synthesized"
+    assert metrics[RETIMED]["sync_error_max_ms"] == pytest.approx(0.0, abs=1e-9)
+    # The frames the trim cut have no prediction, so they are skipped rather than missed
+    assert metrics[RETIMED]["residual_vs_gt_ms"]["n"] == 20 - TRIMMED
+
+
+def test_a_misdecode_is_attributed_through_the_retiming():
+    """A wrong read has to land on the annotation it contradicts, not on its neighbour."""
+    ground_truth, benchmark = retimed_dataset(misdecoded=(7,), rejected=(9,))
+
+    metrics = compute_clock_metrics(benchmark, ground_truth)[RETIMED]
+
+    assert metrics["false_acceptances"] == 1  # frame 7 was misdecoded but kept
+    assert metrics["false_rejections"] == 1  # frame 9 decoded correctly but was thrown out
+    assert metrics["n_flagged"] == 20 - TRIMMED

--- a/sw/tests/test_frame_keys.py
+++ b/sw/tests/test_frame_keys.py
@@ -1,0 +1,30 @@
+"""The identity that ground truth and benchmark results associate through.
+
+A key that formats or sorts differently silently splits one frame into two: the
+annotation lands under one string and the prediction under another, and evaluation
+scores the frame as a miss on both sides rather than reporting an error.
+"""
+
+from rocsync.benchmark.common import frame_key
+
+
+def test_still_image_key_is_its_relative_path():
+    assert frame_key("sub/img.png") == "sub/img.png"
+    assert frame_key("sub/img.png", None) == "sub/img.png"
+
+
+def test_video_frame_key_carries_a_padded_index():
+    assert frame_key("sub/clip.mp4", 0) == "sub/clip.mp4#000000"
+    assert frame_key("sub/clip.mp4", 42) == "sub/clip.mp4#000042"
+
+
+def test_keys_sort_in_frame_order():
+    """Padding exists for this; without it frame 100 would sort before frame 9."""
+    keys = [frame_key("clip.mp4", i) for i in range(151)]
+    assert sorted(keys) == keys
+
+
+def test_a_video_frame_sorts_next_to_its_own_file():
+    """`#` sorts below `.` and `/`, so frames never interleave with sibling names."""
+    keys = sorted(["clip.mp4#000001", "clip.mp4#000000", "clip.txt", "clip-other.mp4"])
+    assert keys == ["clip-other.mp4", "clip.mp4#000000", "clip.mp4#000001", "clip.txt"]

--- a/sw/tests/test_frame_keys.py
+++ b/sw/tests/test_frame_keys.py
@@ -5,7 +5,16 @@ annotation lands under one string and the prediction under another, and evaluati
 scores the frame as a miss on both sides rather than reporting an error.
 """
 
-from rocsync.benchmark.common import frame_key, parse_frame_key
+from rocsync.benchmark.common import frame_key, parse_frame_key, retimed_videos, source_key
+
+RETIMED = retimed_videos(
+    {
+        "videos": {
+            "clip.retimed.mp4": {"source": "clip.mp4", "source_frame_offset": 12},
+            "clip.mp4": {"timeline": "measured"},
+        }
+    }
+)
 
 
 def test_still_image_key_is_its_relative_path():
@@ -44,3 +53,22 @@ def test_only_the_last_separator_splits_the_key():
 def test_a_trailing_separator_without_an_index_is_part_of_the_path():
     assert parse_frame_key("clip.mp4#") == ("clip.mp4#", None)
     assert parse_frame_key("clip.mp4#abc") == ("clip.mp4#abc", None)
+
+
+def test_a_retimed_frame_resolves_to_the_annotation_it_was_cut_from():
+    """Annotations stay with the recording, so a retimed prediction has to reach back."""
+    assert source_key("clip.retimed.mp4#000000", RETIMED) == "clip.mp4#000012"
+    assert source_key("clip.retimed.mp4#000005", RETIMED) == "clip.mp4#000017"
+
+
+def test_source_key_round_trips_against_frame_key():
+    video = RETIMED["clip.retimed.mp4"]
+    for index in range(5):
+        key = source_key(frame_key(video.path, index), RETIMED)
+        assert parse_frame_key(key) == (video.source, index + video.frame_offset)
+
+
+def test_source_key_leaves_a_recording_and_a_still_alone():
+    assert source_key("clip.mp4#000003", RETIMED) == "clip.mp4#000003"
+    assert source_key("still.png", RETIMED) == "still.png"
+    assert source_key("clip.mp4#000003", {}) == "clip.mp4#000003"

--- a/sw/tests/test_frame_keys.py
+++ b/sw/tests/test_frame_keys.py
@@ -5,7 +5,7 @@ annotation lands under one string and the prediction under another, and evaluati
 scores the frame as a miss on both sides rather than reporting an error.
 """
 
-from rocsync.benchmark.common import frame_key
+from rocsync.benchmark.common import frame_key, parse_frame_key
 
 
 def test_still_image_key_is_its_relative_path():
@@ -28,3 +28,19 @@ def test_a_video_frame_sorts_next_to_its_own_file():
     """`#` sorts below `.` and `/`, so frames never interleave with sibling names."""
     keys = sorted(["clip.mp4#000001", "clip.mp4#000000", "clip.txt", "clip-other.mp4"])
     assert keys == ["clip-other.mp4", "clip.mp4#000000", "clip.mp4#000001", "clip.txt"]
+
+
+def test_a_key_round_trips_back_to_its_parts():
+    for rel_path, index in [("sub/img.png", None), ("sub/clip.mp4", 0), ("sub/clip.mp4", 42)]:
+        assert parse_frame_key(frame_key(rel_path, index)) == (rel_path, index)
+
+
+def test_only_the_last_separator_splits_the_key():
+    """A path may contain a `#` of its own; the index is always what follows the last."""
+    assert parse_frame_key("take #2/clip.mp4#000007") == ("take #2/clip.mp4", 7)
+    assert parse_frame_key("take #2/still.png") == ("take #2/still.png", None)
+
+
+def test_a_trailing_separator_without_an_index_is_part_of_the_path():
+    assert parse_frame_key("clip.mp4#") == ("clip.mp4#", None)
+    assert parse_frame_key("clip.mp4#abc") == ("clip.mp4#abc", None)

--- a/sw/tests/test_frame_source.py
+++ b/sw/tests/test_frame_source.py
@@ -1,0 +1,165 @@
+"""Video enumeration and the frame reads behind it.
+
+`FrameSource` reaches a frame by grabbing forward or by seeking depending on how far
+away it is, and either path can return the *wrong* frame rather than fail, so every read
+is checked against a plain sequential decode of the same file. Key formatting is covered
+by test_frame_keys, which needs no fixture.
+"""
+
+import shutil
+import subprocess
+
+import cv2
+import numpy as np
+import pytest
+
+from rocsync.benchmark.common import (
+    FORWARD_GRAB_LIMIT,
+    FRAME_CACHE_SIZE,
+    FrameRef,
+    FrameSource,
+    collect_frames,
+    count_video_frames,
+    frame_key,
+)
+
+N_FRAMES = 20
+FPS = 10
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="needs ffmpeg to synthesize the fixture"
+)
+
+
+@pytest.fixture(scope="module")
+def clip(tmp_path_factory):
+    """A short clip whose every frame differs, so a misread frame cannot pass."""
+    directory = tmp_path_factory.mktemp("frames")
+    path = directory / "clip.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            f"testsrc=size=64x48:rate={FPS}:duration={N_FRAMES / FPS:g}",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ],
+        check=True,
+    )
+    return path
+
+
+@pytest.fixture(scope="module")
+def expected(clip):
+    """Every frame of the clip, decoded front to back -- the reference to match."""
+    cap = cv2.VideoCapture(str(clip), cv2.CAP_FFMPEG)
+    frames = []
+    while True:
+        success, frame = cap.read()
+        if not success:
+            break
+        frames.append(frame)
+    cap.release()
+    assert len(frames) == N_FRAMES
+    return frames
+
+
+def _ref(clip, index):
+    return FrameRef(clip, index, frame_key(clip.name, index))
+
+
+def test_count_video_frames_matches_a_full_decode(clip, expected):
+    assert count_video_frames(clip) == len(expected)
+
+
+def test_sequential_read_returns_every_frame(clip, expected):
+    with FrameSource() as source:
+        for i, reference in enumerate(expected):
+            assert np.array_equal(source.read(_ref(clip, i)), reference), f"frame {i}"
+
+
+def test_stepping_back_returns_the_earlier_frame(clip, expected):
+    with FrameSource() as source:
+        source.read(_ref(clip, 5))
+        assert np.array_equal(source.read(_ref(clip, 4)), expected[4])
+
+
+def test_jumping_backwards_seeks_to_the_right_frame(clip, expected):
+    """Past the cache, so this exercises the seek rather than a cache hit."""
+    with FrameSource() as source:
+        for i in range(N_FRAMES):
+            source.read(_ref(clip, i))
+        assert np.array_equal(source.read(_ref(clip, 1)), expected[1])
+
+
+def test_jumping_far_forward_seeks_to_the_right_frame(clip, expected):
+    target = FORWARD_GRAB_LIMIT + 5
+    assert target < N_FRAMES, "fixture too short to pass the forward-grab limit"
+    with FrameSource() as source:
+        source.read(_ref(clip, 0))
+        assert np.array_equal(source.read(_ref(clip, target)), expected[target])
+
+
+def test_reading_the_same_frame_twice_is_stable(clip, expected):
+    with FrameSource() as source:
+        first = source.read(_ref(clip, 7))
+        assert first is not None
+        first = first.copy()
+        assert np.array_equal(source.read(_ref(clip, 7)), first)
+        assert np.array_equal(first, expected[7])
+
+
+def test_cache_stays_bounded(clip):
+    """A 4K frame is ~25 MB, so an unbounded cache would grow with the dataset."""
+    with FrameSource() as source:
+        for i in range(N_FRAMES):
+            source.read(_ref(clip, i))
+        assert len(source._cache) <= FRAME_CACHE_SIZE
+
+
+def test_out_of_range_frame_reads_as_none(clip):
+    with FrameSource() as source:
+        assert source.read(_ref(clip, N_FRAMES + 10)) is None
+
+
+# ── Enumeration ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def dataset(tmp_path, clip):
+    """A directory mixing a still image with a video, as a real dataset does."""
+    shutil.copy(clip, tmp_path / "clip.mp4")
+    cv2.imwrite(str(tmp_path / "still.png"), np.zeros((8, 8, 3), dtype=np.uint8))
+    return tmp_path
+
+
+def test_collect_frames_enumerates_images_and_every_video_frame(dataset):
+    frames = collect_frames(dataset)
+
+    expected_keys = [f"clip.mp4#{i:06d}" for i in range(N_FRAMES)] + ["still.png"]
+    assert [ref.key for ref in frames] == expected_keys
+    assert [ref.index for ref in frames[:N_FRAMES]] == list(range(N_FRAMES))
+    assert frames[-1].index is None
+
+
+def test_collect_frames_ignores_a_directory_named_like_a_video(dataset):
+    (dataset / "notavideo.mp4").mkdir()
+    assert len(collect_frames(dataset)) == N_FRAMES + 1
+
+
+def test_collect_frames_skips_an_unreadable_video(dataset):
+    (dataset / "broken.mp4").write_bytes(b"not a video")
+    frames = collect_frames(dataset)
+
+    # No key at all, so the annotator and the validator cannot disagree about it
+    assert not any("broken" in ref.key for ref in frames)
+    assert len(frames) == N_FRAMES + 1

--- a/sw/tests/test_frame_source.py
+++ b/sw/tests/test_frame_source.py
@@ -156,6 +156,24 @@ def test_collect_frames_ignores_a_directory_named_like_a_video(dataset):
     assert len(collect_frames(dataset)) == N_FRAMES + 1
 
 
+def test_a_retimed_clip_shadows_the_recording_it_was_cut_from(dataset):
+    """Otherwise the validator would benchmark the same footage twice over."""
+    shutil.copy(dataset / "clip.mp4", dataset / "clip.retimed.mp4")
+
+    videos = {ref.key.split("#")[0] for ref in collect_frames(dataset)}
+    assert "clip.retimed.mp4" in videos
+    assert "clip.mp4" not in videos
+
+
+def test_the_annotator_is_shown_the_recording_and_not_the_retimed_clip(dataset):
+    """A retimed clip is trimmed, so annotating it would put frames out of reach."""
+    shutil.copy(dataset / "clip.mp4", dataset / "clip.retimed.mp4")
+
+    videos = {ref.key.split("#")[0] for ref in collect_frames(dataset, sources_only=True)}
+    assert "clip.mp4" in videos
+    assert "clip.retimed.mp4" not in videos
+
+
 def test_collect_frames_skips_an_unreadable_video(dataset):
     (dataset / "broken.mp4").write_bytes(b"not a video")
     frames = collect_frames(dataset)

--- a/sw/tests/test_ground_truth.py
+++ b/sw/tests/test_ground_truth.py
@@ -25,9 +25,10 @@ import pytest
 from rocsync.benchmark.annotate import annotated_starts, derive_reference_clock, video_rel_paths
 from rocsync.benchmark.common import (
     MIN_REFERENCE_FRAMES,
-    REFERENCE_RESIDUAL_THRESHOLD_MS,
     ReferenceClock,
     collect_frames,
+    reference_outliers,
+    residual_threshold_ms,
 )
 from rocsync.board_profiles import PROFILES_BY_ARUCO
 from rocsync.camera import CameraType
@@ -119,13 +120,26 @@ def test_annotated_positions_are_image_space(annotations):
     )
 
 
+def clip_starts(images, rel_path, stored):
+    """Annotated board times in one clip's own frame numbering.
+
+    A retimed clip has no annotations of its own -- they stay with the recording it
+    was cut from -- so its stored mapping is what puts them back on its frames.
+    """
+    source = stored.get("source", rel_path)
+    offset = int(stored.get("source_frame_offset", 0))
+    return {index - offset: start for index, start in annotated_starts(images, source).items()}
+
+
 def test_every_reference_clock_still_fits_its_annotations(ground_truth):
-    """A stored reference clock reproduces, and no annotation contradicts it.
+    """No annotation contradicts the reference clock stored for its video.
 
     The evaluation measures fitted clocks against these numbers, so a residual beyond
-    the threshold means the reference is scoring against a frame that is itself wrong.
-    Deriving it here rather than trusting the file also catches annotations edited
-    without re-running `rocsync-annotate --fit-clocks`.
+    the video's tolerance means the reference is scoring against a frame that is itself
+    wrong. A measured reference is additionally re-derived here rather than trusted,
+    which catches annotations edited without re-running `rocsync-annotate --fit-clocks`;
+    a synthesized one is drawn rather than fitted, so the annotations are what it has to
+    answer to, not a least-squares line through them.
     """
     references = ground_truth.get("videos", {})
     if not references:
@@ -133,15 +147,20 @@ def test_every_reference_clock_still_fits_its_annotations(ground_truth):
 
     for rel_path, stored in references.items():
         pts = dict(enumerate(frame_pts(GROUND_TRUTH.parent / rel_path)))
-        clock, outliers = derive_reference_clock(ground_truth["images"], rel_path, pts)
+        threshold = residual_threshold_ms(stored)
+        starts = clip_starts(ground_truth["images"], rel_path, stored)
+        outliers = reference_outliers(ReferenceClock.from_dict(stored), starts, pts, threshold)
 
-        assert clock is not None, f"{rel_path}: too few annotations to re-derive"
+        assert len(starts) >= MIN_REFERENCE_FRAMES, f"{rel_path}: too few annotations to check"
         assert not outliers, (
-            f"{rel_path}: {len(outliers)} annotated frame(s) beyond "
-            f"{REFERENCE_RESIDUAL_THRESHOLD_MS} ms:\n  "
+            f"{rel_path}: {len(outliers)} annotated frame(s) beyond {threshold:.2f} ms:\n  "
             + "\n  ".join(f"#{i:06d} {residual:+.2f} ms" for i, residual in outliers[:20])
         )
-        assert clock == ReferenceClock.from_dict(stored), (
+        if stored.get("timeline") == "synthesized":
+            continue
+
+        derived, _ = derive_reference_clock(starts, pts, threshold)
+        assert derived == ReferenceClock.from_dict(stored), (
             f"{rel_path}: stored reference does not match the annotations it claims to "
             f"describe; re-run `rocsync-annotate --fit-clocks`"
         )
@@ -149,7 +168,7 @@ def test_every_reference_clock_still_fits_its_annotations(ground_truth):
 
 def test_every_sufficiently_annotated_video_has_a_reference_clock(ground_truth):
     """A video the evaluation could score must not be silently unscored."""
-    frames = collect_frames(GROUND_TRUTH.parent)
+    frames = collect_frames(GROUND_TRUTH.parent, sources_only=True)
     references = ground_truth.get("videos", {})
 
     missing = [

--- a/sw/tests/test_ground_truth.py
+++ b/sw/tests/test_ground_truth.py
@@ -1,0 +1,106 @@
+"""Check a ground truth file against itself.
+
+Each annotation carries corner LED positions in image space and a homography, and the
+evaluation relies on the two describing the same board pose: warping the modelled LED
+layout through the homography must land on the annotated positions. Both ways of
+producing an annotation make that exact rather than approximate — a four-point
+``getPerspectiveTransform`` fit has no residual, and the pipeline's fine transform is
+built from the same corners it reports — so this pins an invariant rather than measuring
+agreement. It earns its keep by catching a file whose positions were edited without
+recomputing the homography, and it becomes a real least-squares check on v2 boards,
+whose fifth always-on LED over-determines the fit.
+
+The dataset lives outside the repository, so the test skips when it is absent. Point
+ROCSYNC_GROUND_TRUTH at a ground_truth.json to run it elsewhere.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from rocsync.board_profiles import PROFILES_BY_ARUCO
+from rocsync.camera import CameraType
+
+GROUND_TRUTH = Path(
+    os.environ.get(
+        "ROCSYNC_GROUND_TRUTH", "/home/jonas/datasets/rocsync_benchmark/ground_truth.json"
+    )
+)
+
+# Exact for a four-point fit; the slack covers v2's least-squares fit over five LEDs.
+TOL_PX = 2.0
+
+pytestmark = pytest.mark.skipif(
+    not GROUND_TRUTH.is_file(), reason=f"ground truth not available at {GROUND_TRUTH}"
+)
+
+
+@pytest.fixture(scope="module")
+def annotations():
+    with open(GROUND_TRUTH) as f:
+        return json.load(f)["images"]
+
+
+def _nominal_in_image(gt):
+    """Modelled corner LED layout warped into image space, or None if not derivable."""
+    H = gt.get("homography")
+    aruco_id = gt.get("aruco", {}).get("id")
+    if H is None or aruco_id not in PROFILES_BY_ARUCO:
+        return None
+    board = PROFILES_BY_ARUCO[aruco_id].rectify()
+    inv_H = np.linalg.inv(np.array(H, dtype=np.float64))
+    pts = np.array([board.always_on_leds[CameraType.RGB]], dtype=np.float64)
+    return cv2.perspectiveTransform(pts, inv_H).reshape(-1, 2)
+
+
+def test_annotated_corners_match_the_warped_layout(annotations):
+    """The homography and the annotated positions describe the same board pose.
+
+    Evaluation compares predictions against the annotated positions; this is what
+    licenses that, rather than reprojecting the modelled layout instead.
+    """
+    offenders = []
+    compared = 0
+
+    for key, gt in annotations.items():
+        nominal = _nominal_in_image(gt)
+        if nominal is None:
+            continue
+        for i, corner in enumerate(gt.get("corners", [])):
+            if not corner.get("visible") or corner.get("position") is None:
+                continue
+            if i >= len(nominal):
+                continue
+            err = float(np.linalg.norm(np.array(corner["position"], dtype=np.float64) - nominal[i]))
+            compared += 1
+            if err > TOL_PX:
+                offenders.append(f"{key} corner {i}: {err:.2f} px")
+
+    assert compared > 0, "no annotated corner had a homography to check against"
+    assert not offenders, (
+        f"{len(offenders)}/{compared} annotated corners disagree with the warped layout "
+        f"by more than {TOL_PX} px:\n  " + "\n  ".join(offenders[:20])
+    )
+
+
+def test_annotated_positions_are_image_space(annotations):
+    """Positions are image coordinates, not the 640 px rectified grid.
+
+    The two spaces are easy to confuse and a file in the wrong one would still load.
+    Real frames are far larger than the board grid, so the spread gives it away.
+    """
+    xs = [
+        c["position"][0]
+        for gt in annotations.values()
+        for c in gt.get("corners", [])
+        if c.get("visible") and c.get("position") is not None
+    ]
+    assert xs, "no annotated corner positions found"
+    assert max(xs) > 640, (
+        f"all annotated x coordinates fall within {max(xs):.0f} px; "
+        "the file may hold rectified board coordinates instead of image coordinates"
+    )

--- a/sw/tests/test_ground_truth.py
+++ b/sw/tests/test_ground_truth.py
@@ -22,8 +22,16 @@ import cv2
 import numpy as np
 import pytest
 
+from rocsync.benchmark.annotate import annotated_starts, derive_reference_clock, video_rel_paths
+from rocsync.benchmark.common import (
+    MIN_REFERENCE_FRAMES,
+    REFERENCE_RESIDUAL_THRESHOLD_MS,
+    ReferenceClock,
+    collect_frames,
+)
 from rocsync.board_profiles import PROFILES_BY_ARUCO
 from rocsync.camera import CameraType
+from rocsync.timeline import frame_pts
 
 GROUND_TRUTH = Path(
     os.environ.get(
@@ -40,9 +48,14 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture(scope="module")
-def annotations():
+def ground_truth():
     with open(GROUND_TRUTH) as f:
-        return json.load(f)["images"]
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def annotations(ground_truth):
+    return ground_truth["images"]
 
 
 def _nominal_in_image(gt):
@@ -103,4 +116,51 @@ def test_annotated_positions_are_image_space(annotations):
     assert max(xs) > 640, (
         f"all annotated x coordinates fall within {max(xs):.0f} px; "
         "the file may hold rectified board coordinates instead of image coordinates"
+    )
+
+
+def test_every_reference_clock_still_fits_its_annotations(ground_truth):
+    """A stored reference clock reproduces, and no annotation contradicts it.
+
+    The evaluation measures fitted clocks against these numbers, so a residual beyond
+    the threshold means the reference is scoring against a frame that is itself wrong.
+    Deriving it here rather than trusting the file also catches annotations edited
+    without re-running `rocsync-annotate --fit-clocks`.
+    """
+    references = ground_truth.get("videos", {})
+    if not references:
+        pytest.skip("no reference clocks in this ground truth")
+
+    for rel_path, stored in references.items():
+        pts = dict(enumerate(frame_pts(GROUND_TRUTH.parent / rel_path)))
+        clock, outliers = derive_reference_clock(ground_truth["images"], rel_path, pts)
+
+        assert clock is not None, f"{rel_path}: too few annotations to re-derive"
+        assert not outliers, (
+            f"{rel_path}: {len(outliers)} annotated frame(s) beyond "
+            f"{REFERENCE_RESIDUAL_THRESHOLD_MS} ms:\n  "
+            + "\n  ".join(f"#{i:06d} {residual:+.2f} ms" for i, residual in outliers[:20])
+        )
+        assert clock == ReferenceClock.from_dict(stored), (
+            f"{rel_path}: stored reference does not match the annotations it claims to "
+            f"describe; re-run `rocsync-annotate --fit-clocks`"
+        )
+
+
+def test_every_sufficiently_annotated_video_has_a_reference_clock(ground_truth):
+    """A video the evaluation could score must not be silently unscored."""
+    frames = collect_frames(GROUND_TRUTH.parent)
+    references = ground_truth.get("videos", {})
+
+    missing = [
+        rel_path
+        for rel_path in video_rel_paths(frames)
+        if rel_path not in references
+        and len(annotated_starts(ground_truth["images"], rel_path)) >= MIN_REFERENCE_FRAMES
+    ]
+
+    assert not missing, (
+        "videos with enough annotations but no reference clock: "
+        + ", ".join(missing)
+        + "; run `rocsync-annotate --fit-clocks`"
     )

--- a/sw/tests/test_reference_clock.py
+++ b/sw/tests/test_reference_clock.py
@@ -7,18 +7,28 @@ measured against a fit that does not contain it, so a single bad annotation show
 full error instead of dragging the line towards itself and hiding half of it.
 """
 
+import shutil
+import subprocess
+
 import pytest
 
 from rocsync.benchmark.common import (
+    MEASURED_RESIDUAL_MAX_MS,
+    MEASURED_RESIDUAL_MIN_MS,
     MIN_REFERENCE_FRAMES,
-    REFERENCE_RESIDUAL_THRESHOLD_MS,
+    SYNTHESIZED_RESIDUAL_THRESHOLD_MS,
     ReferenceClock,
     fit_reference_clock,
+    measured_residual_threshold_ms,
     reference_outliers,
     reference_residual,
+    residual_threshold_ms,
+    source_frame_period_ms,
 )
+from rocsync.timeline import frame_pts, median_frame_period
 
 PERIOD = 500.0  # ms between frames
+THRESHOLD_MS = 2.0
 CLOCK_RATE = 1.000074
 CLOCK_OFFSET_MS = -4333.2
 
@@ -52,7 +62,7 @@ def test_fit_recovers_the_clock_it_was_generated_from():
     assert clock.n_frames_fitted == 20
     assert clock.rmse_ms == pytest.approx(0.0, abs=1e-6)
     assert (clock.pts_min_ms, clock.pts_max_ms) == (0.0, 19 * PERIOD)
-    assert reference_outliers(clock, starts, pts) == []
+    assert reference_outliers(clock, starts, pts, THRESHOLD_MS) == []
 
 
 def test_fit_needs_more_than_a_handful_of_frames():
@@ -69,7 +79,7 @@ def test_a_shifted_annotation_is_the_only_outlier():
     starts, pts = timeline()
     starts[7] += 15.0
 
-    outliers = reference_outliers(fitted(starts, pts), starts, pts)
+    outliers = reference_outliers(fitted(starts, pts), starts, pts, THRESHOLD_MS)
 
     assert [index for index, _ in outliers] == [7]
 
@@ -84,14 +94,70 @@ def test_leave_one_out_shows_the_full_error_of_a_bad_frame():
     # and it is the only frame the leave-one-out fit disagrees with
     for index in starts:
         if index != 7:
-            assert (
-                abs(residual(starts, pts, index, exclude=index)) < REFERENCE_RESIDUAL_THRESHOLD_MS
-            )
+            assert abs(residual(starts, pts, index, exclude=index)) < THRESHOLD_MS
 
 
 def test_round_trips_through_a_dict():
     clock = fitted(*timeline())
-    restored = ReferenceClock.from_dict(clock.to_dict())
+    restored = ReferenceClock.from_dict(clock.to_dict(THRESHOLD_MS))
 
     assert restored == clock
-    assert clock.to_dict()["residual_threshold_ms"] == REFERENCE_RESIDUAL_THRESHOLD_MS
+    assert clock.to_dict(THRESHOLD_MS)["residual_threshold_ms"] == THRESHOLD_MS
+
+
+# ── Per-video tolerance ─────────────────────────────────────────────────────
+
+
+def test_the_measured_tolerance_is_a_third_of_a_source_frame():
+    assert measured_residual_threshold_ms(33.333) == pytest.approx(11.111, abs=1e-3)
+
+
+def test_the_measured_tolerance_is_clamped_at_both_ends():
+    # A 240 fps camera would ask for less than the board itself resolves
+    assert measured_residual_threshold_ms(1000 / 240) == MEASURED_RESIDUAL_MIN_MS
+    # and a 2 fps one for more than a ring period, which would hide a counter step
+    assert measured_residual_threshold_ms(500.0) == MEASURED_RESIDUAL_MAX_MS
+    # An unreadable frame rate falls back to the loosest tolerance rather than the tightest
+    assert measured_residual_threshold_ms(None) == MEASURED_RESIDUAL_MAX_MS
+
+
+def test_a_synthesized_timeline_is_held_to_one_led_at_each_end():
+    entry = {"timeline": "synthesized", "source_frame_period_ms": 33.333}
+    assert residual_threshold_ms(entry) == SYNTHESIZED_RESIDUAL_THRESHOLD_MS
+
+
+def test_a_measured_timeline_is_held_to_its_own_frame_rate():
+    entry = {"timeline": "measured", "source_frame_period_ms": 33.333}
+    assert residual_threshold_ms(entry) == pytest.approx(11.111, abs=1e-3)
+
+
+def test_a_stored_tolerance_outranks_the_rule_of_the_day():
+    """A frozen reference stays valid under the rule it was frozen by."""
+    entry = {"timeline": "measured", "source_frame_period_ms": 33.333}
+    assert residual_threshold_ms({**entry, "residual_threshold_ms": 7.5}) == 7.5
+
+
+@pytest.fixture(scope="module")
+def decimated_clip(tmp_path_factory):
+    """Every 16th frame of a 30 fps recording, the shape the dataset's clips have."""
+    directory = tmp_path_factory.mktemp("decimated")
+    source, decimated = directory / "src.mp4", directory / "decimated.mp4"
+    common = ["ffmpeg", "-y", "-loglevel", "error"]
+    subprocess.run(
+        [*common, "-f", "lavfi", "-i", "testsrc=size=64x48:rate=30:duration=4",
+         "-c:v", "libx264", "-pix_fmt", "yuv420p", str(source)],
+        check=True,
+    )  # fmt: skip
+    subprocess.run(
+        [*common, "-i", str(source), "-vf", "select='not(mod(n,16))'",
+         "-fps_mode", "passthrough", "-c:v", "libx264", str(decimated)],
+        check=True,
+    )  # fmt: skip
+    return decimated
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="needs ffmpeg to synthesize the clip")
+def test_the_source_frame_period_survives_decimation(decimated_clip):
+    """The clip's timestamps sit 533 ms apart, but its packets still say 33.3 ms."""
+    assert median_frame_period(frame_pts(decimated_clip)) == pytest.approx(533, abs=1)
+    assert source_frame_period_ms(decimated_clip) == pytest.approx(1000 / 30, abs=0.1)

--- a/sw/tests/test_reference_clock.py
+++ b/sw/tests/test_reference_clock.py
@@ -1,0 +1,97 @@
+"""The reference clock the benchmark scores against.
+
+It is fitted by plain least squares rather than the production RANSAC, so the ground
+truth cannot move when the production fitter changes, and no outlier is tolerated. The
+annotator leans on the leave-one-out property pinned here: a frame's residual is
+measured against a fit that does not contain it, so a single bad annotation shows its
+full error instead of dragging the line towards itself and hiding half of it.
+"""
+
+import pytest
+
+from rocsync.benchmark.common import (
+    MIN_REFERENCE_FRAMES,
+    REFERENCE_RESIDUAL_THRESHOLD_MS,
+    ReferenceClock,
+    fit_reference_clock,
+    reference_outliers,
+    reference_residual,
+)
+
+PERIOD = 500.0  # ms between frames
+CLOCK_RATE = 1.000074
+CLOCK_OFFSET_MS = -4333.2
+
+
+def fitted(starts, pts, exclude=None):
+    """`fit_reference_clock` where the caller has already ensured it succeeds."""
+    clock = fit_reference_clock(starts, pts, exclude=exclude)
+    assert clock is not None
+    return clock
+
+
+def residual(starts, pts, index, exclude=None):
+    value = reference_residual(fitted(starts, pts, exclude=exclude), index, starts, pts)
+    assert value is not None
+    return value
+
+
+def timeline(n=20):
+    """Frame pts and the board times an exact clock would put them at."""
+    pts = {i: i * PERIOD for i in range(n)}
+    starts = {i: CLOCK_RATE * p + CLOCK_OFFSET_MS for i, p in pts.items()}
+    return starts, pts
+
+
+def test_fit_recovers_the_clock_it_was_generated_from():
+    starts, pts = timeline()
+    clock = fitted(starts, pts)
+
+    assert clock.clock_rate == pytest.approx(CLOCK_RATE, abs=1e-9)
+    assert clock.clock_offset_ms == pytest.approx(CLOCK_OFFSET_MS, abs=1e-6)
+    assert clock.n_frames_fitted == 20
+    assert clock.rmse_ms == pytest.approx(0.0, abs=1e-6)
+    assert (clock.pts_min_ms, clock.pts_max_ms) == (0.0, 19 * PERIOD)
+    assert reference_outliers(clock, starts, pts) == []
+
+
+def test_fit_needs_more_than_a_handful_of_frames():
+    starts, pts = timeline(MIN_REFERENCE_FRAMES - 1)
+    assert fit_reference_clock(starts, pts) is None
+
+
+def test_fit_needs_two_distinct_presentation_timestamps():
+    starts, pts = timeline()
+    assert fit_reference_clock(starts, dict.fromkeys(pts, 0.0)) is None
+
+
+def test_a_shifted_annotation_is_the_only_outlier():
+    starts, pts = timeline()
+    starts[7] += 15.0
+
+    outliers = reference_outliers(fitted(starts, pts), starts, pts)
+
+    assert [index for index, _ in outliers] == [7]
+
+
+def test_leave_one_out_shows_the_full_error_of_a_bad_frame():
+    starts, pts = timeline()
+    starts[7] += 15.0
+
+    # Included, the frame drags the line towards itself and under-reports its own error
+    assert abs(residual(starts, pts, 7)) < 15.0
+    assert residual(starts, pts, 7, exclude=7) == pytest.approx(-15.0, abs=1e-6)
+    # and it is the only frame the leave-one-out fit disagrees with
+    for index in starts:
+        if index != 7:
+            assert (
+                abs(residual(starts, pts, index, exclude=index)) < REFERENCE_RESIDUAL_THRESHOLD_MS
+            )
+
+
+def test_round_trips_through_a_dict():
+    clock = fitted(*timeline())
+    restored = ReferenceClock.from_dict(clock.to_dict())
+
+    assert restored == clock
+    assert clock.to_dict()["residual_threshold_ms"] == REFERENCE_RESIDUAL_THRESHOLD_MS

--- a/sw/tests/test_retime.py
+++ b/sw/tests/test_retime.py
@@ -1,0 +1,196 @@
+"""Retimed benchmark clips: the timeline is rewritten, the pixels are not.
+
+A recording's container timestamps are a nominal grid the sensor only approximates, which
+puts a floor of several milliseconds under any clock fitted against them. `rocsync-retime`
+removes that floor by making the annotated board times the timeline, so the clock a
+benchmark run has to recover is known exactly. Two properties carry the whole idea and are
+pinned here: every anchor lands on the recorded clock to well under the 2 ms tolerance, and
+every frame is bit-identical to the one it was copied from -- without which the corner,
+homography and LED annotations the clip is built from would no longer describe it.
+"""
+
+import itertools
+import json
+import shutil
+import subprocess
+
+import cv2
+import numpy as np
+import pytest
+
+from rocsync.benchmark.common import (
+    SYNTHESIZED_RESIDUAL_THRESHOLD_MS,
+    annotated_board_time,
+    frame_key,
+    retimed_videos,
+    source_key,
+)
+from rocsync.benchmark.retime import RetimeError, retime_video
+from rocsync.timeline import frame_pts
+
+av = pytest.importorskip("av", reason="rocsync-retime needs PyAV")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="needs ffmpeg to synthesize the fixture"
+)
+
+VIDEO = "clips/take.mp4"
+RETIMED = "clips/take.retimed.mp4"
+N_FRAMES = 40
+FPS = 20
+ARUCO_ID = 21
+BOARD_PERIOD = 100  # ring LEDs, so board time is counter * 100 + ring start
+EXPOSURE_MS = 8
+FIRST_ANCHOR, LAST_ANCHOR, ANCHOR_STRIDE = 4, 36, 4
+BOARD_START_MS = 61_000.0  # a plausible board time, far from zero
+
+
+def as_annotation(board_ms):
+    """A ground truth entry whose counter and ring reconstruct to `board_ms`."""
+    counter, ring_start = divmod(round(board_ms), BOARD_PERIOD)
+    return {
+        "aruco": {"visible": True, "id": ARUCO_ID},
+        "counter": {"visible": True, "value": counter},
+        "ring": {"start": ring_start, "end": (ring_start + EXPOSURE_MS) % BOARD_PERIOD},
+    }
+
+
+@pytest.fixture
+def dataset(tmp_path):
+    """A clip whose every frame differs, annotated on every fourth frame.
+
+    The board advances a little faster than the container thinks it does, so a retimer
+    that ignored the annotations and merely copied the timeline would be caught.
+    """
+    (tmp_path / "clips").mkdir()
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-loglevel", "error",
+            "-f", "lavfi", "-i", f"testsrc=size=64x48:rate={FPS}:duration={N_FRAMES / FPS:g}",
+            "-c:v", "libx264", "-pix_fmt", "yuv420p", str(tmp_path / VIDEO),
+        ],
+        check=True,
+    )  # fmt: skip
+
+    pts = frame_pts(tmp_path / VIDEO)
+    images = {
+        frame_key(VIDEO, index): as_annotation(BOARD_START_MS + 1.004 * pts[index])
+        for index in range(FIRST_ANCHOR, LAST_ANCHOR + 1, ANCHOR_STRIDE)
+    }
+    return tmp_path, {"images": images, "videos": {}}
+
+
+def read_all(path):
+    """Every frame of a clip, decoded front to back."""
+    cap = cv2.VideoCapture(str(path), cv2.CAP_FFMPEG)
+    frames = []
+    while True:
+        success, frame = cap.read()
+        if not success:
+            break
+        frames.append(frame)
+    cap.release()
+    return frames
+
+
+def anchor_board_times(ground_truth):
+    """{source frame index: board time} for the annotations that anchor a timeline.
+
+    Read through `annotated_board_time` rather than recomputed, so the test anchors on
+    exactly the frames the retimer does -- an arc too close to the edge of the period
+    names no single time and is no anchor, however the entry was written.
+    """
+    anchors = {}
+    for index in range(FIRST_ANCHOR, LAST_ANCHOR + 1, ANCHOR_STRIDE):
+        board_ms = annotated_board_time(ground_truth["images"][frame_key(VIDEO, index)])
+        if board_ms is not None:
+            anchors[index] = board_ms
+    return anchors
+
+
+def test_every_anchor_lands_on_the_recorded_clock(dataset):
+    """The property the whole exercise exists for, read back the way the pipeline reads."""
+    data_dir, ground_truth = dataset
+    retime_video(data_dir, VIDEO, ground_truth)
+    entry = ground_truth["videos"][RETIMED]
+
+    pts = frame_pts(data_dir / RETIMED)
+    offset = entry["source_frame_offset"]
+    residuals = [
+        entry["clock_rate"] * pts[index - offset] + entry["clock_offset_ms"] - board_ms
+        for index, board_ms in anchor_board_times(ground_truth).items()
+    ]
+
+    assert max(abs(r) for r in residuals) < 0.1
+    assert entry["max_residual_ms"] < SYNTHESIZED_RESIDUAL_THRESHOLD_MS
+    assert entry["clock_rate"] != 1.0  # drawn, so a bug that ignores it cannot pass
+
+
+def test_the_pixels_are_copied_rather_than_re_encoded(dataset):
+    """The annotations describe the source's pixels, so they have to survive unchanged."""
+    data_dir, ground_truth = dataset
+    retime_video(data_dir, VIDEO, ground_truth)
+    offset = ground_truth["videos"][RETIMED]["source_frame_offset"]
+
+    source, retimed = read_all(data_dir / VIDEO), read_all(data_dir / RETIMED)
+
+    assert retimed  # a clip that decoded to nothing would pass the loop below
+    for index, frame in enumerate(retimed):
+        assert np.array_equal(frame, source[index + offset]), f"frame {index} differs"
+
+
+def test_the_clip_spans_the_annotated_window(dataset):
+    """Trimming to the anchors is what keeps every timestamp interpolated, never guessed."""
+    data_dir, ground_truth = dataset
+    retime_video(data_dir, VIDEO, ground_truth)
+    entry = ground_truth["videos"][RETIMED]
+
+    offset, n_frames = entry["source_frame_offset"], entry["n_frames"]
+    assert offset <= FIRST_ANCHOR
+    assert offset + n_frames - 1 >= LAST_ANCHOR
+    # Unannotated frames inside the window stay: wraps and partial boards are the point
+    assert n_frames > len(anchor_board_times(ground_truth))
+
+    pts = frame_pts(data_dir / RETIMED)
+    assert len(pts) == n_frames
+    assert pts[0] >= 0.0
+    assert all(b > a for a, b in itertools.pairwise(pts))
+
+
+def test_the_annotations_are_left_where_they_are(dataset):
+    """A retimed clip is a derived artifact; regenerating it must cost no annotation work."""
+    data_dir, ground_truth = dataset
+    before = json.dumps(ground_truth["images"], sort_keys=True)
+
+    retime_video(data_dir, VIDEO, ground_truth)
+
+    assert json.dumps(ground_truth["images"], sort_keys=True) == before
+    retimed = retimed_videos(ground_truth)
+    offset = ground_truth["videos"][RETIMED]["source_frame_offset"]
+    assert source_key(frame_key(RETIMED, 0), retimed) == frame_key(VIDEO, offset)
+
+
+def test_a_clip_is_rebuilt_only_when_its_annotations_move(dataset):
+    data_dir, ground_truth = dataset
+    retime_video(data_dir, VIDEO, ground_truth)
+    first = dict(ground_truth["videos"][RETIMED])
+
+    assert retime_video(data_dir, VIDEO, ground_truth).endswith("up to date")
+    assert ground_truth["videos"][RETIMED] == first
+
+    edited = frame_key(VIDEO, LAST_ANCHOR)
+    ground_truth["images"][edited] = as_annotation(
+        anchor_board_times(ground_truth)[LAST_ANCHOR] + 3
+    )
+    retime_video(data_dir, VIDEO, ground_truth)
+
+    assert ground_truth["videos"][RETIMED]["anchors_digest"] != first["anchors_digest"]
+
+
+def test_annotations_that_disagree_with_the_recording_are_refused(dataset):
+    """Board time running backwards is a bad annotation, not a timeline to build on."""
+    data_dir, ground_truth = dataset
+    ground_truth["images"][frame_key(VIDEO, LAST_ANCHOR)] = as_annotation(BOARD_START_MS - 450)
+
+    with pytest.raises(RetimeError, match="do not increase"):
+        retime_video(data_dir, VIDEO, ground_truth)

--- a/sw/uv.lock
+++ b/sw/uv.lock
@@ -8,6 +8,76 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "av"
+version = "17.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/e3/477fa20578c284abeda08d91b63ee9abaebc93445d8feeb989d3d444bae1/av-17.1.0.tar.gz", hash = "sha256:7f1e71ff621b66253333926f948e00faae11d855b2442133c65128bca64cdeb3", size = 4288546, upload-time = "2026-06-07T05:52:55.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/92/c9d0cea4f6f8f93f5b15a39f99d2d593f922484f22a2d98a8d482283e15b/av-17.1.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:19c84fd72af5ef81a20f18fbc6f9aedff9e1455e53a7062c1d4c95926d73da4e", size = 22622703, upload-time = "2026-06-07T05:51:40.405Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/57/74399770aa103ee4b5ff6da1781440c91a41901d89abb2433fe88773246e/av-17.1.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:19264c9bb4bee404accc7ce9ec461f2044b7f577a70234d29aafde31ed17de46", size = 18273538, upload-time = "2026-06-07T05:51:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/17/27c85b12e9ffa8f3f6854358b3eabcd91f3c29c7dac36843fa1376e833f4/av-17.1.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:22dff0ae582d10ef08c75c2150a4fd27cfc26653b54930c7c27b9f7b3aa20723", size = 34519101, upload-time = "2026-06-07T05:51:45.305Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a4/542d4bfd9f4aec5f3265985b9dbc6b259d45c2e668f9714e5f4e05b71e64/av-17.1.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:90c49bc9608377d01e82e747377505419a229464873341db18202d5dddecce5a", size = 36647600, upload-time = "2026-06-07T05:51:48.57Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1e/63bd5c59580f38109fa4c452b29b715a20c9a5eb3a078b3c447484593c40/av-17.1.0-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:cc5a5247622cb77e24c342364eb68f88c1442ddfaab60c1f1f483359d3cc7879", size = 25786289, upload-time = "2026-06-07T05:51:51.674Z" },
+    { url = "https://files.pythonhosted.org/packages/70/30/78155cef0c9f8bc13f044130192c58bf962f2c9066982ff3593afe8d27f1/av-17.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ff457ed419348e5b8e8c811d341389b052c5e4d5839da3794d019b125b9fe830", size = 35599848, upload-time = "2026-06-07T05:51:54.207Z" },
+    { url = "https://files.pythonhosted.org/packages/76/cb/ae1d7a735a5ad9dc502dba864c51d605cbe932a769218352fd570254c38e/av-17.1.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:1370b11a697eb3f2555906f8ab3519b0cfe48425d7830a3996ad42e6bffafda5", size = 26776479, upload-time = "2026-06-07T05:51:56.788Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/40/128429b9eb0c4a2beb122ed8d04b189515df68967987c2654a2e262a5c43/av-17.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3dcd41e53f53f9a3260751d9c3c11d34e93d70d61e506c81f13dbc1e3606e07b", size = 37763744, upload-time = "2026-06-07T05:51:59.222Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6a/5980e7bbeeadfd7a9db8e38e9f1140a3e0c392fccc31bd7b1e4a75cf5a96/av-17.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:3453b06075c7bb973fdb6de52563f7692ff05cbc64c0bb45f4fd6e8709131f2f", size = 28126516, upload-time = "2026-06-07T05:52:01.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/87/8036b5c781bc3639ea04ef42d4e26da253bd4bd4311d8705b6a1c8824047/av-17.1.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ad7b4aa011093324b7118245f50ac6db244cfe9900d4072508a5245a2b0d3f41", size = 22460847, upload-time = "2026-06-07T05:52:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/af/dfdf6fc7b17814b50d0aa9e7a7e37b87be91be3890f44b0d525433cd1fd1/av-17.1.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:43ebbe977f19a7f2d2bd1a4e119675a0b15e05852cf7309846b6ab922ba7ffe9", size = 18159115, upload-time = "2026-06-07T05:52:06.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/13/64f6c466471cea225b8b2f4cdc51a571f8a286984b55a08d169b932fda5d/av-17.1.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6a20658ec7d96a70e14b1196eff00b7cdd8831ac3b99868e16b8ba8b24090847", size = 33224427, upload-time = "2026-06-07T05:52:09.165Z" },
+    { url = "https://files.pythonhosted.org/packages/77/43/96b35170bf2e64e00a41748c6400ff73232dc0fc62ded283679fb07c7fe0/av-17.1.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f9a65d1f48b818323fb411e80358f89d77dec340b01d27c6b2dfbb9cbf4b779f", size = 35370183, upload-time = "2026-06-07T05:52:11.959Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b3/8e8b4b6498731bfbd88e8399a756543f8088f1bd33d08eab678b5aebe728/av-17.1.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:58f7593726437cda5bd19793027e027768450b5c4a594777bf487798a33db702", size = 24459265, upload-time = "2026-06-07T05:52:14.66Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ac/ceb84b7553db21f1143d817245c560d9267168e1e58b1a8eeae2b62c4d04/av-17.1.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:bbab058bd965309f39962e53caac8126987c68c0be094fc4f9427e5615b0218f", size = 34283709, upload-time = "2026-06-07T05:52:17.389Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f9/4115fd84148c9a1cf365096694be6ac882fd3cd3cdb7a2f35e71fecf1631/av-17.1.0-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9514cfda85180554c430695282faf4be3ffdf95775d8519733821244eecb58e0", size = 25397573, upload-time = "2026-06-07T05:52:20.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ac/92e52d5ed0e0b84d9d93e52b4338c2713d8a44082b8696e6516fdae7c4e4/av-17.1.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e1c90f85cd7431ede95b11e8e711571a896ebea433f298849c2c0f1594c8d86e", size = 36451495, upload-time = "2026-06-07T05:52:22.581Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f2/53a7cd34adb6a971d7e6d99663e74db286966c9db8afdca17472fdf0f98e/av-17.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:5df5c1172ef1cf65a1529d612f7da7798ce2cf82c1ff7212466b538a6cc7214c", size = 28036393, upload-time = "2026-06-07T05:52:25.657Z" },
+    { url = "https://files.pythonhosted.org/packages/66/47/cd9ae0edf2206351c1251bb94b5ec58728e42c5f6ee16c03c412f3a1bb3e/av-17.1.0-cp311-abi3-win_arm64.whl", hash = "sha256:ee98534242a74da847af78624779ac5a3177dc7c69f956a4da9e6f0fdb37d7f6", size = 21174601, upload-time = "2026-06-07T05:52:28.077Z" },
+    { url = "https://files.pythonhosted.org/packages/36/90/b5668cddb3c401fcf22553bc495d5b0c6d8a01d118624b26f0db1d0b8653/av-17.1.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:5327807c1219293803ef0c5d1578ff3ae1cf638c09e5998962026e1a554ec240", size = 22699499, upload-time = "2026-06-07T05:52:30.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/7e/7be6bfddb823d045ff9fd5d4deb922ee3847605e162c3882e6c45b4c35ff/av-17.1.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:6c9b71fe5c0c5a8d303b1588d4d8ce9397d6b023f467cfef95000ba1f75507fa", size = 18366696, upload-time = "2026-06-07T05:52:32.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/391dcfa75c1ae1977efca44b753a11b929399b558826670c16a8808dd0e3/av-17.1.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:f997e3351bdf51127c07a74e21741a2996e9230cbeb2d81c14acde761b116c9c", size = 36582649, upload-time = "2026-06-07T05:52:35.218Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/32/7312854868b318b9d1b1dcbd1bddb460aaaeac7d57f816e11efec3bef5b1/av-17.1.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:efe9b1397300b67b644ad220c89df4892a76f2debe70f16bae1749fa20526e63", size = 38479390, upload-time = "2026-06-07T05:52:37.968Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/af47f59b4458e81ca7d89f477698dbfb3d5a0cd8ae6c1e4441d01074af8a/av-17.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:fa64e1f1500d01c4a98e7a41dc1a9a35fb4dfe71f5de0389264ec1192200c76a", size = 27127432, upload-time = "2026-06-07T05:52:40.371Z" },
+    { url = "https://files.pythonhosted.org/packages/88/85/c2e6861baf0f8c7d21c4ce811d4d424fedac915e3910d3570ce4377717dc/av-17.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ffbd78d73d2c9bf31e9a007c992faec3991428b2941a3b085b84fb82e8c32d19", size = 37406592, upload-time = "2026-06-07T05:52:43.215Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/40/3cc13125aea976101c0858af99ac47257c0654411aa199b5d8e81eea7002/av-17.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:bff8896454b38fcb785a70e5ae0485d7021cb776303a5849393128a30b8f850b", size = 28336228, upload-time = "2026-06-07T05:52:46.134Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/38/c7d9c3e746209a1a695c13e3aa7d817229e84a85d0a84271f313d1befdd3/av-17.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1284addf3c0dd939887a9722dc30df2241a97471ad52c3c507e31583ae22ff02", size = 39490680, upload-time = "2026-06-07T05:52:48.887Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/25/9d42da561b7b8f7dabdfaebba07b52977bee58c5c7e4285ac991abcfaa72/av-17.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ec630be6321b04e317862f6082e84812bbd801e55a3c2298312e3fc8a0a4af4f", size = 28355673, upload-time = "2026-06-07T05:52:51.614Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/41/562a61d5a61fba3ffb273a115e249f1d8471b9515c59fcc38b4b9deda238/av-17.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b41647e42884bf543b8e8d0a1dabd4d1b006c99183eb1a2d7afc5b01f73eeff4", size = 21324700, upload-time = "2026-06-07T05:52:53.972Z" },
+]
+
+[[package]]
+name = "av"
+version = "18.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/f4/f22114d30d3435e38c6af2b4870f37b864403dca6ae7af747a289ce0a18e/av-18.1.0.tar.gz", hash = "sha256:47bfc286e1bc9de7ab4681fc2b575cd2460a66919d31ffe1bd5aa54fae531a28", size = 4451061, upload-time = "2026-08-12T22:28:18.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/d4/d7cdc8bff143c17a6d35924375ae28dd692cacde38700a7d419fde54f44a/av-18.1.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ae75d8bb6467895ed1f8572ededf7ffa49eac07f6e483222f5d7d62a41d12f04", size = 22546147, upload-time = "2026-08-12T22:27:11.851Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c9/37a619297492256b77d5ed906e7d8166c10a26ed251dccf1ae03ab19bff6/av-18.1.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:b30a4e8d934558e19602b68998a4d9ac9f250fa0dacef216f7e8e40153b13316", size = 18217603, upload-time = "2026-08-12T22:27:14.713Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/84/2464ffb64c08c5ce8b522c8e74594714414e3b0575267652c5c51c0574b9/av-18.1.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6fc837cc51adf80331ac850779cd53b5d4c4460b0ebe9057a02a921c6736f19d", size = 33640142, upload-time = "2026-08-12T22:27:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/204dbfc3e08eb4cdc6e6ff57be02150bc44523ebdb50182d10025792ebd9/av-18.1.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8a032e8d8ebc73dec079364b9b4a6837638a2d106e8472314e685ffbf163e700", size = 35786210, upload-time = "2026-08-12T22:27:20.984Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/99/b0d04ec553ff9a7e00455458dfa3a39c8a8f627b273056b4e5fe57d590de/av-18.1.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:3c8b1f8b46f99d52e2d8b0ed5d0cdadf172d24794d46e2077b16e44ed08e26ff", size = 39379798, upload-time = "2026-08-12T22:27:24.432Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b1/e00d4feae59160149df6126585e726fdc6300798fd40c5dd324879e81f68/av-18.1.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ab5ac081bc9eaf54109120d4e56284674fecfbe520d9aa1707c7fa911ec5f4d2", size = 34690321, upload-time = "2026-08-12T22:27:27.769Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/836fa987e3084d11a21489f11357fb24843ef3aa8faf74ddddfc603d5062/av-18.1.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:191224788d87af06c31784a395bb73f14b72f33d7f4871ace0157de2abdc6276", size = 36859932, upload-time = "2026-08-12T22:27:31.403Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b4/76ba21e46704f632004276b85289a1582e95f5eff760436d6149875a1881/av-18.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:ea1480b7a8d5405cb5f382b344731bf125fd2c1c6fae3964f6c48595628387ff", size = 27595679, upload-time = "2026-08-12T22:27:35.177Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ad/a3135884c5753b09773176b97201ae602f67ad14206c395ff838d66bf9b0/av-18.1.0-cp311-abi3-win_arm64.whl", hash = "sha256:5509ec12aaa19fd6601de13cfa6f4cdad450da07982118510592875d970454d6", size = 20257584, upload-time = "2026-08-12T22:27:38.472Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5b/4a756265d7fb164336c8d377bca21c39cfa2c178be23cedee840a69b59c5/av-18.1.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:b36b0bae9e4c62f9487c99481ec15e4e3870fcc868522cd6d18fc2d6bfa04f01", size = 22795654, upload-time = "2026-08-12T22:27:42.016Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/cc/1bc841462114a1adf4f7d87456ab78a6972e23271e71865fcd2bbd0e7360/av-18.1.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:025f84494cb23278498f03b0d8117d3e47a1cbc9c44b97eb31875cf02251e46b", size = 18435735, upload-time = "2026-08-12T22:27:45.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/20/005500ed17a2e62a5e4bb94aa3786942560ec2f55ec1895ebf174c87abef/av-18.1.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:08a9ae288299cfcbf739dba4ad0c53b9b71f45184303dd45947920d022fed695", size = 37090807, upload-time = "2026-08-12T22:27:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/f7/11e7f6d848d3690c31ca4f8578167393e619177f1493ccc93b9400852d4e/av-18.1.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cf8a17466bef07765dbdecc9e66ed9b25d20b4e14f654fbf35345a58ac45fa0c", size = 38976836, upload-time = "2026-08-12T22:27:54.565Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/b271473b24e806062d31191e40c6d65545e9cf59f80f044eba56dcbba0f4/av-18.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d49a5c542dfdc00f43c6cdb6cc41dac1781ee206fe180b56aa7433dfa816dfae", size = 40896630, upload-time = "2026-08-12T22:27:59.118Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/9f/2ab7fa292a947ad3466ed8e655eefa3b82f535d7ea598c297b4471a937c4/av-18.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5548b79e2bf1f59b3e9aedc918a72d9dc45b9adaac10ff9470d5dbdda0002e47", size = 37895673, upload-time = "2026-08-12T22:28:03.98Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/04507c57249b399c3e4f23f01d221532f357338b5316fd2858fbd343127d/av-18.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7ea063f6690193ea335a1d592d6e0274350d45e2ed6af83ee107cb90cbfd84f", size = 39992431, upload-time = "2026-08-12T22:28:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d6/bc4b95bea9c2353a7e4d62a3fcfad9adcf0f881741c6ce01ee179d539ce3/av-18.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e4d48b9f12cad009cc72fe4f4099107de5e819c95f82767f4fd01a01481c0661", size = 28497798, upload-time = "2026-08-12T22:28:13.003Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d2/0c277a46f12647c1833f40496e132fb6001e0d19e6144b5ea30896461feb/av-18.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5cd9085028902c9880622bd37a12fd4b33060f06a52311f6f4867ca9f29a2c3b", size = 21421979, upload-time = "2026-08-12T22:28:16.48Z" },
+]
+
+[[package]]
 name = "basedpyright"
 version = "1.39.10"
 source = { registry = "https://pypi.org/simple" }
@@ -975,6 +1045,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "av", version = "17.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "av", version = "18.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "basedpyright" },
     { name = "pytest" },
     { name = "ruff" },
@@ -991,6 +1063,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "av", specifier = ">=12" },
     { name = "basedpyright", specifier = ">=1.39" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.16.3" },


### PR DESCRIPTION
This PR adds a benchmark module to the rocsync package, including three tools (annotate, validate, evaluate).
Sorry one last time (hopefully) for the extensive PR! We can squash-merge it again.

# Benchmark Tools
All benchmark tools live in a new submodule rocsync.benchmark.

## Annotation Tool

The annotation tool provides an interactive GUI for creating ground truth annotations. It runs the pipeline on each image, displays the result with LED overlays, and lets you verify or correct the decoded values. 

If the pipeline detects and decodes the ROCSync, the user can simply confirm the results.
If the ROCSync is not (or incorrectly) detected, the user can first click on the corner LEDs on the left view. The rectified board is then shown on the right view. Corner positions can be refined by dragging them in either the left or right view.
Finally, the user can select the active counter (one by one) and ring (start + end) LEDs.
The tool saves all annotations in a ground_truth.json file for benchmark evaluation.

Further features:
* Video support: For videos, the tool automatically runs the clock synchronization in the background and shows the delta between the expected and annotated timestamp. It uses the same linear regression as rocsync itself, but without outlier rejection as annotations should be outlier-free.
* Both revisions are supported. The visible board is automatically determined via the arUco marker detection. Alternatively, the user can cycle through the revisions by clicking on the arUco marker on the right view. The board layout is updated automatically
* Zoom loupe: A zoomed-in patch of the mouse cursor is shown in a corner of the left view, to enable a precise LED selection
* Continuous counter and ring decoding: Before the user has confirmed or manually adjusted the binary counter or ring arc, the decoded values will be updated whenever the rectification is adjusted.
* 

Screenshot of an annotated frame:
<img width="2250" height="972" alt="image" src="https://github.com/user-attachments/assets/1d40cec6-22d7-4c05-9700-83f85aacf4ac" />

## Validation Tool

The validation tool runs the rocsync pipeline on all frame in the benchmark and saves per-frame and per-step results in a structure mirroring the ground truth format, plus per-step timing. Command-line arguments and git state are also recorded.

## Evaluation Tool

The evaluation tool compares benchmark results against ground truth annotations, and reports per-frame and per-step metrics, as well as aggregated metrics of the synchronization outcome. Per-step metrics include TPR, FPR, precision, F1, value accuracy (exact and one-off), localization errors, and latency statistics. See the first comment on #13 for an exemplary output.

## Retime Tool

As frame timestamps of recorded videos can be noisy, the synchronization (i.e. linear regression result) is lower-bounded by the timestamp accuracy. To exclude this source of noise from the benchmark, the retime tool re-encodes the annotated video frames with corrected timestamps based on the annotations. The target clock_rate and clock_offset are uniformly sampled and stored in the ground_truth.json, which yields a more diverse set of targets (instead of all clock_rates being approximately 1.0).

# Changes outside of the benchmark module

* Benchmark hooks: Optionally collect per-step results and timings in a new _stats_ dict that is threaded through all steps. Used by the validation tool to collect detailed infos. (sw/rocsync/vision.py)
* Bugfix: OpenCV's VideoCapture assumes a constant framerate. When seeking by frame timestamp, the seek may not yield the correct frame depending on missing frames and framerate variance. Fixed by a linear forward/backward search after seek (sw/rocsync/clips.py).
* Improvement: Use ffprobe to efficiently collect all frame timestamps of a video file, instead of iterating over all frames. (sw/rocsync/timeline.py and sw/rocsync/video.py)
* Tests were automatically generated by Claude and succeed, but I did not verify their usefulness. I don't mind if we keep them or discard them in favor of manually implemented or curated ones.