### PR TITLE
Benchmark bugfixes

### DIFF
--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -357,9 +357,11 @@ Rectification scores the homography itself rather than the corners it was fitted
 the board model knows about (`board.layout_coords`) is mapped through the predicted homography and
 back through the annotated one, and the round trip's residual is the rectification's own error in
 board px, at every LED position including the ring and counter — regions the four fitted anchors
-only extrapolate into. A frame is a detection when its worst LED still lands inside the sample
-radius. The coarse ArUco-only row is not a competing method; it is the floor the fit degrades to
-when corner refinement fails, so the gap between the two rows is what refinement is worth.
+only extrapolate into. The reported error statistics pool every LED's residual over every scored
+frame, the same board-px population the corner detection section reports, so the two are directly
+comparable. A frame is a detection when its worst LED still lands inside the sample radius. The
+coarse ArUco-only row is not a competing method; it is the floor the fit degrades to when corner
+refinement fails, so the gap between the two rows is what refinement is worth.
 
 Reading position and rectification errors: the annotator pre-fills each image from a pipeline run,
 so on every frame accepted without correction the annotation *is* that pipeline's output — its

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -298,7 +298,7 @@ uv run rocsync-validate [data_dir] [-o results.json] [--debug DIR]
 - `-o`: Output JSON file (default: `benchmark_results.json`).
 - `--debug`: Directory for debug images.
 
-Results JSON contains a `config` section and an `images` section with per-frame aruco, corners, counter, ring, timestamp, success flag, and timing breakdown. Keys match the ground truth's, so `n_images` in `config` counts benchmark frames rather than files. Corner positions are in original image coordinates, matching the ground truth: the pipeline detects them in the rough-rectified grid, whose scale is a property of the checkout being measured, so they are un-warped through that grid's own homography before being stored.
+Results JSON contains a `config` section and an `images` section with per-frame aruco, corners, counter, ring, timestamp, success flag, homography, rough_homography, and timing breakdown. Keys match the ground truth's, so `n_images` in `config` counts benchmark frames rather than files. Corner positions are in original image coordinates, matching the ground truth: the pipeline detects them in the rough-rectified grid, whose scale is a property of the checkout being measured, so they are un-warped through that grid's own homography before being stored. `homography` and `rough_homography` are the pipeline's own image → rectified-board matrices — the fine one fitted from the corner LEDs, the coarse one from the ArUco marker alone — saved as-is so `rocsync-evaluate` can score the rectification itself rather than only the LEDs it was fitted from.
 
 Every video additionally gets its clock fitted, by the same code a `rocsync` run uses, and a
 `videos` section records the resulting `VideoStatistics` — clock rate and offset, R²/RMSE
@@ -331,7 +331,10 @@ uv run rocsync-evaluate [paths...] [-g ground_truth.json] [-t] [--allow-partial]
 
 Metrics are computed per pipeline step:
 - **ArUco**: detection rates + corner pixel error in image space
-- **Corners**: detection rates in image space and board space + pixel errors in both spaces
+- **Corners**: per-corner detection rates in image space and board space + pixel errors in both spaces
+- **Rectification**: the final and the coarse (ArUco-only) homography, each scored at every
+  modelled LED position (always-on, ring, and counter) in board px against the LED sampling
+  radius — see below
 - **Counter**: detection rates + value accuracy
 - **Ring**: detection rates + start/end value accuracy, wrapping arcs included
 - **Overall**: timestamp detection + exact match accuracy + start/end/exposure error statistics,
@@ -347,14 +350,25 @@ Metrics are computed per pipeline step:
 Corner positions are compared against the annotated coordinates. Board space is derived by mapping
 both sides through the annotated homography, which normalises the threshold to LED sample radii —
 a fixed pixel threshold in image space means different things depending on how large the board
-appears in the frame.
+appears in the frame. Each frame is scored against its own board's sample radius, so a mix of
+board profiles is never scored against the wrong one's threshold.
 
-Reading position errors: the annotator pre-fills each image from a pipeline run, so on every frame
-accepted without correction the annotation *is* that pipeline's output. Position error therefore
-reads as zero for whichever checkout produced the annotations, and a non-zero error for another
-checkout measures divergence from it rather than distance from truth. Detection rates do not suffer
-this — the ground truth's positives include everything annotated by hand on frames where the
-pipeline failed.
+Rectification scores the homography itself rather than the corners it was fitted from: every LED
+the board model knows about (`board.layout_coords`) is mapped through the predicted homography and
+back through the annotated one, and the round trip's residual is the rectification's own error in
+board px, at every LED position including the ring and counter — regions the four fitted anchors
+only extrapolate into. A frame is a detection when its worst LED still lands inside the sample
+radius. The coarse ArUco-only row is not a competing method; it is the floor the fit degrades to
+when corner refinement fails, so the gap between the two rows is what refinement is worth.
+
+Reading position and rectification errors: the annotator pre-fills each image from a pipeline run,
+so on every frame accepted without correction the annotation *is* that pipeline's output — its
+`homography` field is copied straight from the pipeline's own `stats["homography"]`, and only a
+corner edit ever refits it. Position and rectification error therefore read as zero for whichever
+checkout produced the annotations, and a non-zero error for another checkout measures divergence
+from it rather than distance from truth; only hand-corrected frames carry independent signal.
+Detection rates do not suffer this — the ground truth's positives include everything annotated by
+hand on frames where the pipeline failed.
 
 A ring arc that wraps the end of the period was exposed across a counter increment, so the
 counter no longer says which period the arc belongs to and no timestamp follows from it. The

--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -190,10 +190,10 @@ Fields:
   approaching the 100 ms ring period would stop flagging a whole counter step. The stored number is what the reference was checked
   against and what scoring reports, so a frozen reference stays valid under the rule it was
   frozen by.
-- `videos[path].source_frame_period_ms`: Frame period of the recording, read from the packet
-  duration rather than the timestamp spacing. A clip holding every 16th frame of a 30 fps
-  recording still says 33.3 ms per packet while its timestamps sit 533 ms apart, and it is the
-  camera's own rate that the tolerance has to scale from.
+- `videos[path].source_frame_period_ms`: Frame period of the recording, read from the
+  `source_frame_rate` tag [`prepare_clip.sh`](#adding-videos-to-the-benchmark) writes. A clip
+  holding every 16th frame of a 30 fps recording has timestamps 533 ms apart and a frame rate of
+  its own of 1.9 fps, and it is the camera's 33.3 ms that the tolerance has to scale from.
 - `videos[path].source` / `source_frame_offset` / `anchors_digest` / `n_frames`: Present on a
   retimed clip only. Frame *j* of the clip is frame *j + source_frame_offset* of `source`, which
   is where its annotations live. The digest covers the annotations it was built from and
@@ -437,14 +437,22 @@ metadata itself, so a backend that did not would put every position in a transpo
 
 ## Adding videos to the benchmark
 
-I recommend to subsample videos to 1-2 fps to obtain 
+Every frame of a video is a benchmark frame and every one of them is annotated by hand, so a
+recording is cut down before it joins the dataset:
 
-The following command subsamples videos to approximately 0.9 fps, while preserving exact frame timestamps:
+```bash
+rocsync/benchmark/prepare_clip.sh input_video.mp4 0.9 <data_dir>/<subset>/clip.mp4
+```
 
-`ffmpeg -i input_video.mp4 -vf "select='isnan(prev_selected_t)+gte(t-prev_selected_t,1/0.9)'" -fps_mode passthrough -c:v libx264 -crf 18 -preset slow -an rocsync_benchmark/<subset>/output_video.mp4`
+0.9–1.9 fps keeps annotation affordable. Avoid rates that divide 100 ms evenly, or every frame
+catches the ring arc at the same phase.
 
-When selecting the output framerate, avoid multiples of 100ms to collect frames with different ring arcs.
-I recommend 0.9 - 1.9 fps to minimize annotation cost.
+The script keeps the frames' original timestamps — a clock is fitted to them, and left to itself
+the encoder rounds each one onto the grid of whichever frame rate it guesses, which on a 30 fps
+recording moves a frame by up to half a frame. It also writes the recording's frame rate to a
+`source_frame_rate` metadata tag, because a clip holding every 16th frame no longer says that
+anywhere in its own timing, and it is the camera's rate the residual tolerance scales from. It
+refuses to write a clip whose tag did not survive the muxer.
 
 ## Removing inputs from the benchmark
 

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -29,17 +29,15 @@ from rocsync.benchmark.common import (
     corner_positions_in_image,
     fit_reference_clock,
     frame_key,
-    measured_residual_threshold_ms,
     orphaned_entries,
     parse_frame_key,
     reconstruct_timestamp,
     reference_outliers,
     reference_residual,
-    source_frame_period_ms,
 )
 from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO, RectifiedBoard
 from rocsync.camera import CameraType
-from rocsync.timeline import frame_pts
+from rocsync.timeline import frame_pts, measured_residual_threshold_ms, source_frame_period_ms
 from rocsync.vision import ARUCO_DICTIONARY, process_frame, read_counter, read_ring
 
 # Every board rectifies to the same pixel grid, so one radius serves the whole GUI.

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -415,21 +415,32 @@ class FrameSource:
         self.close()
 
 
-def corner_positions_in_image(stats):
-    """Detected corner LED positions in original image coordinates.
+def corner_positions_in_image(stats, n_leds=4):
+    """Detected corner LED positions in original image coordinates, one slot per LED.
 
     The pipeline detects corners in the rough-rectified grid, whose scale is a
     property of the branch under test. Un-warping through that grid's own
     homography yields the annotated quantity, comparable across branches.
+
+    The pipeline reports one row per always-on LED, NaN where it found none; this is
+    where that becomes the None the annotation format uses, so position i always names
+    LED i. `n_leds` only sizes the all-None result for a frame that reported nothing.
     """
     positions = stats.get("corner_positions")
     rough_H = stats.get("rough_homography")
     if positions is None or rough_H is None:
-        return [None] * 4
+        return [None] * n_leds
 
-    inv_rough = np.linalg.inv(np.array(rough_H, dtype=np.float64))
-    pts = np.array([positions], dtype=np.float64)
-    return cv2.perspectiveTransform(pts, inv_rough).reshape(-1, 2).tolist()
+    positions = np.array(positions, dtype=np.float64).reshape(-1, 2)
+    found = np.isfinite(positions).all(axis=1)
+    slots = [None] * len(positions)
+    if found.any():
+        inv_rough = np.linalg.inv(np.array(rough_H, dtype=np.float64))
+        pts = positions[found].reshape(1, -1, 2)
+        mapped = cv2.perspectiveTransform(pts, inv_rough).reshape(-1, 2).tolist()
+        for i, point in zip(np.flatnonzero(found), mapped, strict=True):
+            slots[i] = point
+    return slots
 
 
 def ring_visible(image_data):

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -10,7 +10,13 @@ import numpy as np
 
 from rocsync.board_profiles import PROFILES_BY_ARUCO
 from rocsync.dataset import VIDEO_SUFFIXES
-from rocsync.timeline import frame_pts, median_frame_period, probe_packet_field, run_ffprobe
+from rocsync.timeline import (
+    frame_pts,
+    median_frame_period,
+    parse_ratio,
+    probe_packet_field,
+    run_ffprobe,
+)
 
 STEP_ORDER = [
     "aruco_detection",
@@ -35,7 +41,7 @@ MIN_REFERENCE_FRAMES = 5  # a two-point fit is exact by construction and proves 
 # absorb the camera: the container stores a nominal frame rate while the sensor exposes
 # when it pleases, which on the dataset's 30 fps clips scatters by up to 9 ms.
 SYNTHESIZED_RESIDUAL_THRESHOLD_MS = 2.0
-MEASURED_RESIDUAL_FRACTION = 1 / 2  # of a source frame
+MEASURED_RESIDUAL_FRACTION = 1 / 3  # of a source frame
 MEASURED_RESIDUAL_MIN_MS = 2.0  # never tighter than the board itself resolves
 MEASURED_RESIDUAL_MAX_MS = 50.0  # below the ring period, so a counter step still shows
 
@@ -118,11 +124,21 @@ def _probe_packet_count(path):
 def source_frame_period_ms(video_path):
     """Frame period of the recording this file was cut from, in ms, or None.
 
-    Read from the packet duration, which survives decimation: a clip holding every 16th
-    frame of a 30 fps recording still says 33.3 ms per packet while its timestamps sit
-    533 ms apart. The timestamp spacing would describe the subsampling instead, and a
-    tolerance scaled from that would be far too loose to catch anything.
+    A decimated clip cannot say this in its timing: keeping the frames' original
+    timestamps is what the benchmark fits a clock to, and those timestamps describe the
+    subsampling, not the recording. `prepare_clip.sh` therefore writes the recording's
+    frame rate to a metadata tag, which no muxer reinterprets, and that is read first.
     """
+    tagged = run_ffprobe(
+        video_path, "-show_entries", "format_tags=source_frame_rate", "-of", "csv=p=0"
+    )
+    # csv output pads a trailing empty field with a comma, and quotes a value holding one
+    rate = parse_ratio((tagged or "").strip().strip('"').rstrip(","))
+    if rate:
+        return 1000 / rate
+
+    # A clip cut before the tag existed says it in its packets instead: an encoder that
+    # rounds timestamps onto the frame-rate grid leaves the recording's rate behind there
     durations = [d for d in probe_packet_field(video_path, "duration_time") if d > 0]
     if durations:
         # The mode, so one odd packet at a cut cannot stand for the whole recording

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -418,6 +418,29 @@ def corner_positions_in_image(stats, n_leds=4):
     return slots
 
 
+def rectification_errors(pred_H, gt_H, points):
+    """Board-space distance between where each modelled point lands under the two fits.
+
+    Sends every `points` (board px) back to image space through the predicted
+    homography and forward again through the ground-truth one; the round trip
+    is the identity only where the two fits agree, so the residual isolates the
+    rectification's own accuracy from whatever fed it. None when either matrix
+    is missing or the predicted one cannot be inverted.
+    """
+    if pred_H is None or gt_H is None:
+        return None
+    pred_H = np.array(pred_H, dtype=np.float64)
+    gt_H = np.array(gt_H, dtype=np.float64)
+    try:
+        inv_pred = np.linalg.inv(pred_H)
+    except np.linalg.LinAlgError:
+        return None
+    pts = np.array([points], dtype=np.float64)
+    image_pts = cv2.perspectiveTransform(pts, inv_pred)
+    board_pts = cv2.perspectiveTransform(image_pts, gt_H).reshape(-1, 2)
+    return np.linalg.norm(board_pts - np.asarray(points, dtype=np.float64), axis=1)
+
+
 def ring_visible(image_data):
     """Ring is visible when start != end (half-open interval has nonzero length)."""
     ring = image_data.get("ring", {})

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -12,10 +12,9 @@ from rocsync.board_profiles import PROFILES_BY_ARUCO
 from rocsync.dataset import VIDEO_SUFFIXES
 from rocsync.timeline import (
     frame_pts,
-    median_frame_period,
-    parse_ratio,
-    probe_packet_field,
+    measured_residual_threshold_ms,
     run_ffprobe,
+    source_frame_period_ms,
 )
 
 STEP_ORDER = [
@@ -37,13 +36,11 @@ SEEK_BACKOFF_FRAMES = 32  # retry margin for a seek that landed past the frame w
 MIN_REFERENCE_FRAMES = 5  # a two-point fit is exact by construction and proves nothing
 
 # A synthesized timeline is built from the annotations themselves, so the only slack it
-# needs covers reading the ring arc one LED out at either end. A measured one has to
-# absorb the camera: the container stores a nominal frame rate while the sensor exposes
-# when it pleases, which on the dataset's 30 fps clips scatters by up to 9 ms.
+# needs covers reading the ring arc one LED out at either end. A measured one uses
+# `measured_residual_threshold_ms` from `rocsync.timeline` instead, which absorbs the
+# camera: the container stores a nominal frame rate while the sensor exposes when it
+# pleases, which on the dataset's 30 fps clips scatters by up to 9 ms.
 SYNTHESIZED_RESIDUAL_THRESHOLD_MS = 2.0
-MEASURED_RESIDUAL_FRACTION = 1 / 3  # of a source frame
-MEASURED_RESIDUAL_MIN_MS = 2.0  # never tighter than the board itself resolves
-MEASURED_RESIDUAL_MAX_MS = 50.0  # below the ring period, so a counter step still shows
 
 RETIMED_MARKER = ".retimed"  # `clip.retimed.mp4` is `clip.mp4` on a synthesized timeline
 
@@ -119,44 +116,6 @@ def _probe_packet_count(path):
     )
     counted = (output or "").strip().rstrip(",")
     return int(counted) if counted.isdigit() else None
-
-
-def source_frame_period_ms(video_path):
-    """Frame period of the recording this file was cut from, in ms, or None.
-
-    A decimated clip cannot say this in its timing: keeping the frames' original
-    timestamps is what the benchmark fits a clock to, and those timestamps describe the
-    subsampling, not the recording. `prepare_clip.sh` therefore writes the recording's
-    frame rate to a metadata tag, which no muxer reinterprets, and that is read first.
-    """
-    tagged = run_ffprobe(
-        video_path, "-show_entries", "format_tags=source_frame_rate", "-of", "csv=p=0"
-    )
-    # csv output pads a trailing empty field with a comma, and quotes a value holding one
-    rate = parse_ratio((tagged or "").strip().strip('"').rstrip(","))
-    if rate:
-        return 1000 / rate
-
-    # A clip cut before the tag existed says it in its packets instead: an encoder that
-    # rounds timestamps onto the frame-rate grid leaves the recording's rate behind there
-    durations = [d for d in probe_packet_field(video_path, "duration_time") if d > 0]
-    if durations:
-        # The mode, so one odd packet at a cut cannot stand for the whole recording
-        return float(max(set(durations), key=durations.count)) * 1000
-
-    # Without a packet duration the spacing is all there is, subsampled or not
-    try:
-        return median_frame_period(frame_pts(video_path))
-    except OSError:
-        return None  # a file that will not open has no period to report
-
-
-def measured_residual_threshold_ms(source_period_ms):
-    """How far an annotated frame may sit from a clock fitted to a recorded timeline."""
-    if not source_period_ms:
-        return MEASURED_RESIDUAL_MAX_MS
-    scaled = source_period_ms * MEASURED_RESIDUAL_FRACTION
-    return min(max(scaled, MEASURED_RESIDUAL_MIN_MS), MEASURED_RESIDUAL_MAX_MS)
 
 
 def residual_threshold_ms(video_entry):

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -370,29 +370,48 @@ def compute_counter_metrics(benchmark_images, gt_images):
     }
 
 
+def _ring_led_error(pred_index, gt_index, period):
+    """How many LEDs apart two ring positions sit, measured the short way around.
+
+    Modular, because index 0 and index period-1 are neighbours on the ring: a plain
+    difference would call that one-LED disagreement a full period.
+    """
+    if pred_index is None or gt_index is None or not period:
+        return None
+    diff = (int(pred_index) - int(gt_index)) % period
+    return min(diff, period - diff)
+
+
 def compute_ring_metrics(benchmark_images, gt_images):
-    """Compute ring detection + start/end value accuracy."""
+    """Compute ring detection + start/end value accuracy, exact and within one LED."""
     detection = compute_step_detection(benchmark_images, gt_images, "ring")
 
     n_compared = 0
-    start_correct = 0
-    end_correct = 0
+    correct = {"start": 0, "end": 0}
+    near = {"start": 0, "end": 0}
     for img_key, gt in gt_images.items():
         pred = benchmark_images.get(img_key)
         if pred is None:
             continue
         if not ring_visible(gt) or not ring_visible(pred):
             continue
+        board = _board_for_gt(gt)
         n_compared += 1
-        if pred.get("ring", {}).get("start") == gt.get("ring", {}).get("start"):
-            start_correct += 1
-        if pred.get("ring", {}).get("end") == gt.get("ring", {}).get("end"):
-            end_correct += 1
+        for end in ("start", "end"):
+            gt_index = gt.get("ring", {}).get(end)
+            pred_index = pred.get("ring", {}).get(end)
+            if pred_index == gt_index:
+                correct[end] += 1
+            error = _ring_led_error(pred_index, gt_index, board.period if board else None)
+            if error is not None and error <= DECODE_TOLERANCE_LEDS:
+                near[end] += 1
 
     return {
         "detection": detection,
-        "start_correct": start_correct,
-        "end_correct": end_correct,
+        "start_correct": correct["start"],
+        "end_correct": correct["end"],
+        "start_near": near["start"],
+        "end_near": near["end"],
         "value_compared": n_compared,
     }
 
@@ -403,8 +422,8 @@ def compute_overall_metrics(benchmark_images, gt_images):
 
     n_compared = 0
     n_correct = 0
-    start_errors = []
-    end_errors = []
+    n_within_tolerance = 0
+    mid_errors = []
     exposure_errors = []
 
     for img_key, gt in gt_images.items():
@@ -424,8 +443,14 @@ def compute_overall_metrics(benchmark_images, gt_images):
         if pred_ts == gt_ts:
             n_correct += 1
         if pred_ts is not None and gt_ts is not None:
-            start_errors.append(abs(pred_ts[0] - gt_ts[0]))
-            end_errors.append(abs(pred_ts[1] - gt_ts[1]))
+            # The mid-exposure instant is the timestamp a consumer actually uses, and it
+            # is the one quantity a half-lit LED at either end of the arc cannot move:
+            # reading the arc one LED long at both ends shifts start and end the same
+            # way and leaves the middle where it was.
+            mid_error = abs((pred_ts[0] + pred_ts[1]) - (gt_ts[0] + gt_ts[1])) / 2
+            mid_errors.append(mid_error)
+            if mid_error <= DECODE_TOLERANCE_LEDS:
+                n_within_tolerance += 1
             pred_exposure = pred_ts[1] - pred_ts[0]
             gt_exposure = gt_ts[1] - gt_ts[0]
             exposure_errors.append(abs(pred_exposure - gt_exposure))
@@ -433,10 +458,10 @@ def compute_overall_metrics(benchmark_images, gt_images):
     return {
         "detection": detection,
         "timestamp_correct": n_correct,
+        "timestamp_within_tolerance": n_within_tolerance,
         "timestamp_compared": n_compared,
         "timestamp_error": {
-            "start": descriptive_stats(start_errors),
-            "end": descriptive_stats(end_errors),
+            "mid": descriptive_stats(mid_errors),
             "exposure": descriptive_stats(exposure_errors),
         },
     }
@@ -506,7 +531,7 @@ def compute_clock_metrics(benchmark, gt) -> dict[str, dict]:
         # Per-frame accuracy against the annotations themselves, and whether the fit's
         # own outlier rejection agrees with them
         residuals = []
-        false_rejections = false_acceptances = n_flagged = 0
+        rejected_but_correct = considered_but_misdecoded = n_checked_frames = 0
         annotated_path = reference.get("source", rel_path)  # retimed clips borrow theirs
         for key, annotation in gt_images.items():
             path, index = parse_frame_key(key)
@@ -525,25 +550,27 @@ def compute_clock_metrics(benchmark, gt) -> dict[str, dict]:
             fit = prediction.get("fit")
             if fit is None or gt_ts is None:
                 continue
-            n_flagged += 1
+            n_checked_frames += 1
             decoded_correctly = reconstruct_timestamp(prediction, board) == gt_ts
             if decoded_correctly and not fit["inlier"]:
-                false_rejections += 1
+                rejected_but_correct += 1
             elif not decoded_correctly and fit["inlier"]:
-                false_acceptances += 1
+                considered_but_misdecoded += 1
 
         metrics[rel_path] = described(
             reference,
             status=None,
             clock_rate_error_ppm=(rate - ref.clock_rate) * 1e6,
             clock_offset_error_ms=offset - ref.clock_offset_ms,
-            sync_error_first_ms=first,
-            sync_error_last_ms=last,
-            sync_error_max_ms=max(abs(first), abs(last)),
+            first_frame_error_ms=first,
+            last_frame_error_ms=last,
+            # The clock is only ever used inside the annotated span, so the two ends of
+            # that span bound the board time it gets wrong anywhere a caller will ask.
+            frame_time_error_ms=max(abs(first), abs(last)),
             residuals_ms=residuals,
-            false_rejections=false_rejections,
-            false_acceptances=false_acceptances,
-            n_flagged=n_flagged,
+            rejected_but_correct=rejected_but_correct,
+            considered_but_misdecoded=considered_but_misdecoded,
+            n_checked_frames=n_checked_frames,
             rmse_after=pred.get("rmse_after"),
             r2_after=pred.get("r2_after"),
             n_considered_frames=pred.get("n_considered_frames"),
@@ -559,12 +586,12 @@ CLOCK_GROUPS = ("measured", "retimed")
 
 # Frame counters describe how much work a fit did, so a group reports their totals.
 CLOCK_COUNT_KEYS = (
-    "false_rejections",
-    "false_acceptances",
-    "n_flagged",
     "n_considered_frames",
     "n_rejected_frames",
     "n_dropped_frames",
+    "n_checked_frames",
+    "rejected_but_correct",
+    "considered_but_misdecoded",
 )
 
 
@@ -604,8 +631,8 @@ def _aggregate_group(videos):
         "clock_rate_error_ppm_max_abs": over_videos("clock_rate_error_ppm", max, abs),
         "clock_offset_error_ms_mean_abs": over_videos("clock_offset_error_ms", _mean, abs),
         "clock_offset_error_ms_max_abs": over_videos("clock_offset_error_ms", max, abs),
-        "sync_error_mean_ms": over_videos("sync_error_max_ms", _mean),
-        "sync_error_max_ms": over_videos("sync_error_max_ms", max),
+        "frame_time_error_ms_mean": over_videos("frame_time_error_ms", _mean),
+        "frame_time_error_ms_max": over_videos("frame_time_error_ms", max),
         "rmse_after_mean": over_videos("rmse_after", _mean),
         "rmse_after_max": over_videos("rmse_after", max),
         "r2_after_min": over_videos("r2_after", min),
@@ -818,25 +845,28 @@ def _print_metric_rows(methods, rows, get_video, col_width, label_width=LABEL_WI
 
 CLOCK_GROUP_LABELS = {"measured": "measured videos", "retimed": "retimed videos"}
 
-# The last column says which direction wins the row, or None for a row that reports what
-# a fit did rather than how well it did it.
+# Rows are named for the fields `rocsync` itself reports on a video -- clock_rate,
+# clock_offset_ms, first_frame/last_frame, rmse_after, r2_after and the frame counts --
+# so a column here reads as the error in a number the tool already prints. The last entry
+# says which direction wins the row, or None for a row that reports what a fit did rather
+# than how well it did it.
 CLOCK_AGGREGATE_ROWS = [
-    ("residual_threshold_ms_max", "reference tolerance, loosest [ms]", format_value, None),
-    ("clock_rate_error_ppm_mean_abs", "clock rate error, mean |err| [ppm]", format_value, LOWER),
-    ("clock_rate_error_ppm_max_abs", "clock rate error, worst |err| [ppm]", format_value, LOWER),
-    ("clock_offset_error_ms_mean_abs", "clock offset error, mean |err| [ms]", format_value, LOWER),
-    ("clock_offset_error_ms_max_abs", "clock offset error, worst |err| [ms]", format_value, LOWER),
-    ("sync_error_mean_ms", "sync error, mean over videos [ms]", format_value, LOWER),
-    ("sync_error_max_ms", "sync error, worst over videos [ms]", format_value, LOWER),
-    ("rmse_after_mean", "fit RMSE, mean over videos [ms]", format_value, LOWER),
-    ("rmse_after_max", "fit RMSE, worst over videos [ms]", format_value, LOWER),
-    ("r2_after_min", "fit R2, worst over videos", format_value, HIGHER),
-    ("false_rejections", "outliers rejected in error", format_value, LOWER),
-    ("false_acceptances", "misdecodes kept as inliers", format_value, LOWER),
-    ("n_flagged", "frames with both a fit and an annotation", format_value, None),
-    ("n_considered_frames", "frames in the fit", format_value, None),
-    ("n_rejected_frames", "frames rejected by the fit", format_value, None),
-    ("n_dropped_frames", "frames missing from the container", format_value, None),
+    ("residual_threshold_ms_max", "residual_threshold, loosest [ms]", format_value, None),
+    ("clock_rate_error_ppm_mean_abs", "clock_rate error, mean |err| [ppm]", format_value, LOWER),
+    ("clock_rate_error_ppm_max_abs", "clock_rate error, worst |err| [ppm]", format_value, LOWER),
+    ("clock_offset_error_ms_mean_abs", "clock_offset_ms error, mean |err|", format_value, LOWER),
+    ("clock_offset_error_ms_max_abs", "clock_offset_ms error, worst |err|", format_value, LOWER),
+    ("frame_time_error_ms_mean", "first/last_frame error, mean [ms]", format_value, LOWER),
+    ("frame_time_error_ms_max", "first/last_frame error, worst [ms]", format_value, LOWER),
+    ("rmse_after_mean", "rmse_after, mean over videos [ms]", format_value, LOWER),
+    ("rmse_after_max", "rmse_after, worst over videos [ms]", format_value, LOWER),
+    ("r2_after_min", "r2_after, worst over videos", format_value, HIGHER),
+    ("n_considered_frames", "n_considered_frames (fit inliers)", format_value, None),
+    ("n_rejected_frames", "n_rejected_frames (fit outliers)", format_value, None),
+    ("n_dropped_frames", "n_dropped_frames (gaps in container)", format_value, None),
+    ("n_checked_frames", "fit frames with an annotation", format_value, None),
+    ("rejected_but_correct", "  rejected though decoded correctly", format_value, LOWER),
+    ("considered_but_misdecoded", "  kept though misdecoded", format_value, LOWER),
 ]
 
 
@@ -982,22 +1012,16 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
 
     print()
     print_header(methods, col_width, label_width, "Value accuracy")
-    _print_value_accuracy(
-        methods,
-        lambda m: all_metrics[m]["ring"]["value_compared"],
-        lambda m: all_metrics[m]["ring"]["start_correct"],
-        "ring.start correct",
-        col_width,
-        label_width,
-    )
-    _print_value_accuracy(
-        methods,
-        lambda m: all_metrics[m]["ring"]["value_compared"],
-        lambda m: all_metrics[m]["ring"]["end_correct"],
-        "ring.end correct",
-        col_width,
-        label_width,
-    )
+    for end in ("start", "end"):
+        for suffix, label in (("correct", "exact"), ("near", f"±{DECODE_TOLERANCE_LEDS} LED")):
+            _print_value_accuracy(
+                methods,
+                lambda m: all_metrics[m]["ring"]["value_compared"],
+                lambda m, key=f"{end}_{suffix}": all_metrics[m]["ring"][key],
+                f"ring.{end} {label}",
+                col_width,
+                label_width,
+            )
 
     # ── Overall ──────────────────────────────────────────────────────────
     print(f"{'=' * 100}")
@@ -1019,12 +1043,19 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
         col_width,
         label_width,
     )
+    _print_value_accuracy(
+        methods,
+        lambda m: all_metrics[m]["overall"]["timestamp_compared"],
+        lambda m: all_metrics[m]["overall"]["timestamp_within_tolerance"],
+        f"mid-exposure within ±{DECODE_TOLERANCE_LEDS} ms",
+        col_width,
+        label_width,
+    )
 
     print()
     print_header(methods, col_width, label_width, "Timestamp error (ms)")
     for err_key, err_label in [
-        ("start", "start error"),
-        ("end", "end error"),
+        ("mid", "mid-exposure error"),
         ("exposure", "exposure error"),
     ]:
         print(f"  {err_label.upper():>{label_width}}")

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -37,6 +37,7 @@ from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO
 CORNER_IMAGE_SPACE_THRESHOLD_PX = 3
 # A corner counts as found when it lands within one LED sampling disc of where it belongs.
 CORNER_BOARD_SPACE_THRESHOLD_PX = BOARD_V1.rectify().led_sample_radius
+DECODE_TOLERANCE_LEDS = 1
 LABEL_WIDTH_DEFAULT = 40
 
 
@@ -161,12 +162,20 @@ def _timestamp_extractable(gt):
     return board is not None and reconstruct_timestamp(gt, board) is not None
 
 
-def _corner_positions(entry):
-    """Annotated or predicted corner LED positions in image space, None per invisible corner."""
-    return [
+def _corner_positions(entry, n_leds=None):
+    """Annotated or predicted corner LED positions in image space, None per invisible corner.
+
+    Position i names always-on LED i on both sides, so the two lists compare slot by
+    slot. `n_leds` pads a shorter list, which is how a run that reported nothing for a
+    five-LED board still gets scored against all five annotated slots.
+    """
+    positions = [
         c["position"] if c.get("visible") and c.get("position") is not None else None
         for c in entry.get("corners", [])
     ]
+    if n_leds is None:
+        return positions
+    return (positions + [None] * n_leds)[:n_leds]
 
 
 def _to_board_space(positions, gt):
@@ -210,14 +219,17 @@ def compute_step_detection(benchmark_images, gt_images, step):
         if step == "corners":
             gt_corners = gt.get("corners", [])
             pred_corners = pred.get("corners", [])
-            gt_positions = _corner_positions(gt)
-            pred_positions = _corner_positions(pred)
+            # The annotation says how many LEDs the board has; a shorter prediction is
+            # a run that found fewer, not a board with fewer slots to find them in.
+            n_leds = len(gt_corners)
+            gt_positions = _corner_positions(gt, n_leds)
+            pred_positions = _corner_positions(pred, n_leds)
 
             gt_any_visible = any(c.get("visible", False) for c in gt_corners)
             pred_any_visible = any(c.get("visible", False) for c in pred_corners)
             any_tp = False
 
-            for i in range(min(len(gt_positions), len(pred_positions), 4)):
+            for i in range(n_leds):
                 if gt_positions[i] is None or pred_positions[i] is None:
                     continue
                 err = np.linalg.norm(np.array(pred_positions[i]) - np.array(gt_positions[i]))
@@ -294,16 +306,16 @@ def compute_corner_metrics(benchmark_images, gt_images):
         board = _board_for_gt(gt)
         gt_corners = gt.get("corners", [])
         pred_corners = pred.get("corners", [])
-        gt_positions = _corner_positions(gt)
-        pred_positions = _corner_positions(pred)
+        n_corners = len(gt_corners)
+        gt_positions = _corner_positions(gt, n_corners)
+        pred_positions = _corner_positions(pred, n_corners)
         # Board space normalises the threshold to LED sample radii, independent of apparent board size
         gt_board = _to_board_space(gt_positions, gt)
         pred_board = _to_board_space(pred_positions, gt)
-        n_corners = min(len(gt_corners), len(pred_corners))
 
         for i in range(n_corners):
             gt_vis = gt_corners[i].get("visible", False)
-            pred_vis = pred_corners[i].get("visible", False)
+            pred_vis = i < len(pred_corners) and pred_corners[i].get("visible", False)
             both = gt_positions[i] is not None and pred_positions[i] is not None
 
             # Image-space pixel error (on TPs where both are visible with positions)

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -359,7 +359,7 @@ def compute_homography_metrics(benchmark_images, gt_images, key):
     fitted from.
     """
     tp = fp = fn = tn = 0
-    frame_means, frame_maxes = [], []
+    errors_px = []
     leds_within = leds_compared = 0
 
     for img_key, gt in gt_images.items():
@@ -382,8 +382,7 @@ def compute_homography_metrics(benchmark_images, gt_images, key):
             threshold = board.led_sample_radius
             leds_within += int(np.count_nonzero(errors <= threshold))
             leds_compared += len(errors)
-            frame_means.append(float(np.mean(errors)))
-            frame_maxes.append(float(np.max(errors)))
+            errors_px.extend(errors.tolist())
             if float(np.max(errors)) <= threshold:
                 tp += 1
             else:
@@ -397,8 +396,7 @@ def compute_homography_metrics(benchmark_images, gt_images, key):
 
     return {
         "detection": confusion_metrics(tp, fp, fn, tn),
-        "error_mean_px": descriptive_stats(frame_means),
-        "error_max_px": descriptive_stats(frame_maxes),
+        "error_px": descriptive_stats(errors_px),
         "leds_within": leds_within,
         "leds_compared": leds_compared,
     }
@@ -856,11 +854,13 @@ def _print_detection(methods, get_det, col_width, label_width=LABEL_WIDTH_DEFAUL
         )
 
 
-def _print_error_stats(methods, get_stats, col_width, label_width=LABEL_WIDTH_DEFAULT):
+def _print_error_stats(
+    methods, get_stats, col_width, label_width=LABEL_WIDTH_DEFAULT, label_fmt="{stat}"
+):
     """Print descriptive statistics (mean/median/std/min/max/n)."""
     for stat in ["mean", "std", "min", "median", "max", "n"]:
         print_row(
-            stat,
+            label_fmt.format(stat=stat),
             [get_stats(m).get(stat) for m in methods],
             col_width,
             label_width,
@@ -905,7 +905,7 @@ def _print_metric_rows(methods, rows, get_video, col_width, label_width=LABEL_WI
 def _print_rectification_block(
     methods, all_metrics, fit, label, col_width, label_width=LABEL_WIDTH_DEFAULT
 ):
-    """Print one fit's (fine/rough) detection, LED-within-threshold, and error rows."""
+    """Print one fit's (fine/rough) detection and LED error rows."""
 
     def get(m):
         return all_metrics[m]["rectification"][fit]
@@ -914,7 +914,7 @@ def _print_rectification_block(
     _print_detection(methods, lambda m: get(m)["detection"], col_width, label_width)
 
     print()
-    print_header(methods, col_width, label_width, f"{label} — LED positions")
+    print_header(methods, col_width, label_width, f"{label} — LED error")
     _print_value_accuracy(
         methods,
         lambda m: get(m)["leds_compared"],
@@ -923,14 +923,13 @@ def _print_rectification_block(
         col_width,
         label_width,
     )
-
-    print()
-    print_header(methods, col_width, label_width, f"{label} — per-frame mean error (board px)")
-    _print_error_stats(methods, lambda m: get(m)["error_mean_px"], col_width, label_width)
-
-    print()
-    print_header(methods, col_width, label_width, f"{label} — per-frame worst LED (board px)")
-    _print_error_stats(methods, lambda m: get(m)["error_max_px"], col_width, label_width)
+    _print_error_stats(
+        methods,
+        lambda m: get(m)["error_px"],
+        col_width,
+        label_width,
+        label_fmt="{stat} (board px)",
+    )
 
 
 CLOCK_GROUP_LABELS = {"measured": "measured videos", "retimed": "retimed videos"}

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -27,16 +27,22 @@ from rocsync.benchmark.common import (
     descriptive_stats,
     parse_frame_key,
     reconstruct_timestamp,
+    rectification_errors,
     residual_threshold_ms,
     retimed_videos,
     ring_visible,
     source_key,
 )
 from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO
+from rocsync.camera import CameraType
 
 CORNER_IMAGE_SPACE_THRESHOLD_PX = 3
-# A corner counts as found when it lands within one LED sampling disc of where it belongs.
-CORNER_BOARD_SPACE_THRESHOLD_PX = BOARD_V1.rectify().led_sample_radius
+# A point counts as landing correctly when it sits within one LED sampling disc of where
+# it belongs — used for both board-space corner matching and rectification accuracy, since
+# both ask whether a read would sample the right LED. Every scored frame uses its own
+# board's radius (`_board_for_gt(gt).led_sample_radius`); this is only the header display
+# value, since today every profile resolves to the same radius at the default board size.
+LED_DISC_THRESHOLD_PX = BOARD_V1.rectify().led_sample_radius
 DECODE_TOLERANCE_LEDS = 1
 LABEL_WIDTH_DEFAULT = 40
 
@@ -202,11 +208,7 @@ def _to_board_space(positions, gt):
 
 
 def compute_step_detection(benchmark_images, gt_images, step):
-    """Compute TP/FP/FN/TN and derived rates for a single step.
-
-    Corner detection uses per-corner matching against the annotated positions,
-    with a threshold of CORNER_IMAGE_SPACE_THRESHOLD_PX in image coordinates.
-    """
+    """Compute TP/FP/FN/TN and derived rates for a single step."""
     gt_pos_fn = STEP_GT_POSITIVE[step]
     pred_pos_fn = STEP_PRED_POSITIVE[step]
     tp = fp = fn = tn = 0
@@ -216,48 +218,45 @@ def compute_step_detection(benchmark_images, gt_images, step):
         if pred is None:
             continue
 
-        if step == "corners":
-            gt_corners = gt.get("corners", [])
-            pred_corners = pred.get("corners", [])
-            # The annotation says how many LEDs the board has; a shorter prediction is
-            # a run that found fewer, not a board with fewer slots to find them in.
-            n_leds = len(gt_corners)
-            gt_positions = _corner_positions(gt, n_leds)
-            pred_positions = _corner_positions(pred, n_leds)
+        gt_positive = gt_pos_fn(gt)
+        pred_positive = pred_pos_fn(pred)
 
-            gt_any_visible = any(c.get("visible", False) for c in gt_corners)
-            pred_any_visible = any(c.get("visible", False) for c in pred_corners)
-            any_tp = False
-
-            for i in range(n_leds):
-                if gt_positions[i] is None or pred_positions[i] is None:
-                    continue
-                err = np.linalg.norm(np.array(pred_positions[i]) - np.array(gt_positions[i]))
-                if err <= CORNER_IMAGE_SPACE_THRESHOLD_PX:
-                    any_tp = True
-
-            if gt_any_visible and any_tp:
-                tp += 1
-            elif not gt_any_visible and pred_any_visible:
-                fp += 1
-            elif gt_any_visible and not any_tp:
-                fn += 1
-            else:
-                tn += 1
+        if gt_positive and pred_positive:
+            tp += 1
+        elif not gt_positive and pred_positive:
+            fp += 1
+        elif gt_positive and not pred_positive:
+            fn += 1
         else:
-            gt_positive = gt_pos_fn(gt)
-            pred_positive = pred_pos_fn(pred)
-
-            if gt_positive and pred_positive:
-                tp += 1
-            elif not gt_positive and pred_positive:
-                fp += 1
-            elif gt_positive and not pred_positive:
-                fn += 1
-            else:
-                tn += 1
+            tn += 1
 
     return confusion_metrics(tp, fp, fn, tn)
+
+
+def _corner_confusion(gt_corners, pred_corners, gt_positions, pred_positions, threshold):
+    """TP/FP/FN/TN over one frame's corner slots, matched at `threshold`.
+
+    A slot is a TP only when both sides placed it within threshold; visibility alone
+    (no matching position) still counts as a miss or a false alarm. Image space and
+    board space both go through this so the two rows answer the same question.
+    """
+    tp = fp = fn = tn = 0
+    for i in range(len(gt_positions)):
+        gt_vis = i < len(gt_corners) and gt_corners[i].get("visible", False)
+        pred_vis = i < len(pred_corners) and pred_corners[i].get("visible", False)
+        if gt_positions[i] is not None and pred_positions[i] is not None:
+            err = np.linalg.norm(np.array(pred_positions[i]) - np.array(gt_positions[i]))
+            if err <= threshold:
+                tp += 1
+            else:
+                fn += 1
+        elif gt_vis:
+            fn += 1
+        elif pred_vis:
+            fp += 1
+        else:
+            tn += 1
+    return tp, fp, fn, tn
 
 
 def compute_aruco_metrics(benchmark_images, gt_images):
@@ -291,9 +290,7 @@ def compute_aruco_metrics(benchmark_images, gt_images):
 
 def compute_corner_metrics(benchmark_images, gt_images):
     """Compute corner LED metrics: image-space and board-space detection + errors."""
-    detection_image = compute_step_detection(benchmark_images, gt_images, "corners")
-
-    # Per-corner board-space detection and pixel errors in both spaces
+    tp_image = fp_image = fn_image = tn_image = 0
     tp_board = fp_board = fn_board = tn_board = 0
     errors_image = []
     errors_board = []
@@ -310,38 +307,100 @@ def compute_corner_metrics(benchmark_images, gt_images):
         gt_positions = _corner_positions(gt, n_corners)
         pred_positions = _corner_positions(pred, n_corners)
         # Board space normalises the threshold to LED sample radii, independent of apparent board size
-        gt_board = _to_board_space(gt_positions, gt)
-        pred_board = _to_board_space(pred_positions, gt)
+        if board is not None:
+            gt_board = _to_board_space(gt_positions, gt)
+            pred_board = _to_board_space(pred_positions, gt)
+        else:
+            gt_board = pred_board = [None] * n_corners
 
         for i in range(n_corners):
-            gt_vis = gt_corners[i].get("visible", False)
-            pred_vis = i < len(pred_corners) and pred_corners[i].get("visible", False)
-            both = gt_positions[i] is not None and pred_positions[i] is not None
+            if gt_positions[i] is not None and pred_positions[i] is not None:
+                errors_image.append(
+                    float(np.linalg.norm(np.array(pred_positions[i]) - np.array(gt_positions[i])))
+                )
+            if gt_board[i] is not None and pred_board[i] is not None:
+                errors_board.append(
+                    float(np.linalg.norm(np.array(pred_board[i]) - np.array(gt_board[i])))
+                )
 
-            # Image-space pixel error (on TPs where both are visible with positions)
-            if both:
-                err_img = np.linalg.norm(np.array(pred_positions[i]) - np.array(gt_positions[i]))
-                errors_image.append(float(err_img))
+        tp, fp, fn, tn = _corner_confusion(
+            gt_corners, pred_corners, gt_positions, pred_positions, CORNER_IMAGE_SPACE_THRESHOLD_PX
+        )
+        tp_image += tp
+        fp_image += fp
+        fn_image += fn
+        tn_image += tn
 
-            if both and board is not None and gt_board[i] is not None:
-                err_board = np.linalg.norm(np.array(pred_board[i]) - np.array(gt_board[i]))
-                errors_board.append(float(err_board))
-                if err_board <= CORNER_BOARD_SPACE_THRESHOLD_PX:
-                    tp_board += 1
-                else:
-                    fn_board += 1
-            elif gt_vis:
-                fn_board += 1
-            elif pred_vis:
-                fp_board += 1
-            else:
-                tn_board += 1
+        # Each frame's own board sets its radius, so a mix of profiles is scored
+        # correctly even if a future one resolves to a different radius than BOARD_V1.
+        board_threshold = board.led_sample_radius if board is not None else LED_DISC_THRESHOLD_PX
+        tp, fp, fn, tn = _corner_confusion(
+            gt_corners, pred_corners, gt_board, pred_board, board_threshold
+        )
+        tp_board += tp
+        fp_board += fp
+        fn_board += fn
+        tn_board += tn
 
     return {
-        "detection_image": detection_image,
+        "detection_image": confusion_metrics(tp_image, fp_image, fn_image, tn_image),
         "detection_board": confusion_metrics(tp_board, fp_board, fn_board, tn_board),
         "error_image_px": descriptive_stats(errors_image),
         "error_board_px": descriptive_stats(errors_board),
+    }
+
+
+def compute_homography_metrics(benchmark_images, gt_images, key):
+    """Score one predicted homography (`key`: "homography" or "rough_homography").
+
+    Reprojects every modelled LED (`rectification_errors`) rather than reusing the
+    annotated corners, so the score covers the ring and counter regions a fit built
+    from just the four anchors is extrapolating into, not only the points it was
+    fitted from.
+    """
+    tp = fp = fn = tn = 0
+    frame_means, frame_maxes = [], []
+    leds_within = leds_compared = 0
+
+    for img_key, gt in gt_images.items():
+        pred = benchmark_images.get(img_key)
+        if pred is None:
+            continue
+
+        board = _board_for_gt(gt)
+        gt_H = gt.get("homography")
+        pred_H = pred.get(key)
+        gt_positive = board is not None and gt_H is not None
+        pred_positive = pred_H is not None
+
+        if gt_positive and pred_positive:
+            errors = rectification_errors(pred_H, gt_H, board.layout_coords(CameraType.RGB))
+            if errors is None:
+                fn += 1
+                continue
+            # This frame's own board sets the radius its LEDs are actually sampled at.
+            threshold = board.led_sample_radius
+            leds_within += int(np.count_nonzero(errors <= threshold))
+            leds_compared += len(errors)
+            frame_means.append(float(np.mean(errors)))
+            frame_maxes.append(float(np.max(errors)))
+            if float(np.max(errors)) <= threshold:
+                tp += 1
+            else:
+                fn += 1
+        elif not gt_positive and pred_positive:
+            fp += 1
+        elif gt_positive and not pred_positive:
+            fn += 1
+        else:
+            tn += 1
+
+    return {
+        "detection": confusion_metrics(tp, fp, fn, tn),
+        "error_mean_px": descriptive_stats(frame_means),
+        "error_max_px": descriptive_stats(frame_maxes),
+        "leds_within": leds_within,
+        "leds_compared": leds_compared,
     }
 
 
@@ -843,6 +902,37 @@ def _print_metric_rows(methods, rows, get_video, col_width, label_width=LABEL_WI
         )
 
 
+def _print_rectification_block(
+    methods, all_metrics, fit, label, col_width, label_width=LABEL_WIDTH_DEFAULT
+):
+    """Print one fit's (fine/rough) detection, LED-within-threshold, and error rows."""
+
+    def get(m):
+        return all_metrics[m]["rectification"][fit]
+
+    print_header(methods, col_width, label_width, f"{label} — detection")
+    _print_detection(methods, lambda m: get(m)["detection"], col_width, label_width)
+
+    print()
+    print_header(methods, col_width, label_width, f"{label} — LED positions")
+    _print_value_accuracy(
+        methods,
+        lambda m: get(m)["leds_compared"],
+        lambda m: get(m)["leds_within"],
+        "LEDs within sample radius",
+        col_width,
+        label_width,
+    )
+
+    print()
+    print_header(methods, col_width, label_width, f"{label} — per-frame mean error (board px)")
+    _print_error_stats(methods, lambda m: get(m)["error_mean_px"], col_width, label_width)
+
+    print()
+    print_header(methods, col_width, label_width, f"{label} — per-frame worst LED (board px)")
+    _print_error_stats(methods, lambda m: get(m)["error_max_px"], col_width, label_width)
+
+
 CLOCK_GROUP_LABELS = {"measured": "measured videos", "retimed": "retimed videos"}
 
 # Rows are named for the fields `rocsync` itself reports on a video -- clock_rate,
@@ -957,7 +1047,7 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
         methods,
         col_width,
         label_width,
-        f"Detection (thres: {CORNER_BOARD_SPACE_THRESHOLD_PX}px in board space)",
+        f"Detection (thres: {LED_DISC_THRESHOLD_PX}px in board space)",
     )
     _print_detection(
         methods, lambda m: all_metrics[m]["corners"]["detection_board"], col_width, label_width
@@ -979,6 +1069,17 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
         lambda m: all_metrics[m]["corners"]["error_board_px"],
         col_width,
         label_width,
+    )
+
+    # ── Rectification (final homography) ─────────────────────────────────
+    print(f"{'=' * 100}")
+    print("  RECTIFICATION (image → board homography)")
+    print(f"{'=' * 100}")
+
+    _print_rectification_block(methods, all_metrics, "fine", "Final fit", col_width, label_width)
+    print()
+    _print_rectification_block(
+        methods, all_metrics, "rough", "Coarse (ArUco-only) fit", col_width, label_width
     )
 
     # ── Counter reading ──────────────────────────────────────────────────
@@ -1215,6 +1316,10 @@ def main():
         all_metrics[m] = {
             "aruco": compute_aruco_metrics(bm, gt_images),
             "corners": compute_corner_metrics(bm, gt_images),
+            "rectification": {
+                "fine": compute_homography_metrics(bm, gt_images, "homography"),
+                "rough": compute_homography_metrics(bm, gt_images, "rough_homography"),
+            },
             "counter": compute_counter_metrics(bm, gt_images),
             "ring": compute_ring_metrics(bm, gt_images),
             "overall": compute_overall_metrics(bm, gt_images),

--- a/sw/rocsync/benchmark/prepare_clip.sh
+++ b/sw/rocsync/benchmark/prepare_clip.sh
@@ -13,15 +13,18 @@ probe() {
     printf '%s' "${value%,}"
 }
 
-if [ $# -ne 3 ]; then
-    echo "Usage: $(basename "$0") <input_video> <fps> <output_video>" >&2
+if [ $# -lt 3 ] || [ $(( ($# - 3) % 2 )) -ne 0 ]; then
+    echo "Usage: $(basename "$0") <input_video> <fps> <output_video> [<start> <end> ...]" >&2
     echo "  fps: frames per second to keep, e.g. 1.9" >&2
+    echo "  start/end: optional time windows in seconds to restrict extraction to;" >&2
+    echo "             with none given, the whole input is used" >&2
     exit 1
 fi
 
 input=$1
 fps=$2
 output=$3
+shift 3
 
 if [ ! -f "$input" ]; then
     echo "No such file: $input" >&2
@@ -43,8 +46,28 @@ if [ -z "$source_rate" ] || [ "$source_rate" = "0/0" ]; then
     exit 1
 fi
 
+# One term per window, gated by between(t,start,end); with no windows given, the whole
+# input is a single unconditional term.
+sample_gate="(isnan(prev_selected_t)+gte(t-prev_selected_t,1/$fps))"
+if [ $# -eq 0 ]; then
+    select_expr=$sample_gate
+else
+    select_expr=""
+    while [ $# -gt 0 ]; do
+        start=$1
+        end=$2
+        shift 2
+        term="between(t,$start,$end)*$sample_gate"
+        if [ -z "$select_expr" ]; then
+            select_expr=$term
+        else
+            select_expr="$select_expr+$term"
+        fi
+    done
+fi
+
 ffmpeg -hide_banner -loglevel error -i "$input" \
-    -vf "select='isnan(prev_selected_t)+gte(t-prev_selected_t,1/$fps)'" \
+    -vf "select='$select_expr',showinfo" \
     -fps_mode passthrough -enc_time_base -1 \
     -c:v libx264 -crf 18 -preset slow -an \
     -metadata source_frame_rate="$source_rate" -movflags use_metadata_tags \

--- a/sw/rocsync/benchmark/prepare_clip.sh
+++ b/sw/rocsync/benchmark/prepare_clip.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Cut a recording down to a benchmark clip via downsampling while preserving the original per-frame timestamps
+
+set -euo pipefail
+
+# One ffprobe value, without the padding ffprobe's csv output puts around it: a trailing
+# empty field prints as a comma, and a value that holds one comes back quoted.
+probe() {
+    local value
+    value=$(ffprobe -v error "$@")
+    value=${value%%$'\n'*}
+    value=${value//\"/}
+    printf '%s' "${value%,}"
+}
+
+if [ $# -ne 3 ]; then
+    echo "Usage: $(basename "$0") <input_video> <fps> <output_video>" >&2
+    echo "  fps: frames per second to keep, e.g. 1.9" >&2
+    exit 1
+fi
+
+input=$1
+fps=$2
+output=$3
+
+if [ ! -f "$input" ]; then
+    echo "No such file: $input" >&2
+    exit 1
+fi
+if [ -e "$output" ]; then
+    echo "Refusing to overwrite $output" >&2
+    exit 1
+fi
+
+# A clip cut from a clip inherits the rate of the recording behind both, not the rate of
+# the input, which decimation has already divided down.
+source_rate=$(probe -show_entries format_tags=source_frame_rate -of csv=p=0 "$input")
+if [ -z "$source_rate" ]; then
+    source_rate=$(probe -select_streams v:0 -show_entries stream=r_frame_rate -of csv=p=0 "$input")
+fi
+if [ -z "$source_rate" ] || [ "$source_rate" = "0/0" ]; then
+    echo "Could not read a frame rate from $input" >&2
+    exit 1
+fi
+
+ffmpeg -hide_banner -loglevel error -i "$input" \
+    -vf "select='isnan(prev_selected_t)+gte(t-prev_selected_t,1/$fps)'" \
+    -fps_mode passthrough -enc_time_base -1 \
+    -c:v libx264 -crf 18 -preset slow -an \
+    -metadata source_frame_rate="$source_rate" -movflags use_metadata_tags \
+    "$output"
+
+# The tag is what the benchmark reads, so a muxer that dropped it fails here rather than
+# silently loosening every tolerance the clip is later held to.
+written=$(probe -show_entries format_tags=source_frame_rate -of csv=p=0 "$output")
+if [ "$written" != "$source_rate" ]; then
+    echo "$output: source_frame_rate tag reads '$written', expected '$source_rate'" >&2
+    rm -f "$output"  # a clip that failed its own check is not one to keep or to retry around
+    exit 1
+fi
+
+frames=$(probe -select_streams v:0 -count_packets -show_entries stream=nb_read_packets \
+    -of csv=p=0 "$output")
+echo "$output: $frames frames kept, source_frame_rate=$source_rate"

--- a/sw/rocsync/benchmark/retime.py
+++ b/sw/rocsync/benchmark/retime.py
@@ -167,9 +167,11 @@ def remux(
     Frames are selected by display index but written in decode order, which is not the
     same order once B-frames are involved. A copy also cannot start mid-GOP or orphan a
     reference that a retained frame needs, so the span is widened to the enclosing
-    keyframe and to whatever decode order drags in. That can pull a few frames past the
-    annotated window; they follow the overall anchor slope, which over a handful of
-    frames costs far less than the tolerance they are never checked against anyway.
+    keyframe, and its tail grown until the frames it holds are contiguous in display
+    order -- a decode range that ends inside a B-pyramid group already holds that group's
+    later references while missing one displayed between them. That can pull a few frames
+    past the annotated window; they follow the overall anchor slope, which over a handful
+    of frames costs far less than the tolerance they are never checked against anyway.
 
     `remap` is zeroed on the first anchor, so everything is shifted up by at least
     `pad_ms` before it is written -- far enough that no decode timestamp lands below
@@ -198,8 +200,17 @@ def remux(
         while lo > 0 and not packets[lo].is_keyframe:
             lo -= 1
 
-        kept = sorted(display_of[i] for i in range(lo, hi + 1))
-        if kept != list(range(kept[0], kept[0] + len(kept))):
+        def kept_frames(lo, hi):
+            return sorted(display_of[i] for i in range(lo, hi + 1))
+
+        def is_contiguous(kept):
+            return kept == list(range(kept[0], kept[0] + len(kept)))
+
+        while hi + 1 < len(packets) and not is_contiguous(kept_frames(lo, hi)):
+            hi += 1
+
+        kept = kept_frames(lo, hi)
+        if not is_contiguous(kept):
             raise RetimeError("the frames a stream copy needs are not contiguous")
 
         # `remap` speaks the decoder's start-relative timestamps, packets the raw ones
@@ -253,7 +264,7 @@ def retime_video(data_dir, rel_path, ground_truth, jitter_ms=0.0, force=False):
     pts_by_index = dict(enumerate(frame_pts(data_dir / rel_path)))
     missing = [i for i, _ in anchors if i not in pts_by_index]
     if missing:
-        raise RetimeError(f"{rel_path}: annotated frames {missing[:5]} are not in the file")
+        raise RetimeError(f"annotated frames {missing[:5]} are not in the file")
 
     clock_rate = draw_clock(rel_path)
     remap = build_timeline(anchors, pts_by_index, clock_rate)
@@ -276,7 +287,7 @@ def retime_video(data_dir, rel_path, ground_truth, jitter_ms=0.0, force=False):
     if margin > MAX_MARGIN_FRAMES:
         Path(data_dir / out_rel).unlink(missing_ok=True)
         raise RetimeError(
-            f"{rel_path}: the codec forces {margin} frames outside the annotated window, "
+            f"the codec forces {margin} frames outside the annotated window, "
             f"more than the {MAX_MARGIN_FRAMES} that stay within tolerance"
         )
 
@@ -285,7 +296,7 @@ def retime_video(data_dir, rel_path, ground_truth, jitter_ms=0.0, force=False):
     # from the written file, not from what was handed to the muxer.
     written_pts = frame_pts(data_dir / out_rel)
     if len(written_pts) != n_frames:
-        raise RetimeError(f"{rel_path}: wrote {n_frames} frames but reads back {len(written_pts)}")
+        raise RetimeError(f"wrote {n_frames} frames but reads back {len(written_pts)}")
     anchor_pts = [written_pts[index - start_index] for index, _ in anchors]
     boards = [board_ms for _, board_ms in anchors]
     clock_offset_ms = float(
@@ -297,8 +308,7 @@ def retime_video(data_dir, rel_path, ground_truth, jitter_ms=0.0, force=False):
     if np.abs(residuals).max() > SYNTHESIZED_RESIDUAL_THRESHOLD_MS:
         Path(data_dir / out_rel).unlink(missing_ok=True)
         raise RetimeError(
-            f"{rel_path}: the muxed timeline misses its anchors by up to "
-            f"{np.abs(residuals).max():.3f} ms"
+            f"the muxed timeline misses its anchors by up to {np.abs(residuals).max():.3f} ms"
         )
     # The recording keeps its own measured reference: the two describe different
     # questions, and the report picks between them rather than needing one deleted.
@@ -330,7 +340,7 @@ def _retime_one(data_dir, rel_path, ground_truth, args):
     try:
         return retime_video(data_dir, rel_path, ground_truth, args.jitter_ms, args.force), True
     except (RetimeError, OSError) as e:
-        return f"ERROR: {e}", False
+        return f"ERROR: {rel_path}: {e}", False
 
 
 def main():

--- a/sw/rocsync/benchmark/retime.py
+++ b/sw/rocsync/benchmark/retime.py
@@ -37,9 +37,8 @@ from rocsync.benchmark.common import (
     is_retimed,
     parse_frame_key,
     retimed_path,
-    source_frame_period_ms,
 )
-from rocsync.timeline import frame_pts
+from rocsync.timeline import frame_pts, source_frame_period_ms
 
 try:
     import av

--- a/sw/rocsync/benchmark/validate.py
+++ b/sw/rocsync/benchmark/validate.py
@@ -34,11 +34,17 @@ from rocsync.timeline import frame_pts, source_frame_period_ms, summarize_timeli
 from rocsync.vision import process_frame
 
 
+def _matrix(H):
+    """A homography as a JSON-safe nested list, or None."""
+    return np.asarray(H, dtype=np.float64).tolist() if H is not None else None
+
+
 def extract_pipeline_result(stats):
     """Extract a ground-truth-compatible result dict from pipeline stats.
 
-    Returns a dict with keys: aruco, corners, counter, ring, timestamp.
-    Structure mirrors ground_truth.json to simplify comparison.
+    Returns a dict with keys: aruco, corners, counter, ring, timestamp,
+    homography, rough_homography. Structure mirrors ground_truth.json to
+    simplify comparison.
     """
     steps = stats.get("steps", {})
 
@@ -89,6 +95,8 @@ def extract_pipeline_result(stats):
         "counter": counter,
         "ring": ring,
         "timestamp": timestamp,
+        "homography": _matrix(stats.get("homography")),
+        "rough_homography": _matrix(stats.get("rough_homography")),
     }
 
 

--- a/sw/rocsync/benchmark/validate.py
+++ b/sw/rocsync/benchmark/validate.py
@@ -30,7 +30,7 @@ from rocsync.benchmark.common import (
 )
 from rocsync.board_profiles import PROFILES_BY_ARUCO
 from rocsync.camera import CameraType
-from rocsync.timeline import frame_pts, summarize_timeline
+from rocsync.timeline import frame_pts, source_frame_period_ms, summarize_timeline
 from rocsync.vision import process_frame
 
 
@@ -196,7 +196,11 @@ def fit_videos(frames, results):
 
         try:
             statistics, _, considered, rejected, _ = summarize_timeline(
-                timestamps, frame_times, len(frame_times), fps
+                timestamps,
+                frame_times,
+                len(frame_times),
+                fps,
+                frame_period_ms=source_frame_period_ms(path),
             )
         except ValueError as e:
             videos[rel_path] = {

--- a/sw/rocsync/benchmark/validate.py
+++ b/sw/rocsync/benchmark/validate.py
@@ -54,8 +54,10 @@ def extract_pipeline_result(stats):
     board = PROFILES_BY_ARUCO[aruco_id] if aruco_id is not None else None
 
     # -- Corners (original image coordinates, as annotated) --
+    n_leds = len(board.always_on_leds[CameraType.RGB]) if board is not None else 4
     corners = [
-        {"visible": pos is not None, "position": pos} for pos in corner_positions_in_image(stats)
+        {"visible": pos is not None, "position": pos}
+        for pos in corner_positions_in_image(stats, n_leds)
     ]
 
     # -- Counter --

--- a/sw/rocsync/timeline.py
+++ b/sw/rocsync/timeline.py
@@ -101,11 +101,36 @@ def detect_dropouts(pts, period):
     return len(gaps), n_dropped, float(largest_gap), gaps
 
 
+# A RANSAC inlier band has to be wide enough to absorb real jitter (the sensor exposes
+# when it pleases, not on the container's nominal grid) but tight enough that a genuine
+# misdecode -- typically off by whole ring/counter periods -- still falls outside it.
+# Scaling off the frame period keeps that band meaningful at any frame rate; the clamp
+# keeps it meaningful when the period itself is very small or unknown.
+MEASURED_RESIDUAL_FRACTION = 1 / 3  # of a source frame
+MEASURED_RESIDUAL_MIN_MS = 2.0  # never tighter than the board itself resolves
+MEASURED_RESIDUAL_MAX_MS = 50.0  # below the ring period, so a counter step still shows
+
+
+def measured_residual_threshold_ms(frame_period_ms):
+    """How far a fitted frame may sit from its decoded board time and still be an inlier.
+
+    Deliberately not derived from the spacing between the frames actually offered to a
+    fit: a subsampled/decimated recording's frames are spaced by the sampling, not the
+    sensor, so that spacing would inflate the threshold enough to accept a misdecode
+    that is wrong by whole ring or counter periods. `frame_period_ms` should be the true
+    sensor frame period instead, e.g. from `source_frame_period_ms`.
+    """
+    if not frame_period_ms:
+        return MEASURED_RESIDUAL_MAX_MS
+    scaled = frame_period_ms * MEASURED_RESIDUAL_FRACTION
+    return min(max(scaled, MEASURED_RESIDUAL_MIN_MS), MEASURED_RESIDUAL_MAX_MS)
+
+
 def fit_timeline(
     frame_times,
     timestamps,
     residual_threshold=None,
-    fallback_period=None,
+    frame_period_ms=None,
     max_trials=1000,
 ):
     """Robustly fit board time against a source clock.
@@ -116,11 +141,15 @@ def fit_timeline(
     For video, the source clock is the container's presentation timestamp and
     the keys are frame indices. For a device that reports its own clock, pass
     an identity map and an explicit `residual_threshold`; without one the
-    threshold is the median frame period, i.e. at most one frame of deviation.
+    threshold is derived from `frame_period_ms`, the true sensor frame period
+    (see `measured_residual_threshold_ms`) -- deliberately not measured off
+    `frame_times` itself, since a subsampled/decimated recording's frames are
+    spaced by the sampling, not the sensor, and would otherwise inflate the
+    threshold enough to accept far-too-large misdecodes as inliers.
 
     Only frames present in both dicts are used. Raises ValueError if fewer than
-    two such frames exist, if no usable threshold can be determined, or if the
-    fit is degenerate (a non-positive or non-finite clock rate).
+    two such frames exist, or if the fit is degenerate (a non-positive or
+    non-finite clock rate).
     """
     order = sorted(k for k in timestamps if frame_times.get(k) is not None)
     if len(order) < 2:
@@ -136,9 +165,7 @@ def fit_timeline(
 
     threshold = residual_threshold
     if threshold is None:
-        threshold = median_frame_period(frame_times.values(), fallback=fallback_period)
-    if not threshold or threshold <= 0:
-        raise ValueError("Unable to determine a usable residual threshold.")
+        threshold = measured_residual_threshold_ms(frame_period_ms)
 
     model = RANSACRegressor(
         residual_threshold=threshold,  # max one frame deviation
@@ -182,6 +209,7 @@ def summarize_timeline(
     fps,
     window_frame_times=None,
     timeline_windowed=False,
+    frame_period_ms=None,
 ):
     """Fit board time against the container clock and describe the result.
 
@@ -193,6 +221,11 @@ def summarize_timeline(
     `window_frame_times` lists the frames of each search window separately, because a
     gap between two disjoint windows is not a dropout. Callers that scanned the whole
     file can leave it out.
+
+    `frame_period_ms` is the true sensor frame period, used to size the fit's inlier
+    band (see `measured_residual_threshold_ms`); pass it whenever it's known, e.g. via
+    `source_frame_period_ms`, since a subsampled/decimated input's own frame spacing is
+    not a safe stand-in. Without one, the container's nominal fps is used instead.
 
     Returns (statistics, fit, considered, rejected, gaps). Raises ValueError when the
     timeline cannot be fitted.
@@ -209,7 +242,7 @@ def summarize_timeline(
         raise ValueError("Unable to determine the frame period.")
 
     try:
-        fit = fit_timeline(frame_times, timestamps, fallback_period=nominal_period)
+        fit = fit_timeline(frame_times, timestamps, frame_period_ms=frame_period_ms or nominal_period)
     except ValueError as e:
         raise ValueError(f"Unable to fit the frame timeline: {e}") from e
 
@@ -366,6 +399,36 @@ def frame_pts(video_path):
         start = float(stream.get("start_pts", ticks[0]))
         return [(t - start) * time_base * 1000 for t in ticks]
     return _decoded_frame_pts(video_path)
+
+
+def source_frame_period_ms(video_path):
+    """Frame period of the recording this file was cut from, in ms, or None.
+
+    A decimated clip cannot say this in its timing: keeping the frames' original
+    timestamps is what a clock is fitted to, and those timestamps describe the
+    subsampling, not the recording. `prepare_clip.sh` therefore writes the recording's
+    frame rate to a metadata tag, which no muxer reinterprets, and that is read first.
+    """
+    tagged = run_ffprobe(
+        video_path, "-show_entries", "format_tags=source_frame_rate", "-of", "csv=p=0"
+    )
+    # csv output pads a trailing empty field with a comma, and quotes a value holding one
+    rate = parse_ratio((tagged or "").strip().strip('"').rstrip(","))
+    if rate:
+        return 1000 / rate
+
+    # A clip cut before the tag existed says it in its packets instead: an encoder that
+    # rounds timestamps onto the frame-rate grid leaves the recording's rate behind there
+    durations = [d for d in probe_packet_field(video_path, "duration_time") if d > 0]
+    if durations:
+        # The mode, so one odd packet at a cut cannot stand for the whole recording
+        return float(max(set(durations), key=durations.count)) * 1000
+
+    # Without a packet duration the spacing is all there is, subsampled or not
+    try:
+        return median_frame_period(frame_pts(video_path))
+    except OSError:
+        return None  # a file that will not open has no period to report
 
 
 def _decoded_frame_pts(video_path):

--- a/sw/rocsync/timeline.py
+++ b/sw/rocsync/timeline.py
@@ -311,10 +311,16 @@ def _is_float(text):
     return True
 
 
-def _parse_ratio(text):
-    """A 'num/den' ffprobe ratio as a float, or None if it is not one."""
-    num, _, den = (text or "").partition("/")
+def parse_ratio(text):
+    """An ffprobe 'num/den' ratio as a float, or None if it is not a number at all.
+
+    A plain number is accepted too, so a field ffprobe prints as a ratio and a human
+    writes as a decimal both read the same.
+    """
+    num, sep, den = (text or "").partition("/")
     try:
+        if not sep:
+            return float(num)
         num, den = float(num), float(den)
     except ValueError:
         return None
@@ -353,7 +359,7 @@ def frame_pts(video_path):
         elif value and value != "N/A":
             stream[name] = value
 
-    time_base = _parse_ratio(stream.get("time_base"))
+    time_base = parse_ratio(stream.get("time_base"))
     if ticks and time_base is not None:
         # Packets arrive in decode order, which B-frames make differ from display order
         ticks.sort()

--- a/sw/rocsync/video.py
+++ b/sw/rocsync/video.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 
 from rocsync.clips import MAX_FRAMES_IN_FLIGHT
 from rocsync.printer import errprint, print, printresult, warnprint
-from rocsync.timeline import summarize_timeline
+from rocsync.timeline import source_frame_period_ms, summarize_timeline
 from rocsync.video_statistics import VideoStatistics
 from rocsync.vision import CameraType, process_frame
 
@@ -270,6 +270,10 @@ def process_video(
     n_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
     cap.release()
 
+    # The true sensor frame period, immune to a file that is itself a decimated clip --
+    # sizes the clock fit's inlier band instead of the possibly-subsampled frame spacing
+    frame_period_ms = source_frame_period_ms(video_path)
+
     # Whether the reported span and dropouts describe the file or just the windows
     timeline_windowed = bool(windows)
 
@@ -306,6 +310,7 @@ def process_video(
             fps,
             window_frame_times=window_frame_times,
             timeline_windowed=timeline_windowed,
+            frame_period_ms=frame_period_ms,
         )
     except ValueError as e:
         errprint(f"Error: {e}")

--- a/sw/rocsync/vision.py
+++ b/sw/rocsync/vision.py
@@ -216,7 +216,16 @@ def find_corners_convexhull(mask, frame_number, debug_dir=None):
         return corners
 
 
+
 def find_corners_dots(mask, frame_number, board, debug_dir=None):
+    """Match always-on LEDs to their expected spots.
+
+    Returns one row per always-on LED of the board, in board order, holding the matched
+    position in `mask` coordinates or NaN where nothing landed close enough. A caller
+    filters on `np.isfinite` and indexes `board.always_on_leds` with the same mask to
+    recover the nominal spots. Strict mode requires every LED and returns None if any is
+    missing.
+    """
     corner_dots = board.always_on_leds[CameraType.RGB]
     points = blob_detector.detect(mask)
     if not points:
@@ -346,7 +355,7 @@ def rectify_board(
             if corners is None:
                 return True, None, board
             if stats is not None:
-                stats["corner_positions"] = corners.tolist()
+                stats["corner_positions"] = None if corners is None else corners.tolist()
 
             # Only the four anchors define the transform; any extra always-on dots were
             # matched purely as a sanity check.

--- a/sw/rocsync/vision.py
+++ b/sw/rocsync/vision.py
@@ -220,16 +220,11 @@ def find_corners_convexhull(mask, frame_number, debug_dir=None):
 def find_corners_dots(mask, frame_number, board, debug_dir=None):
     """Match always-on LEDs to their expected spots.
 
-    Returns one row per always-on LED of the board, in board order, holding the matched
-    position in `mask` coordinates or NaN where nothing landed close enough. A caller
-    filters on `np.isfinite` and indexes `board.always_on_leds` with the same mask to
-    recover the nominal spots. Strict mode requires every LED and returns None if any is
-    missing.
+    Returns one row per always-on LED of the board, in board order, holding the
+    matched position in `mask` coordinates or NaN where nothing landed close enough.
     """
     corner_dots = board.always_on_leds[CameraType.RGB]
     points = blob_detector.detect(mask)
-    if not points:
-        return
     if debug_dir:
         debug_image = cv2.drawKeypoints(
             mask,
@@ -239,17 +234,34 @@ def find_corners_dots(mask, frame_number, board, debug_dir=None):
             cv2.DRAW_MATCHES_FLAGS_DRAW_RICH_KEYPOINTS,
         )
         cv2.imwrite(f"{debug_dir}/corner_{frame_number}.png", debug_image)
+    if not points:
+        return np.full((len(corner_dots), 2), np.nan, dtype=np.float32)
 
-    closest_points = [
-        min(points, key=lambda p: np.linalg.norm(p.pt - target)).pt for target in corner_dots
-    ]
-    max_distance = max(
-        [np.linalg.norm(act - exp) for act, exp in zip(closest_points, corner_dots, strict=True)]
+    # For each target, find its closest available blob; commit the globally closest
+    # target/blob pair first and remove that blob, so no blob is claimed by two targets.
+    available = list(points)
+    assigned = {}
+    while available and len(assigned) < len(corner_dots):
+        best = None
+        for i, target in enumerate(corner_dots):
+            if i in assigned:
+                continue
+            blob = min(available, key=lambda p: np.linalg.norm(p.pt - target))
+            dist = np.linalg.norm(blob.pt - target)
+            if best is None or dist < best[2]:
+                best = (i, blob, dist)
+        i, blob, dist = best
+        assigned[i] = (blob.pt, dist)
+        available.remove(blob)
+
+    return np.array(
+        [
+            assigned[i][0] if i in assigned and assigned[i][1] <= board.rough_corner_tol
+            else (np.nan, np.nan)
+            for i in range(len(corner_dots))
+        ],
+        dtype=np.float32,
     )
-    if max_distance > board.rough_corner_tol:
-        return  # Some corner is too far away from where it should be
-
-    return np.array(closest_points, dtype=np.float32)
 
 
 def find_corners_aruco(mask, frame_number, debug_dir=None):
@@ -345,20 +357,22 @@ def rectify_board(
                 stats["rough_homography"] = rough_transformation_matrix
             t0 = time.perf_counter()
             corners = find_corners_dots(rough_pcb, frame_number, board, debug_dir)
+            found = np.isfinite(corners).all(axis=1)
             _record_step(
                 stats,
                 "corner_detection",
                 t0,
-                success=corners is not None,
-                count=0 if corners is None else len(corners),
+                success=bool(found.any()),
+                count=int(found.sum()),
             )
-            if corners is None:
-                return True, None, board
             if stats is not None:
-                stats["corner_positions"] = None if corners is None else corners.tolist()
+                stats["corner_positions"] = corners.tolist()
 
-            # Only the four anchors define the transform; any extra always-on dots were
-            # matched purely as a sanity check.
+            # The first four always-on LEDs are the perspective-transform anchors; without
+            # all four there's nothing to fit the fine homography from. Any extra always-on
+            # dots beyond those four were matched purely as a sanity check.
+            if not found[:4].all():
+                return True, None, board
             transformation_matrix = np.dot(
                 cv2.getPerspectiveTransform(corners[:4], board.transform_corners(CameraType.RGB)),
                 rough_transformation_matrix,

--- a/sw/tests/test_benchmark_timeline.py
+++ b/sw/tests/test_benchmark_timeline.py
@@ -146,7 +146,7 @@ def test_a_matching_clock_scores_no_error():
     assert metrics["status"] is None
     assert metrics["clock_rate_error_ppm"] == pytest.approx(0.0, abs=1e-6)
     assert metrics["clock_offset_error_ms"] == pytest.approx(0.0, abs=1e-9)
-    assert metrics["sync_error_max_ms"] == pytest.approx(0.0, abs=1e-9)
+    assert metrics["frame_time_error_ms"] == pytest.approx(0.0, abs=1e-9)
     assert len(metrics["residuals_ms"]) == 20
 
 
@@ -157,8 +157,8 @@ def test_a_shifted_clock_is_off_by_that_shift_everywhere():
 
     assert metrics["clock_offset_error_ms"] == pytest.approx(12.5)
     # A pure offset error does not decay along the recording
-    assert metrics["sync_error_first_ms"] == pytest.approx(12.5)
-    assert metrics["sync_error_last_ms"] == pytest.approx(12.5)
+    assert metrics["first_frame_error_ms"] == pytest.approx(12.5)
+    assert metrics["last_frame_error_ms"] == pytest.approx(12.5)
     assert descriptive_stats(metrics["residuals_ms"])["mean"] == pytest.approx(12.5, abs=0.5)
 
 
@@ -167,9 +167,9 @@ def test_outlier_rejection_is_scored_against_the_annotations():
 
     metrics = compute_clock_metrics(benchmark, ground_truth)[VIDEO]
 
-    assert metrics["false_rejections"] == 1  # frame 9 decoded correctly but was thrown out
-    assert metrics["false_acceptances"] == 1  # frame 3 was misdecoded but kept
-    assert metrics["n_flagged"] == 20
+    assert metrics["rejected_but_correct"] == 1  # frame 9 decoded correctly but was thrown out
+    assert metrics["considered_but_misdecoded"] == 1  # frame 3 was misdecoded but kept
+    assert metrics["n_checked_frames"] == 20
 
 
 def test_a_run_without_a_timeline_is_reported_rather_than_scored():
@@ -193,7 +193,7 @@ def test_a_retimed_clip_is_scored_through_the_annotations_it_was_cut_from():
 
     assert VIDEO not in metrics  # scored once, through the clip that stands in for it
     assert metrics[RETIMED]["timeline"] == "synthesized"
-    assert metrics[RETIMED]["sync_error_max_ms"] == pytest.approx(0.0, abs=1e-9)
+    assert metrics[RETIMED]["frame_time_error_ms"] == pytest.approx(0.0, abs=1e-9)
     # The frames the trim cut have no prediction, so they are skipped rather than missed
     assert len(metrics[RETIMED]["residuals_ms"]) == 20 - TRIMMED
 
@@ -204,9 +204,9 @@ def test_a_misdecode_is_attributed_through_the_retiming():
 
     metrics = compute_clock_metrics(benchmark, ground_truth)[RETIMED]
 
-    assert metrics["false_acceptances"] == 1  # frame 7 was misdecoded but kept
-    assert metrics["false_rejections"] == 1  # frame 9 decoded correctly but was thrown out
-    assert metrics["n_flagged"] == 20 - TRIMMED
+    assert metrics["considered_but_misdecoded"] == 1  # frame 7 was misdecoded but kept
+    assert metrics["rejected_but_correct"] == 1  # frame 9 decoded correctly but was thrown out
+    assert metrics["n_checked_frames"] == 20 - TRIMMED
 
 
 def test_aggregation_splits_measured_from_retimed_videos():
@@ -237,7 +237,7 @@ def test_aggregation_keeps_the_worst_video_and_sums_the_frame_counts():
     assert group["clock_offset_error_ms_max_abs"] == pytest.approx(12.5)
     assert group["clock_offset_error_ms_mean_abs"] == pytest.approx(8.25)
     assert group["n_rejected_frames"] == 2  # one frame per video
-    assert group["n_flagged"] == 40
+    assert group["n_checked_frames"] == 40
     assert group["residual_vs_gt_ms"]["n"] == 40
 
 
@@ -249,4 +249,4 @@ def test_aggregation_names_the_videos_it_could_not_score():
 
     assert (group["n_scored"], group["n_videos"]) == (0, 1)
     assert group["unscored"] == "no video timeline recorded (1)"
-    assert group["sync_error_max_ms"] is None
+    assert group["frame_time_error_ms_max"] is None

--- a/sw/tests/test_ground_truth.py
+++ b/sw/tests/test_ground_truth.py
@@ -2,13 +2,15 @@
 
 Each annotation carries corner LED positions in image space and a homography, and the
 evaluation relies on the two describing the same board pose: warping the modelled LED
-layout through the homography must land on the annotated positions. Both ways of
-producing an annotation make that exact rather than approximate — a four-point
-``getPerspectiveTransform`` fit has no residual, and the pipeline's fine transform is
-built from the same corners it reports — so this pins an invariant rather than measuring
-agreement. It earns its keep by catching a file whose positions were edited without
-recomputing the homography, and it becomes a real least-squares check on v2 boards,
-whose fifth always-on LED over-determines the fit.
+layout through the homography must land on the annotated positions. That holds where the
+visible corners determine the homography — a four-point ``getPerspectiveTransform`` fit
+has no residual, and a v2 board's fifth always-on LED turns it into a least-squares fit
+that lands within a few pixels. It earns its keep by catching a file whose positions were
+edited without recomputing the homography.
+
+Below four corners in general position there is nothing to refit, so the annotator leaves
+whatever homography was in place while the corners are dragged. Those frames are reported
+rather than failed: the annotation tool is where that gap belongs, not a test.
 
 The dataset lives outside the repository, so the test skips when it is absent. Point
 ROCSYNC_GROUND_TRUTH at a ground_truth.json to run it elsewhere.
@@ -16,13 +18,19 @@ ROCSYNC_GROUND_TRUTH at a ground_truth.json to run it elsewhere.
 
 import json
 import os
+import warnings
 from pathlib import Path
 
 import cv2
 import numpy as np
 import pytest
 
-from rocsync.benchmark.annotate import annotated_starts, derive_reference_clock, video_rel_paths
+from rocsync.benchmark.annotate import (
+    annotated_starts,
+    derive_reference_clock,
+    fit_corner_homography,
+    video_rel_paths,
+)
 from rocsync.benchmark.common import (
     MIN_REFERENCE_FRAMES,
     ReferenceClock,
@@ -40,8 +48,9 @@ GROUND_TRUTH = Path(
     )
 )
 
-# Exact for a four-point fit; the slack covers v2's least-squares fit over five LEDs.
-TOL_PX = 2.0
+# Exact for a four-point fit; the slack covers v2's least-squares fit over five LEDs,
+# whose two leftmost LEDs sit 38 px apart and so trade a few pixels against each other.
+TOL_PX = 4.0
 
 pytestmark = pytest.mark.skipif(
     not GROUND_TRUTH.is_file(), reason=f"ground truth not available at {GROUND_TRUTH}"
@@ -71,6 +80,18 @@ def _nominal_in_image(gt):
     return cv2.perspectiveTransform(pts, inv_H).reshape(-1, 2)
 
 
+def _determines_its_homography(gt):
+    """Whether this frame's visible corners are the ones its homography could come from."""
+    aruco_id = gt.get("aruco", {}).get("id")
+    if aruco_id not in PROFILES_BY_ARUCO:
+        return False
+    corners = [
+        {"visible": bool(c.get("visible")), "position": c.get("position")}
+        for c in gt.get("corners", [])
+    ]
+    return fit_corner_homography(corners, PROFILES_BY_ARUCO[aruco_id].rectify()) is not None
+
+
 def test_annotated_corners_match_the_warped_layout(annotations):
     """The homography and the annotated positions describe the same board pose.
 
@@ -78,11 +99,15 @@ def test_annotated_corners_match_the_warped_layout(annotations):
     licenses that, rather than reprojecting the modelled layout instead.
     """
     offenders = []
+    unverifiable = []
     compared = 0
 
     for key, gt in annotations.items():
         nominal = _nominal_in_image(gt)
         if nominal is None:
+            continue
+        if not _determines_its_homography(gt):
+            unverifiable.append(key)
             continue
         for i, corner in enumerate(gt.get("corners", [])):
             if not corner.get("visible") or corner.get("position") is None:
@@ -93,6 +118,14 @@ def test_annotated_corners_match_the_warped_layout(annotations):
             compared += 1
             if err > TOL_PX:
                 offenders.append(f"{key} corner {i}: {err:.2f} px")
+
+    if unverifiable:
+        warnings.warn(
+            f"{len(unverifiable)} frame(s) have too few corners to determine a homography, "
+            "so their annotated positions and their homography cannot be checked against "
+            "each other:\n  " + "\n  ".join(unverifiable[:20]),
+            stacklevel=1,
+        )
 
     assert compared > 0, "no annotated corner had a homography to check against"
     assert not offenders, (

--- a/sw/tests/test_reference_clock.py
+++ b/sw/tests/test_reference_clock.py
@@ -15,19 +15,22 @@ import pytest
 
 import rocsync.benchmark
 from rocsync.benchmark.common import (
-    MEASURED_RESIDUAL_MAX_MS,
-    MEASURED_RESIDUAL_MIN_MS,
     MIN_REFERENCE_FRAMES,
     SYNTHESIZED_RESIDUAL_THRESHOLD_MS,
     ReferenceClock,
     fit_reference_clock,
-    measured_residual_threshold_ms,
     reference_outliers,
     reference_residual,
     residual_threshold_ms,
+)
+from rocsync.timeline import (
+    MEASURED_RESIDUAL_MAX_MS,
+    MEASURED_RESIDUAL_MIN_MS,
+    frame_pts,
+    measured_residual_threshold_ms,
+    median_frame_period,
     source_frame_period_ms,
 )
-from rocsync.timeline import frame_pts, median_frame_period
 
 PERIOD = 500.0  # ms between frames
 THRESHOLD_MS = 2.0

--- a/sw/tests/test_reference_clock.py
+++ b/sw/tests/test_reference_clock.py
@@ -9,9 +9,11 @@ full error instead of dragging the line towards itself and hiding half of it.
 
 import shutil
 import subprocess
+from pathlib import Path
 
 import pytest
 
+import rocsync.benchmark
 from rocsync.benchmark.common import (
     MEASURED_RESIDUAL_MAX_MS,
     MEASURED_RESIDUAL_MIN_MS,
@@ -108,13 +110,9 @@ def test_round_trips_through_a_dict():
 # ── Per-video tolerance ─────────────────────────────────────────────────────
 
 
-def test_the_measured_tolerance_is_a_third_of_a_source_frame():
-    assert measured_residual_threshold_ms(33.333) == pytest.approx(11.111, abs=1e-3)
-
-
 def test_the_measured_tolerance_is_clamped_at_both_ends():
-    # A 240 fps camera would ask for less than the board itself resolves
-    assert measured_residual_threshold_ms(1000 / 240) == MEASURED_RESIDUAL_MIN_MS
+    # A camera fast enough that a whole frame is below what the board itself resolves
+    assert measured_residual_threshold_ms(MEASURED_RESIDUAL_MIN_MS) == MEASURED_RESIDUAL_MIN_MS
     # and a 2 fps one for more than a ring period, which would hide a counter step
     assert measured_residual_threshold_ms(500.0) == MEASURED_RESIDUAL_MAX_MS
     # An unreadable frame rate falls back to the loosest tolerance rather than the tightest
@@ -128,7 +126,7 @@ def test_a_synthesized_timeline_is_held_to_one_led_at_each_end():
 
 def test_a_measured_timeline_is_held_to_its_own_frame_rate():
     entry = {"timeline": "measured", "source_frame_period_ms": 33.333}
-    assert residual_threshold_ms(entry) == pytest.approx(11.111, abs=1e-3)
+    assert residual_threshold_ms(entry) == measured_residual_threshold_ms(33.333)
 
 
 def test_a_stored_tolerance_outranks_the_rule_of_the_day():
@@ -137,27 +135,48 @@ def test_a_stored_tolerance_outranks_the_rule_of_the_day():
     assert residual_threshold_ms({**entry, "residual_threshold_ms": 7.5}) == 7.5
 
 
+PREPARE_CLIP = Path(rocsync.benchmark.__file__).parent / "prepare_clip.sh"
+
+
 @pytest.fixture(scope="module")
 def decimated_clip(tmp_path_factory):
-    """Every 16th frame of a 30 fps recording, the shape the dataset's clips have."""
+    """A 30 fps recording cut down to ~2 fps, the shape the dataset's clips have."""
     directory = tmp_path_factory.mktemp("decimated")
     source, decimated = directory / "src.mp4", directory / "decimated.mp4"
-    common = ["ffmpeg", "-y", "-loglevel", "error"]
     subprocess.run(
-        [*common, "-f", "lavfi", "-i", "testsrc=size=64x48:rate=30:duration=4",
+        ["ffmpeg", "-y", "-loglevel", "error",
+         "-f", "lavfi", "-i", "testsrc=size=64x48:rate=30:duration=4",
          "-c:v", "libx264", "-pix_fmt", "yuv420p", str(source)],
         check=True,
     )  # fmt: skip
-    subprocess.run(
-        [*common, "-i", str(source), "-vf", "select='not(mod(n,16))'",
-         "-fps_mode", "passthrough", "-c:v", "libx264", str(decimated)],
-        check=True,
-    )  # fmt: skip
-    return decimated
+    subprocess.run([str(PREPARE_CLIP), str(source), "1.9", str(decimated)], check=True)
+    return source, decimated
 
 
 @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="needs ffmpeg to synthesize the clip")
 def test_the_source_frame_period_survives_decimation(decimated_clip):
-    """The clip's timestamps sit 533 ms apart, but its packets still say 33.3 ms."""
-    assert median_frame_period(frame_pts(decimated_clip)) == pytest.approx(533, abs=1)
-    assert source_frame_period_ms(decimated_clip) == pytest.approx(1000 / 30, abs=0.1)
+    """The clip's own frames sit 533 ms apart, and it still reports the 30 fps it was cut from.
+
+    The tolerance scales from the recording's frame rate, so a clip that could only report
+    its own would be held to a bound 16 times too loose to catch anything.
+    """
+    _, clip = decimated_clip
+
+    assert median_frame_period(frame_pts(clip)) == pytest.approx(533, abs=1)
+    assert source_frame_period_ms(clip) == pytest.approx(1000 / 30, abs=0.1)
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="needs ffmpeg to synthesize the clip")
+def test_a_prepared_clip_keeps_the_timestamps_it_was_cut_from(decimated_clip):
+    """The frames it kept sit where they sat in the recording.
+
+    An encoder left to itself rounds every timestamp onto the grid of the frame rate it
+    guesses, which on a real recording moves a frame by up to half a source frame -- more
+    than the tolerance a clock fitted to those frames is held to.
+    """
+    source, clip = decimated_clip
+    recorded, kept = frame_pts(source), frame_pts(clip)
+
+    assert len(kept) > 5
+    for pts in kept:
+        assert min(abs(pts - t) for t in recorded) == pytest.approx(0.0, abs=0.01)

--- a/sw/tests/test_timeline_fit.py
+++ b/sw/tests/test_timeline_fit.py
@@ -123,7 +123,7 @@ def test_fit_needs_two_usable_frames():
         fit_timeline({0: 0.0}, {0: (1.0, 2.0)})
     # A timestamped frame whose presentation timestamp is unknown is unusable
     with pytest.raises(ValueError):
-        fit_timeline({0: 0.0}, {0: (1.0, 2.0), 5: (3.0, 4.0)}, fallback_period=33.0)
+        fit_timeline({0: 0.0}, {0: (1.0, 2.0), 5: (3.0, 4.0)}, frame_period_ms=33.0)
 
 
 def test_fit_ignores_timestamps_without_a_presentation_time():


### PR DESCRIPTION
**Bugfixes:**
* Fixes an indexing bug in the benchmark that misinterpreted the always-on corner LED correspondences if some were missing.
* Subsampled benchmark videos now keep a metadata tag with the original frame-rate information, as this frame-rate is used as the basis for determining the timestamp inlier vs. outlier threshold
* The timestamp inlier vs. outlier threshold is now gated between 2 - 50 ms and defaults to 33.3% of the video framerate. We're assuming that higher-fps cameras also produce more accurate frame timestamps. The gates are motivated by in-transit ring LEDs at the start and end of the arc (~2ms error is the expected noise floor); and 50ms to filter out binary clock decoding errors (yielding >=100ms error).
* Avoid calling corners.tolist() unconditionally, as corners may be None

**Improvements:**
* Aligns the metrics printed by rocsync-evaluate with the ones output by rocsync itself
* Report exact timestamp decodes and +-1 LED decode errors (tolerate read errors of in-transit LEDs)
* Annotation tool: Initialize board overlay centered on the input image
* Evaluation tool: Report consistent metrics for rough and refined homography

# Benchmark Comparison

Summary: Exact same results for all steps except for the clock_fit section. The benchmark_bugfix branch yields significantly better results, as it correctly discards outliers.

```Ground truth: /home/jonas/datasets/rocsync_benchmark/ground_truth.json (604 frames)
Methods: benchmark_bugfixes, benchmark_PR
  benchmark_bugfixes: feature/benchmark_bugfixes@c6b46a9  2026-08-25T12:01:08+00:00  cv2 5.0.0  numpy 2.5.1  599 images, scores 599/604
  benchmark_PR: feature/benchmark@0001e59  2026-08-25T12:30:50+00:00  cv2 5.0.0  numpy 2.5.1  599 images, scores 599/604

WARNING: 5 ground truth frame(s) no column scores. If those inputs are gone, prune them:
  rocsync-annotate <data_dir> --prune
    eFAST/20260717_131635_zed_left.mp4: 5 frame(s)
```

---
  ARUCO DETECTION
---
                                              benchmark_bugfixes          benchmark_PR
    --------------DETECTION---------------  --------------------  --------------------
                                        TP                   502                   502
                                        FP                     0                     0
                                        FN                    87                    87
                                        TN                    10                    10
                              TPR (Recall)                 85.2%                 85.2%
                                       FPR                  0.0%                  0.0%
                                 Precision                100.0%                100.0%
                                  F1 Score                 92.0%                 92.0%

                                              benchmark_bugfixes          benchmark_PR
    ----CORNER ERROR (PX, IMAGE SPACE)----  --------------------  --------------------
                                      mean                  1.89                  1.89
                                       std                  1.70                  1.70
                                       min                  0.00                  0.00
                                    median                  1.22                  1.22
                                       max                 16.69                 16.69
                                         n                   502                   502
---
  CORNER LED DETECTION
---
                                              benchmark_bugfixes          benchmark_PR
    DETECTION (THRES: 3PX IN IMAGE SPACE)-  --------------------  --------------------
                                        TP                   124                   124
                                        FP                     0                     0
                                        FN                   469                   469
                                        TN                     6                     6
                              TPR (Recall)                 20.9%                 20.9%
                                       FPR                  0.0%                  0.0%
                                 Precision                100.0%                100.0%
                                  F1 Score                 34.6%                 34.6%

                                              benchmark_bugfixes          benchmark_PR
    DETECTION (THRES: 8PX IN BOARD SPACE)-  --------------------  --------------------
                                        TP                   575                   575
                                        FP                     0                     0
                                        FN                  1962                  1962
                                        TN                    81                    81
                              TPR (Recall)                 22.7%                 22.7%
                                       FPR                  0.0%                  0.0%
                                 Precision                100.0%                100.0%
                                  F1 Score                 37.0%                 37.0%

                                              benchmark_bugfixes          benchmark_PR
    ------PIXEL ERROR — IMAGE SPACE-------  --------------------  --------------------
                                      mean                  0.58                  0.58
                                       std                  4.21                  4.21
                                       min                  0.00                  0.00
                                    median                  0.02                  0.02
                                       max                 61.07                 61.07
                                         n                   587                   587

                                              benchmark_bugfixes          benchmark_PR
    ------PIXEL ERROR — BOARD SPACE-------  --------------------  --------------------
                                      mean                  0.82                  0.82
                                       std                  5.19                  5.19
                                       min                  0.00                  0.00
                                    median                  0.02                  0.02
                                       max                 39.02                 39.02
                                         n                   587                   587
---
  COUNTER READING
---
                                              benchmark_bugfixes          benchmark_PR
    --------------DETECTION---------------  --------------------  --------------------
                                        TP                   124                   124
                                        FP                     0                     0
                                        FN                   460                   460
                                        TN                    15                    15
                              TPR (Recall)                 21.2%                 21.2%
                                       FPR                  0.0%                  0.0%
                                 Precision                100.0%                100.0%
                                  F1 Score                 35.0%                 35.0%

                                              benchmark_bugfixes          benchmark_PR
    ------------VALUE ACCURACY------------  --------------------  --------------------
                     counter.value correct         122/124 (98%)         122/124 (98%)
---
  RING READING
---
                                              benchmark_bugfixes          benchmark_PR
    --------------DETECTION---------------  --------------------  --------------------
                                        TP                   123                   123
                                        FP                     1                     1
                                        FN                   452                   452
                                        TN                    23                    23
                              TPR (Recall)                 21.4%                 21.4%
                                       FPR                  4.2%                  4.2%
                                 Precision                 99.2%                 99.2%
                                  F1 Score                 35.2%                 35.2%

                                              benchmark_bugfixes          benchmark_PR
    ------------VALUE ACCURACY------------  --------------------  --------------------
                          ring.start exact         118/123 (96%)         118/123 (96%)
                         ring.start ±1 LED        123/123 (100%)        123/123 (100%)
                            ring.end exact         116/123 (94%)         116/123 (94%)
                           ring.end ±1 LED        123/123 (100%)        123/123 (100%)
---
  OVERALL (timestamp)
---
                                              benchmark_bugfixes          benchmark_PR
    --------------DETECTION---------------  --------------------  --------------------
                                        TP                   110                   110
                                        FP                     1                     1
                                        FN                   398                   398
                                        TN                    90                    90
                              TPR (Recall)                 21.7%                 21.7%
                                       FPR                  1.1%                  1.1%
                                 Precision                 99.1%                 99.1%
                                  F1 Score                 35.5%                 35.5%

                                              benchmark_bugfixes          benchmark_PR
    ----------TIMESTAMP ACCURACY----------  --------------------  --------------------
                     timestamp exact match         100/110 (91%)         100/110 (91%)
                 mid-exposure within ±1 ms         108/110 (98%)         108/110 (98%)

                                              benchmark_bugfixes          benchmark_PR
    ---------TIMESTAMP ERROR (MS)---------  --------------------  --------------------
                        MID-EXPOSURE ERROR
                                      mean                625.48                625.48
                                       std               4676.41               4676.41
                                       min                  0.00                  0.00
                                    median                  0.00                  0.00
                                       max              40799.50              40799.50
                            EXPOSURE ERROR
                                      mean                  0.09                  0.09
                                       std                  0.32                  0.32
                                       min                  0.00                  0.00
                                    median                  0.00                  0.00
                                       max                  2.00                  2.00
---
  CLOCK FIT (aggregated over videos)
---
                                              benchmark_bugfixes          benchmark_PR
    -----------MEASURED VIDEOS------------  --------------------  --------------------
                             videos scored                   0/4                   0/4
                                  unscored  benchmark_bugfixes: Insufficient number of timestamped frames. (4)
                                  unscored  benchmark_PR: Insufficient number of timestamped frames. (4)
          residual_threshold, loosest [ms]                     -                     -
        clock_rate error, mean |err| [ppm]                     -                     -
       clock_rate error, worst |err| [ppm]                     -                     -
         clock_offset_ms error, mean |err|                     -                     -
        clock_offset_ms error, worst |err|                     -                     -
         first/last_frame error, mean [ms]                     -                     -
        first/last_frame error, worst [ms]                     -                     -
         rmse_after, mean over videos [ms]                     -                     -
        rmse_after, worst over videos [ms]                     -                     -
               r2_after, worst over videos                     -                     -
         n_considered_frames (fit inliers)                     -                     -
          n_rejected_frames (fit outliers)                     -                     -
      n_dropped_frames (gaps in container)                     -                     -
             fit frames with an annotation                     -                     -
         rejected though decoded correctly                     -                     -
                    kept though misdecoded                     -                     -

                                              benchmark_bugfixes          benchmark_PR
    -RESIDUAL VS ANNOTATIONS (MS), POOLED-  --------------------  --------------------
                                      mean                     -                     -
                                       std                     -                     -
                                       min                     -                     -
                                    median                     -                     -
                                       max                     -                     -
                                         n                     0                     0

                                              benchmark_bugfixes          benchmark_PR
    ------------RETIMED VIDEOS------------  --------------------  --------------------
                             videos scored                   3/3                   3/3
          residual_threshold, loosest [ms]                  2.00                  2.00
        clock_rate error, mean |err| [ppm]                  1.85                  9.98
       clock_rate error, worst |err| [ppm]                  4.06                 25.86
         clock_offset_ms error, mean |err|                  0.01                  1.11
        clock_offset_ms error, worst |err|                  0.03                  3.33
         first/last_frame error, mean [ms]                  0.09                  1.17
        first/last_frame error, worst [ms]                  0.19                  3.33
         rmse_after, mean over videos [ms]                  0.15                  5.49
        rmse_after, worst over videos [ms]                  0.23                 16.24
               r2_after, worst over videos                  1.00                  1.00
         n_considered_frames (fit inliers)                    77                    78
          n_rejected_frames (fit outliers)                     3                     2
      n_dropped_frames (gaps in container)                   221                   221
             fit frames with an annotation                    79                    79
         rejected though decoded correctly                     0                     0
                    kept though misdecoded                     7                     7

                                              benchmark_bugfixes          benchmark_PR
    -RESIDUAL VS ANNOTATIONS (MS), POOLED-  --------------------  --------------------
                                      mean                  0.06                  0.89
                                       std                  0.05                  1.28
                                       min                 -0.01                 -0.01
                                    median                  0.05                  0.11
                                       max                  0.19                  3.33
                                         n                   193                   193

---
  TIMING — ALL IMAGES (ms)
---
                                              benchmark_bugfixes          benchmark_PR
    -----------ARUCO_DETECTION------------  --------------------  --------------------
                                      mean                 21.01                 21.05
                                       std                 12.70                 12.66
                                       min                  7.31                  7.52
                                    median                 15.26                 15.43
                                       max                 91.55                 90.23
    ------------CORNER_DETECTION------------
                                      mean                  9.82                  9.81
                                       std                  4.38                  4.39
                                       min                  3.25                  2.84
                                    median                  8.83                  8.84
                                       max                 33.21                 36.08
    -----------FINE_RECTIFICATION-----------
                                      mean                  3.66                  3.66
                                       std                  2.00                  2.02
                                       min                  1.48                  1.52
                                    median                  3.94                  3.64
                                       max                  8.12                  8.36
    ------------COUNTER_READING-------------
                                      mean                  9.06                  8.82
                                       std                  1.45                  0.89
                                       min                  7.13                  7.26
                                    median                  9.02                  8.97
                                       max                 18.35                 11.57
    --------------RING_READING--------------
                                      mean                 42.91                 42.76
                                       std                  1.56                  1.03
                                       min                 41.19                 41.17
                                    median                 42.51                 42.52
                                       max                 51.36                 47.26
    -----------------TOTAL------------------
                                      mean                 38.23                 38.18
                                       std                 34.77                 34.39
                                       min                  7.33                  7.54
                                    median                 17.02                 17.01
                                       max                177.06                179.65
