### PR TITLE
Adding IR video support to benchmark

### DIFF
--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -80,7 +80,8 @@ rather than the saved one, so a correction shows in the number before it is acce
 | Q | Quit |
 | H | Toggle help overlay |
 | 0-9 | Select which corner the next left-panel click places |
-| Esc | Cancel ring LED selection |
+| M | Toggle camera mode (RGB / IR) — switches the LED layout to match |
+| Esc | Cancel ring LED selection, or undo a pending board/marker/camera mode change |
 
 ### Mouse Interactions (left panel)
 
@@ -99,9 +100,22 @@ alone from then on; so does opening a frame that was already annotated.
 
 **Counter LEDs** — Click on a counter LED circle to toggle ON/OFF. Click the counter bounding box (outside individual LEDs) to toggle counter visibility.
 
-**ArUco area** — Click the ArUco region to cycle through marker IDs (0 → 21 → none).
+**ArUco area** — Click the ArUco region to cycle the board revision through four states: ID 0 marker visible, ID 0 hidden, ID 21 visible, ID 21 hidden. A board stays selectable with the marker hidden because the marker is never visible in IR at all.
 
 **Ring LEDs** — Two-click protocol: click a ring LED to set the first ON LED (arc start), then click another to set the first OFF LED (arc end). Clicking the same LED for both sets the ring as undecodable. Press `Esc` to cancel after the first click.
+
+### Camera Mode
+
+Press `M` to toggle between RGB and IR. The two camera types light different physical LEDs at
+different positions, so switching mode swaps the corner, ring, and counter overlay positions to
+match — it does not just relabel the same points. Corner LEDs placed for RGB are not reused for
+IR and vice versa; each mode's board profile keeps its own annotation for the current frame, exactly
+like the ArUco cycle: switching away and back with `M` restores what was annotated in the mode you
+return to, and `Esc` reverts every board, marker, and camera mode change made on the current frame
+back to how it was before you started cycling.
+
+The active camera mode and board revision are shown above the board panel, next to the ArUco
+marker's state.
 
 ### Ground Truth Format
 
@@ -116,6 +130,7 @@ the file rather than a presentation timestamp, which would shift with the decode
 {
   "images": {
     "subdir/image.png": {
+      "camera": "rgb",
       "aruco": {"visible": true, "id": 0},
       "corners": [
         {"visible": true, "position": [123.4, 567.8]},
@@ -129,6 +144,11 @@ the file rather than a presentation timestamp, which would shift with the decode
     },
     "subdir/clip.mp4#000042": {
       "...": "same fields; frame 42 of subdir/clip.mp4"
+    },
+    "subdir/ir_clip.mp4#000012": {
+      "camera": "ir",
+      "aruco": {"visible": false, "id": 21},
+      "...": "same fields, against the IR LED layout of board revision 21 (v2)"
     }
   }
 }
@@ -168,7 +188,13 @@ presentation time to board time that the video's annotations agree on:
 ```
 
 Fields:
-- `aruco.visible` / `aruco.id`: Whether the ArUco marker is visible and its detected ID (omitted when not visible).
+- `camera`: `"rgb"` or `"ir"`. Which camera type the frame was annotated for — the two light
+  physically different LEDs at different board positions, so this decides which layout every
+  other field in the entry is read against.
+- `aruco.id`: The board revision (0 = v1, 21 = v2), always present — it identifies the board
+  layout even on a frame where the marker itself was never seen, which in IR is every frame.
+- `aruco.visible`: Whether the ArUco marker was actually visible in the image. Always false in
+  IR.
 - `corners[i].visible` / `corners[i].position`: Per-corner-LED visibility and position in original image coordinates (position omitted when not visible). Benchmark results use the same space, so the two are directly comparable.
 - `homography`: 3×3 matrix mapping original image → rectified board coordinates.
 - `counter.visible` / `counter.value`: Whether the binary counter is readable and its decoded value (omitted when not visible).
@@ -291,14 +317,18 @@ overrides that.
 Runs the pipeline on every frame in a directory and saves per-frame results in a structure mirroring the ground truth format, plus per-step timing.
 
 ```bash
-uv run rocsync-validate [data_dir] [-o results.json] [--debug DIR]
+uv run rocsync-validate [data_dir] [-o results.json] [-g ground_truth.json] [--debug DIR]
 ```
 
 - `data_dir`: Directory containing validation images and videos (default: `validation_data/`).
 - `-o`: Output JSON file (default: `benchmark_results.json`).
+- `-g`: Ground truth JSON, read for each frame's camera mode and board revision (default:
+  `<data_dir>/ground_truth.json`). IR has no marker to auto-resolve a board from, so a frame runs
+  in IR only if its annotation says so; a frame with no annotation, or no ground truth file at
+  all, runs as RGB with the board left for the pipeline to detect from the marker, same as ever.
 - `--debug`: Directory for debug images.
 
-Results JSON contains a `config` section and an `images` section with per-frame aruco, corners, counter, ring, timestamp, success flag, homography, rough_homography, and timing breakdown. Keys match the ground truth's, so `n_images` in `config` counts benchmark frames rather than files. Corner positions are in original image coordinates, matching the ground truth: the pipeline detects them in the rough-rectified grid, whose scale is a property of the checkout being measured, so they are un-warped through that grid's own homography before being stored. `homography` and `rough_homography` are the pipeline's own image → rectified-board matrices — the fine one fitted from the corner LEDs, the coarse one from the ArUco marker alone — saved as-is so `rocsync-evaluate` can score the rectification itself rather than only the LEDs it was fitted from.
+Results JSON contains a `config` section and an `images` section with per-frame aruco, corners, counter, ring, timestamp, success flag, homography, rough_homography, and timing breakdown. Keys match the ground truth's, so `n_images` in `config` counts benchmark frames rather than files. Corner positions and `homography` are in original image coordinates and image → rectified-board respectively, matching the ground truth — the pipeline fits the homography directly from the detected corners rather than composing it with an intermediate rough fit, so what is stored needs no further transform to compare. `rough_homography` is the pipeline's own coarse image → rectified-board matrix, fitted from the ArUco marker alone (RGB only), saved as-is so `rocsync-evaluate` can score the rectification itself rather than only the LEDs it was fitted from.
 
 Every video additionally gets its clock fitted, by the same code a `rocsync` run uses, and a
 `videos` section records the resulting `VideoStatistics` — clock rate and offset, R²/RMSE
@@ -354,14 +384,13 @@ appears in the frame. Each frame is scored against its own board's sample radius
 board profiles is never scored against the wrong one's threshold.
 
 Rectification scores the homography itself rather than the corners it was fitted from: every LED
-the board model knows about (`board.layout_coords`) is mapped through the predicted homography and
-back through the annotated one, and the round trip's residual is the rectification's own error in
-board px, at every LED position including the ring and counter — regions the four fitted anchors
-only extrapolate into. The reported error statistics pool every LED's residual over every scored
-frame, the same board-px population the corner detection section reports, so the two are directly
-comparable. A frame is a detection when its worst LED still lands inside the sample radius. The
-coarse ArUco-only row is not a competing method; it is the floor the fit degrades to when corner
-refinement fails, so the gap between the two rows is what refinement is worth.
+the board model knows about (`board.layout_coords`, read against the frame's annotated `camera`)
+is mapped through the predicted homography and back through the annotated one, and the round
+trip's residual is the rectification's own error in board px, at every LED position including the
+ring and counter — regions the four fitted anchors only extrapolate into. A frame is a detection
+when its worst LED still lands inside the sample radius. The coarse ArUco-only row is not a
+competing method; it is the floor the fit degrades to when corner refinement fails, so the gap
+between the two rows is what refinement is worth.
 
 Reading position and rectification errors: the annotator pre-fills each image from a pipeline run,
 so on every frame accepted without correction the annotation *is* that pipeline's output — its

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -1230,13 +1230,21 @@ class AnnotationTool:
                 new_ann.ring_start = ann.ring_start
                 new_ann.ring_end = ann.ring_end
             # Place corners at the new layout's default positions.
-            # If a homography is available, convert to original image coords.
+            # If a homography is available, convert to original image coords; otherwise
+            # center a scaled copy of the board layout on the image, matching the
+            # centering a freshly loaded frame gets in `run()`.
             new_corner_pos = corner_led_positions(new_board, new_camera)
+            if new_ann.homography is None:
+                img_h, img_w = self._current_image.shape[:2]
+                scale = 0.5 * min(img_w, img_h) / new_board.board_size
+                ox = (img_w - new_board.board_size * scale) / 2
+                oy = (img_h - new_board.board_size * scale) / 2
             for i, c in enumerate(new_ann.corners):
                 if new_ann.homography is not None:
                     c["position"] = new_ann.to_original(*new_corner_pos[i])
                 else:
-                    c["position"] = list(new_corner_pos[i])
+                    bx, by = new_corner_pos[i]
+                    c["position"] = [ox + bx * scale, oy + by * scale]
                 c["visible"] = False
             self.annotation = new_ann
 
@@ -1393,10 +1401,16 @@ class AnnotationTool:
             cv2.line(board_img, (ax1, ay1), (ax2, ay2), COLOR_NOT_VIS, 2)
             cv2.line(board_img, (ax2, ay1), (ax1, ay2), COLOR_NOT_VIS, 2)
 
-        # Corner LEDs (positions stored in original image space, transform to board)
+        # Corner LEDs (positions stored in original image space, transform to board).
+        # Without a homography there is nothing to project through — `to_board` would
+        # fall back to treating the image-space position as board coordinates, which
+        # scrambles the layout — so draw the board's own default corner positions instead.
         corner_labels = []
         for i, c in enumerate(ann.corners):
-            cx, cy = ann.to_board(*c["position"])
+            if ann.homography is None:
+                cx, cy = self.corner_pos[i]
+            else:
+                cx, cy = ann.to_board(*c["position"])
             cx, cy = cx + m, cy + m
             color = COLOR_ON if c["visible"] else COLOR_NOT_VIS
             cv2.circle(board_img, (cx, cy), LED_RADIUS_PX + 4, color, 2)

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -1451,19 +1451,6 @@ class AnnotationTool:
         for text, cx, cy, color in corner_labels:
             board_text(text, cx, cy, color)
 
-        # Annotation status label in top-right corner
-        is_annotated = frame_key in self.ground_truth["images"]
-        annotation_label = "Annotated" if is_annotated else "UNANNOTATED"
-        thickness = 1 if is_annotated else 2
-        (tw, th), _ = cv2.getTextSize(annotation_label, FONT, FONT_SCALE, thickness)
-        draw_text(
-            board_scaled,
-            annotation_label,
-            (h - tw - 10, th + 10),
-            (0, 255, 0) if is_annotated else (0, 0, 255),
-            thickness=thickness,
-        )
-
         self._draw_loupe(left_scaled, original)
 
         # Status bar (3 rows). Left of the panel split: progress, shortcuts, legend.
@@ -1474,11 +1461,23 @@ class AnnotationTool:
         status_bar = np.full((status_h, total_w, 3), COLOR_STATUS_BG, dtype=np.uint8)
         right_x = left_scaled.shape[1] + 8
 
-        # Row 1: progress + file path
+        # Row 1: progress + file path, plus this frame's annotated state on the right
         n_annotated = len(self.ground_truth["images"])
         progress = f"[{self.current_idx + 1}/{len(self.frames)}] ({n_annotated} annotated)"
         info = f"{progress}  {frame_key}"
         draw_text(status_bar, info, (8, row_h - 10), COLOR_TEXT, fit_scale(info, left_w - 16))
+
+        is_annotated = frame_key in self.ground_truth["images"]
+        annotation_label = "Annotated" if is_annotated else "UNANNOTATED"
+        thickness = 1 if is_annotated else 2
+        (tw, _), _ = cv2.getTextSize(annotation_label, FONT, FONT_SCALE, thickness)
+        draw_text(
+            status_bar,
+            annotation_label,
+            (total_w - tw - 10, row_h - 10),
+            (0, 255, 0) if is_annotated else (0, 0, 255),
+            thickness=thickness,
+        )
 
         # Row 2: keyboard shortcuts, shrunk if they would reach past the panel split
         shortcuts = (

--- a/sw/rocsync/benchmark/annotate.py
+++ b/sw/rocsync/benchmark/annotate.py
@@ -25,6 +25,7 @@ import numpy as np
 from rocsync.benchmark.common import (
     MIN_REFERENCE_FRAMES,
     FrameSource,
+    annotation_camera,
     collect_frames,
     corner_positions_in_image,
     fit_reference_clock,
@@ -53,20 +54,20 @@ BOARD_TICK_PX = 10
 # ── Board geometry helpers ──────────────────────────────────────────────────
 
 
-def ring_led_positions(board):
+def ring_led_positions(board, camera):
     """Return list of (x, y) tuples for ring LEDs in rectified board coords."""
-    return [(int(x), int(y)) for x, y in board.ring_led_coords(CameraType.RGB)]
+    return [(int(x), int(y)) for x, y in board.ring_led_coords(camera)]
 
 
-def counter_led_positions(board):
+def counter_led_positions(board, camera):
     """Return list of (x, y) tuples for counter LEDs in rectified board coords."""
-    coords = board.counter_led_coords[CameraType.RGB]
+    coords = board.counter_led_coords[camera]
     return [(int(p[0]), int(p[1])) for p in coords]
 
 
-def corner_led_positions(board):
+def corner_led_positions(board, camera):
     """Return list of (x, y) tuples for corner LEDs in rectified board coords."""
-    return [(int(p[0]), int(p[1])) for p in board.always_on_leds[CameraType.RGB]]
+    return [(int(p[0]), int(p[1])) for p in board.always_on_leds[camera]]
 
 
 def counter_bbox(counter_pos):
@@ -106,13 +107,13 @@ def _determines_homography(points, min_area):
     )
 
 
-def fit_corner_homography(corners, board):
+def fit_corner_homography(corners, board, camera):
     """Fit original image → rectified board from the visible corner LEDs, or None.
 
     None means the visible corners do not determine a map: too few of them, board
     coordinates that are degenerate, or a fit that came out singular.
     """
-    board_pos = board.always_on_leds[CameraType.RGB]
+    board_pos = board.always_on_leds[camera]
     visible = [i for i, c in enumerate(corners) if c["visible"]]
     if len(visible) < MIN_HOMOGRAPHY_CORNERS:
         return None
@@ -167,15 +168,15 @@ def board_from_view(view, board, margin=BOARD_MARGIN_PX):
     return view[margin : margin + bs, margin : margin + bs].copy()
 
 
-def decode_clock(rectified, board):
+def decode_clock(rectified, board, camera):
     """(counter_leds, counter_value, ring_start, ring_end) read off a rectified board.
 
     The ring is returned in the annotation's half-open ascending form; start == end means
     no arc was found.
     """
     stats = {"steps": {}}
-    counter = read_counter(rectified, CameraType.RGB, board, stats=stats)
-    ring = read_ring(rectified, CameraType.RGB, board, stats=stats)
+    counter = read_counter(rectified, camera, board, stats=stats)
+    ring = read_ring(rectified, camera, board, stats=stats)
     leds = [bool(v) for v in stats["counter_leds"]]
     if ring is None:
         return leds, counter, 0, 0
@@ -208,6 +209,7 @@ class ImageAnnotation:
     """
 
     board: RectifiedBoard  # not serialized
+    camera: CameraType  # not serialized directly; drives which LED layout applies
 
     aruco_visible: bool = False
     aruco_id: int = 0
@@ -228,15 +230,15 @@ class ImageAnnotation:
 
     def __post_init__(self):
         if not self.corners:
-            corner_pos = corner_led_positions(self.board)
+            corner_pos = corner_led_positions(self.board, self.camera)
             self.corners = [{"visible": False, "position": list(p)} for p in corner_pos]
         if not self.counter_leds:
             self.counter_leds = [False] * self.board.counter_bits
 
     @classmethod
-    def from_stats(cls, stats, board):
+    def from_stats(cls, stats, board, camera):
         """Pre-populate annotation from pipeline stats dict."""
-        ann = cls(board=board)
+        ann = cls(board=board, camera=camera)
 
         # Homography (original → rectified)
         H = stats.get("homography")
@@ -247,9 +249,9 @@ class ImageAnnotation:
         # ArUco
         aruco_id = stats.get("aruco_id")
         ann.aruco_visible = aruco_id is not None
-        ann.aruco_id = aruco_id if aruco_id is not None else 0
+        ann.aruco_id = aruco_id if aruco_id is not None else board.aruco_marker_id
 
-        # Corner LEDs — the pipeline detects them in rough-rectified space
+        # Corner LEDs — the pipeline reports these in original image space
         for i, pos in enumerate(corner_positions_in_image(stats)):
             if i < len(ann.corners) and pos is not None:
                 ann.corners[i]["visible"] = True
@@ -305,15 +307,14 @@ class ImageAnnotation:
                 corners.append({"visible": False})
 
         result = {
-            "aruco": {"visible": self.aruco_visible},
+            "camera": self.camera.value,
+            "aruco": {"visible": self.aruco_visible, "id": self.aruco_id},
             "corners": corners,
             "homography": self.homography,
             "counter": {"visible": self.counter_visible},
             "ring": {},
         }
 
-        if self.aruco_visible:
-            result["aruco"]["id"] = self.aruco_id
         if self.counter_visible:
             result["counter"]["value"] = self.counter_value
         if self.ring_start == self.ring_end:
@@ -325,15 +326,15 @@ class ImageAnnotation:
         return result
 
     @classmethod
-    def from_dict(cls, data, board):
-        ann = cls(board=board)
+    def from_dict(cls, data, board, camera):
+        ann = cls(board=board, camera=camera)
         aruco = data.get("aruco", {})
         ann.aruco_visible = aruco.get("visible", False)
-        ann.aruco_id = aruco.get("id", 0)
+        ann.aruco_id = aruco.get("id", board.aruco_marker_id)
 
         ann.homography = data.get("homography")
 
-        corner_pos = corner_led_positions(board)
+        corner_pos = corner_led_positions(board, camera)
         for i, c in enumerate(data.get("corners", [])):
             if i < len(ann.corners):
                 if "position" in c:
@@ -515,7 +516,7 @@ class Mode(Enum):
     IDLE = "idle"
     DRAGGING_CORNER = "dragging"
     RING_AWAITING_END = "ring_end"
-    ARUCO_CONFIRM = "aruco_confirm"  # board profile changed, Esc to revert
+    LAYOUT_CONFIRM = "layout_confirm"  # board, marker, or camera mode changed, Esc to revert
 
 
 # ── Display and interaction ─────────────────────────────────────────────────
@@ -555,11 +556,13 @@ HELP_TEXT = [
     "Drag corner LED   : Refine position",
     "Click counter LED : Toggle ON / OFF",
     "Click counter box : Toggle counter visibility",
-    "Click ArUco area  : Cycle ID 0 / ID 21 / none",
+    "Click ArUco area  : Cycle ID 0 visible/hidden,",
+    "                    then ID 21 visible/hidden",
     "Click ring LED    : Set first ON, then first OFF",
     "                    (same LED = undecodable)",
     "=== Keys ===",
     "0-N               : Place that corner next",
+    "M                 : Toggle camera mode (RGB / IR)",
     ". / ,             : Next / previous input file",
     "=== Rectified view ===",
     "Any corner edit re-fits the board view,",
@@ -600,11 +603,12 @@ class AnnotationTool:
         self._video_threshold: dict[str, tuple[float | None, float]] = {}
         self._dirty_videos: set[str] = set()
 
-        # Board profile and derived geometry (set per-image)
+        # Board profile, camera mode, and derived geometry (set per-image)
         self.board = BOARD_V1.rectify()
-        self.ring_pos = ring_led_positions(self.board)
-        self.counter_pos = counter_led_positions(self.board)
-        self.corner_pos = corner_led_positions(self.board)
+        self.camera = CameraType.RGB
+        self.ring_pos = ring_led_positions(self.board, self.camera)
+        self.counter_pos = counter_led_positions(self.board, self.camera)
+        self.corner_pos = corner_led_positions(self.board, self.camera)
         self.counter_box = counter_bbox(self.counter_pos)
         self.aruco_x1 = int(self.board.aruco_corners_coords[0][0])
         self.aruco_y1 = int(self.board.aruco_corners_coords[0][1])
@@ -637,15 +641,18 @@ class AnnotationTool:
         self._ring_edited = False
         self._needs_redraw = True
         self._window_sized = False
-        # (annotation, board) before board-changing ArUco cycle
-        self._aruco_snapshot: tuple[ImageAnnotation, RectifiedBoard] | None = None
+        # Annotation snapshots keyed by (aruco_id, camera.value), taken before a layout
+        # change; lets a mis-click on a board or mode change undo without losing work.
+        self._layout_snapshots: dict[tuple[int, str], ImageAnnotation] = {}
+        self._layout_original: tuple[ImageAnnotation, RectifiedBoard, CameraType] | None = None
 
-    def _set_board(self, board):
-        """Update board profile and recompute derived geometry."""
+    def _set_layout(self, board, camera):
+        """Update board profile, camera mode, and recompute derived geometry."""
         self.board = board
-        self.ring_pos = ring_led_positions(board)
-        self.counter_pos = counter_led_positions(board)
-        self.corner_pos = corner_led_positions(board)
+        self.camera = camera
+        self.ring_pos = ring_led_positions(board, camera)
+        self.counter_pos = counter_led_positions(board, camera)
+        self.corner_pos = corner_led_positions(board, camera)
         self.counter_box = counter_bbox(self.counter_pos)
         self.aruco_x1 = int(board.aruco_corners_coords[0][0])
         self.aruco_y1 = int(board.aruco_corners_coords[0][1])
@@ -694,13 +701,34 @@ class AnnotationTool:
             unreadable = 0
             self._pump()
 
+            # Resolve camera mode and a board guess from the saved annotation if there is
+            # one, else stay on whatever the previous frame left `self.camera`/`self.board`
+            # at — a video's frames are usually all the same mode, so this is what keeps a
+            # long IR clip from needing `M` pressed once per frame.
+            saved = frame_key in self.ground_truth["images"]
+            entry = self.ground_truth["images"].get(frame_key)
+            camera = annotation_camera(entry) if entry is not None else self.camera
+            guess_profile = (
+                PROFILES_BY_ARUCO.get(entry.get("aruco", {}).get("id"), self.board.profile)
+                if entry is not None
+                else self.board.profile
+            )
+
             # Run pipeline
             self.stats = {}
             try:
                 # No area gate: the annotator should see every marker the detector found,
                 # however small — rejecting it is the benchmark's call, not the ground truth's.
+                # IR has no marker to auto-resolve a board from, so it always needs an
+                # explicit guess; RGB stays free to auto-resolve on an unannotated frame.
+                board_hint = guess_profile if saved or camera == CameraType.INFRARED else None
                 process_frame(
-                    image, CameraType.RGB, 0, stats=self.stats, min_aruco_area_fraction=0.0
+                    image,
+                    camera,
+                    0,
+                    board=board_hint,
+                    stats=self.stats,
+                    min_aruco_area_fraction=0.0,
                 )
             except Exception as e:  # noqa: BLE001 — a bad frame must not kill the session
                 print(f"Pipeline error on {frame_key}: {e}", file=sys.stderr)
@@ -710,25 +738,20 @@ class AnnotationTool:
 
             # Resolve board profile from pipeline detection or saved annotation
             aruco_id = self.stats.get("aruco_id")
-            if frame_key in self.ground_truth["images"]:
-                saved_id = self.ground_truth["images"][frame_key].get("aruco", {}).get("id")
-                if saved_id is not None:
-                    aruco_id = saved_id
-            profile = (
-                PROFILES_BY_ARUCO.get(aruco_id, BOARD_V1) if aruco_id is not None else BOARD_V1
-            )
+            if entry is not None:
+                aruco_id = entry.get("aruco", {}).get("id", aruco_id)
+            elif aruco_id is None:
+                aruco_id = guess_profile.aruco_marker_id
+            profile = PROFILES_BY_ARUCO.get(aruco_id, BOARD_V1)
             board = profile.rectify()
-            self._set_board(board)
+            self._set_layout(board, camera)
 
             # Load existing annotation or create from pipeline
             coarse_fit = False
-            saved = frame_key in self.ground_truth["images"]
             if saved:
-                self.annotation = ImageAnnotation.from_dict(
-                    self.ground_truth["images"][frame_key], board
-                )
+                self.annotation = ImageAnnotation.from_dict(entry, board, camera)
             else:
-                self.annotation = ImageAnnotation.from_stats(self.stats, board)
+                self.annotation = ImageAnnotation.from_stats(self.stats, board, camera)
                 # Use the pipeline homography for new annotations, falling back to the
                 # marker alone when corner detection failed — a coarse view to refine
                 # beats a black panel and corners parked at a guess.
@@ -865,40 +888,42 @@ class AnnotationTool:
 
     def _process_key(self, key):
         if key in (13, 10, 32):  # Enter or Space
-            self._commit_aruco_change()
+            self._commit_layout_change()
             return "accept"
         elif key == 83 or key == ord("d"):  # Right arrow
-            self._commit_aruco_change()
+            self._commit_layout_change()
             return "skip"
         elif key == 81 or key == ord("a"):  # Left arrow
-            self._commit_aruco_change()
+            self._commit_layout_change()
             return "back"
         elif key in (ord("n"), ord("N")):
-            self._commit_aruco_change()
+            self._commit_layout_change()
             return "next_unannotated"
         elif key in (ord("b"), ord("B")):
-            self._commit_aruco_change()
+            self._commit_layout_change()
             return "prev_unannotated"
         elif key == ord("."):
-            self._commit_aruco_change()
+            self._commit_layout_change()
             return "next_source"
         elif key == ord(","):
-            self._commit_aruco_change()
+            self._commit_layout_change()
             return "prev_source"
         elif key in (ord("c"), ord("C"), 8, 127):  # C or Backspace
-            self._commit_aruco_change()
+            self._commit_layout_change()
             return "clear"
         elif key in (ord("q"), ord("Q")):
-            self._commit_aruco_change()
+            self._commit_layout_change()
             return "quit"
         elif key in (ord("h"), ord("H")):
             self.show_help = not self.show_help
             self._needs_redraw = True
+        elif key in (ord("m"), ord("M")):
+            self._cycle_camera()
         elif ord("0") <= key <= ord("9"):
             self._select_placing_corner(key - ord("0"))
         elif key == 27:  # Escape
-            if self.mode == Mode.ARUCO_CONFIRM:
-                self._revert_aruco_change()
+            if self.mode == Mode.LAYOUT_CONFIRM:
+                self._revert_layout_change()
             elif self.mode == Mode.RING_AWAITING_END:
                 self.mode = Mode.IDLE
                 self._ring_start_candidate = None
@@ -981,7 +1006,7 @@ class AnnotationTool:
             if event == cv2.EVENT_MOUSEMOVE:
                 self._needs_redraw = True
             if event == cv2.EVENT_LBUTTONDOWN:
-                self._commit_aruco_change()
+                self._commit_layout_change()
                 idx = self._hit_test_corner_original(ox, oy)
                 if idx is not None:
                     # On a corner overlay: hold for a drag, release without one to place.
@@ -1055,7 +1080,7 @@ class AnnotationTool:
 
         elem, idx = self._hit_test(bx, by)
         if elem != "aruco":
-            self._commit_aruco_change()
+            self._commit_layout_change()
         if elem == "corner":
             self._drag_idx = idx
             self._drag_start = (bx, by)
@@ -1138,90 +1163,105 @@ class AnnotationTool:
         self._needs_redraw = True
 
     def _cycle_aruco(self):
+        """Cycle (marker id, visible) through every board with the marker shown or hidden.
+
+        Four states for two board revisions: id0 visible → id0 hidden → id1 visible →
+        id1 hidden → … A board must stay selectable with the marker hidden — the ArUco
+        marker itself is never visible in IR — so `visible` toggles independently of which
+        board is picked, rather than `none` being a single shared third state as before.
+        """
         ann = self.annotation
+        states = [(marker_id, visible) for marker_id in ARUCO_IDS for visible in (True, False)]
+        try:
+            idx = states.index((ann.aruco_id, ann.aruco_visible))
+        except ValueError:
+            idx = -1
+        new_id, new_visible = states[(idx + 1) % len(states)]
+        new_board = PROFILES_BY_ARUCO[new_id].rectify() if new_id in PROFILES_BY_ARUCO else self.board
+        self._switch_layout(new_board, self.camera, new_visible, new_id)
 
-        # Determine the new ArUco state
-        new_visible = ann.aruco_visible
-        new_id = ann.aruco_id
-        if not ann.aruco_visible:
-            new_visible = True
-            new_id = ARUCO_IDS[0]
-        else:
-            try:
-                idx = ARUCO_IDS.index(ann.aruco_id)
-                if idx + 1 < len(ARUCO_IDS):
-                    new_id = ARUCO_IDS[idx + 1]
-                else:
-                    new_visible = False
-            except ValueError:
-                new_visible = False
+    def _cycle_camera(self):
+        """Toggle RGB / IR, keeping the current board and marker selection."""
+        new_camera = CameraType.INFRARED if self.camera == CameraType.RGB else CameraType.RGB
+        ann = self.annotation
+        self._switch_layout(self.board, new_camera, ann.aruco_visible, ann.aruco_id)
 
-        # Snapshot on first cycle; subsequent cycles update in-place
-        if self._aruco_snapshot is None:
-            self._aruco_snapshot = (copy.deepcopy(self.annotation), self.board)
+    def _switch_layout(self, new_board, new_camera, new_aruco_visible, new_aruco_id):
+        """Switch to a different board / camera / marker layout.
 
-        # Check if the board profile changes. Rectified boards are cached per profile,
-        # so identity comparison is enough to spot a change.
-        new_board = self.board
-        if new_visible and new_id in PROFILES_BY_ARUCO:
-            new_board = PROFILES_BY_ARUCO[new_id].rectify()
-        board_changes = new_board is not self.board
+        Snapshotted per (board id, camera), so returning to a layout already visited this
+        frame restores the annotation made under it rather than resetting it — a mis-click
+        on `M` or the ArUco region must not lose work. RGB and IR corner LEDs are different
+        physical LEDs, and so are v1's and v2's, so a layout that has not been visited yet
+        starts from a fresh annotation rather than carrying positions over.
+        """
+        ann = self.annotation
+        geometry_changes = new_board is not self.board or new_camera != self.camera
 
-        if board_changes:
-            snap_ann, snap_board = self._aruco_snapshot
-            self._set_board(new_board)
+        # Snapshot on the first change this frame; later changes update in place
+        if self._layout_original is None:
+            self._layout_original = (copy.deepcopy(ann), self.board, self.camera)
 
-            if new_board is snap_board:
-                # Cycling back to the snapshot's board — restore full annotations
-                self.annotation = copy.deepcopy(snap_ann)
-                self.annotation.aruco_visible = new_visible
-                self.annotation.aruco_id = new_id
-            else:
-                # Different board — build fresh annotation
-                new_ann = ImageAnnotation(board=new_board)
-                new_ann.aruco_visible = new_visible
-                new_ann.aruco_id = new_id
-                # Carry over board-independent state
-                new_ann.homography = ann.homography
-                if new_board.period == ann.board.period:
-                    new_ann.ring_start = ann.ring_start
-                    new_ann.ring_end = ann.ring_end
-                # Place corners at the new board's default positions.
-                # If a homography is available, convert to original image coords.
-                new_corner_pos = corner_led_positions(new_board)
-                for i, c in enumerate(new_ann.corners):
-                    if new_ann.homography is not None:
-                        c["position"] = new_ann.to_original(*new_corner_pos[i])
-                    else:
-                        c["position"] = list(new_corner_pos[i])
-                    c["visible"] = False
-                self.annotation = new_ann
-
-            self.status_msg = f"Board changed to {new_board.profile.name} — Esc to undo"
-        else:
-            ann.aruco_visible = new_visible
-            ann.aruco_id = new_id
+        if not geometry_changes:
+            ann.aruco_visible = new_aruco_visible
+            ann.aruco_id = new_aruco_id
             self.status_msg = "ArUco changed — Esc to undo"
+            self.mode = Mode.LAYOUT_CONFIRM
+            self._needs_redraw = True
+            return
 
-        self.mode = Mode.ARUCO_CONFIRM
+        old_key = (self.board.aruco_marker_id, self.camera.value)
+        new_key = (new_board.aruco_marker_id, new_camera.value)
+        self._layout_snapshots[old_key] = copy.deepcopy(ann)
+        self._set_layout(new_board, new_camera)
+
+        if new_key in self._layout_snapshots:
+            # Layout visited before this frame — restore its annotation
+            self.annotation = self._layout_snapshots.pop(new_key)
+            self.annotation.aruco_visible = new_aruco_visible
+            self.annotation.aruco_id = new_aruco_id
+        else:
+            new_ann = ImageAnnotation(board=new_board, camera=new_camera)
+            new_ann.aruco_visible = new_aruco_visible
+            new_ann.aruco_id = new_aruco_id
+            # Carry over layout-independent state
+            new_ann.homography = ann.homography
+            if new_board.period == ann.board.period:
+                new_ann.ring_start = ann.ring_start
+                new_ann.ring_end = ann.ring_end
+            # Place corners at the new layout's default positions.
+            # If a homography is available, convert to original image coords.
+            new_corner_pos = corner_led_positions(new_board, new_camera)
+            for i, c in enumerate(new_ann.corners):
+                if new_ann.homography is not None:
+                    c["position"] = new_ann.to_original(*new_corner_pos[i])
+                else:
+                    c["position"] = list(new_corner_pos[i])
+                c["visible"] = False
+            self.annotation = new_ann
+
+        self.status_msg = f"Layout changed to {new_board.profile.name}/{new_camera.value} — Esc to undo"
+        self.mode = Mode.LAYOUT_CONFIRM
         self._needs_redraw = True
 
-    def _commit_aruco_change(self):
-        """Discard ArUco snapshot, committing the board profile change."""
-        if self._aruco_snapshot is not None:
-            self._aruco_snapshot = None
-            if self.mode == Mode.ARUCO_CONFIRM:
+    def _commit_layout_change(self):
+        """Discard layout snapshots, committing the board / camera / marker in place."""
+        if self._layout_original is not None:
+            self._layout_original = None
+            self._layout_snapshots.clear()
+            if self.mode == Mode.LAYOUT_CONFIRM:
                 self.mode = Mode.IDLE
                 self.status_msg = ""
                 self._needs_redraw = True
 
-    def _revert_aruco_change(self):
-        """Restore annotation and board profile from snapshot."""
-        if self._aruco_snapshot is None:
+    def _revert_layout_change(self):
+        """Restore annotation, board and camera from the pre-change snapshot."""
+        if self._layout_original is None:
             return
-        self.annotation, old_board = self._aruco_snapshot
-        self._aruco_snapshot = None
-        self._set_board(old_board)
+        self.annotation, old_board, old_camera = self._layout_original
+        self._layout_original = None
+        self._layout_snapshots.clear()
+        self._set_layout(old_board, old_camera)
         self.mode = Mode.IDLE
         self.status_msg = ""
         self._needs_redraw = True
@@ -1234,7 +1274,7 @@ class AnnotationTool:
         """
         ann = self.annotation
         board = self.board
-        H = fit_corner_homography(ann.corners, board)
+        H = fit_corner_homography(ann.corners, board, self.camera)
         if H is None:
             n = sum(1 for c in ann.corners if c["visible"])
             self.status_msg = (
@@ -1262,7 +1302,7 @@ class AnnotationTool:
         rectified = self.stats.get("rectified")
         if rectified is None or (self._counter_edited and self._ring_edited):
             return
-        leds, value, start, end = decode_clock(rectified, self.board)
+        leds, value, start, end = decode_clock(rectified, self.board, self.camera)
         ann = self.annotation
         if not self._counter_edited:
             ann.counter_visible = True
@@ -1403,7 +1443,8 @@ class AnnotationTool:
             pos = (round(x * self.board_scale), round(y * self.board_scale))
             draw_text(board_scaled, text, pos, color)
 
-        aruco_label = f"ArUco ID {ann.aruco_id}" if ann.aruco_visible else "ArUco: none"
+        marker_state = f"ArUco ID {ann.aruco_id}" if ann.aruco_visible else "ArUco: hidden"
+        aruco_label = f"{self.camera.value.upper()}  {self.board.profile.name}  {marker_state}"
         board_text(aruco_label, ax1, ay1 - 8, (128, 128, 128))
         counter_text = f"Counter: {ann.counter_value}" if ann.counter_visible else "Counter: n/a"
         board_text(counter_text, bx1, by1 - 8, COLOR_BOARD_TEXT)
@@ -1442,7 +1483,7 @@ class AnnotationTool:
         # Row 2: keyboard shortcuts, shrunk if they would reach past the panel split
         shortcuts = (
             "Enter/Space=Accept  Left/Right=Prev/Next  N/B=Skip to unannotated  "
-            ",/.=Prev/Next file  0-N=Pick corner  C=Clear  Q=Quit  H=Help"
+            ",/.=Prev/Next file  0-N=Pick corner  M=Camera mode  C=Clear  Q=Quit  H=Help"
         )
         draw_text(
             status_bar,

--- a/sw/rocsync/benchmark/common.py
+++ b/sw/rocsync/benchmark/common.py
@@ -9,6 +9,7 @@ import cv2
 import numpy as np
 
 from rocsync.board_profiles import PROFILES_BY_ARUCO
+from rocsync.camera import CameraType
 from rocsync.dataset import VIDEO_SUFFIXES
 from rocsync.timeline import (
     frame_pts,
@@ -393,29 +394,19 @@ class FrameSource:
 def corner_positions_in_image(stats, n_leds=4):
     """Detected corner LED positions in original image coordinates, one slot per LED.
 
-    The pipeline detects corners in the rough-rectified grid, whose scale is a
-    property of the branch under test. Un-warping through that grid's own
-    homography yields the annotated quantity, comparable across branches.
-
-    The pipeline reports one row per always-on LED, NaN where it found none; this is
-    where that becomes the None the annotation format uses, so position i always names
-    LED i. `n_leds` only sizes the all-None result for a frame that reported nothing.
+    The pipeline reports these already in image space (`rocsync.vision.rectify_board`
+    un-warps its own rough-rectified detections before storing them), one row per
+    always-on LED with NaN where it found none; this is where that becomes the None
+    the annotation format uses, so position i always names LED i. `n_leds` only sizes
+    the all-None result for a frame that reported nothing.
     """
     positions = stats.get("corner_positions")
-    rough_H = stats.get("rough_homography")
-    if positions is None or rough_H is None:
+    if positions is None:
         return [None] * n_leds
 
     positions = np.array(positions, dtype=np.float64).reshape(-1, 2)
     found = np.isfinite(positions).all(axis=1)
-    slots = [None] * len(positions)
-    if found.any():
-        inv_rough = np.linalg.inv(np.array(rough_H, dtype=np.float64))
-        pts = positions[found].reshape(1, -1, 2)
-        mapped = cv2.perspectiveTransform(pts, inv_rough).reshape(-1, 2).tolist()
-        for i, point in zip(np.flatnonzero(found), mapped, strict=True):
-            slots[i] = point
-    return slots
+    return [positions[i].tolist() if found[i] else None for i in range(len(positions))]
 
 
 def rectification_errors(pred_H, gt_H, points):
@@ -466,6 +457,11 @@ def reconstruct_timestamp(image_data, board):
     # Annotations hold a half-open interval; the board decodes an inclusive one
     timestamp = board.board_time_from_ring(counter_value, (start, (end - 1) % board.period))
     return list(timestamp) if timestamp is not None else None
+
+
+def annotation_camera(entry):
+    """The `CameraType` an annotation was made under."""
+    return CameraType(entry.get("camera", CameraType.RGB.value))
 
 
 def annotated_board_time(entry):

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -23,6 +23,7 @@ import numpy as np
 from rocsync.benchmark.common import (
     STEP_ORDER,
     ReferenceClock,
+    annotation_camera,
     confusion_metrics,
     descriptive_stats,
     parse_frame_key,
@@ -34,7 +35,6 @@ from rocsync.benchmark.common import (
     source_key,
 )
 from rocsync.board_profiles import BOARD_V1, PROFILES_BY_ARUCO
-from rocsync.camera import CameraType
 
 CORNER_IMAGE_SPACE_THRESHOLD_PX = 3
 # A point counts as landing correctly when it sits within one LED sampling disc of where
@@ -374,7 +374,7 @@ def compute_homography_metrics(benchmark_images, gt_images, key):
         pred_positive = pred_H is not None
 
         if gt_positive and pred_positive:
-            errors = rectification_errors(pred_H, gt_H, board.layout_coords(CameraType.RGB))
+            errors = rectification_errors(pred_H, gt_H, board.layout_coords(annotation_camera(gt)))
             if errors is None:
                 fn += 1
                 continue

--- a/sw/rocsync/benchmark/validate.py
+++ b/sw/rocsync/benchmark/validate.py
@@ -23,10 +23,13 @@ from tqdm import tqdm
 from rocsync.benchmark.common import (
     STEP_ORDER,
     FrameSource,
+    annotation_camera,
     collect_frames,
     corner_positions_in_image,
     frame_key,
     parse_frame_key,
+    retimed_videos,
+    source_key,
 )
 from rocsync.board_profiles import PROFILES_BY_ARUCO
 from rocsync.camera import CameraType
@@ -39,8 +42,13 @@ def _matrix(H):
     return np.asarray(H, dtype=np.float64).tolist() if H is not None else None
 
 
-def extract_pipeline_result(stats):
+def extract_pipeline_result(stats, camera, board):
     """Extract a ground-truth-compatible result dict from pipeline stats.
+
+    `camera` and `board` are the mode and profile the frame was run under — an
+    explicit annotation, or RGB with auto-resolution when there is none — so a run
+    can be scored against the layout it actually used rather than one re-derived
+    from the ArUco marker, which IR never detects.
 
     Returns a dict with keys: aruco, corners, counter, ring, timestamp,
     homography, rough_homography. Structure mirrors ground_truth.json to
@@ -49,7 +57,6 @@ def extract_pipeline_result(stats):
     steps = stats.get("steps", {})
 
     # -- ArUco --
-    aruco_id = stats.get("aruco_id", None)
     aruco_step = steps.get("aruco_detection", {})
     aruco_visible = aruco_step.get("success", False)
     aruco = {
@@ -57,10 +64,9 @@ def extract_pipeline_result(stats):
         "id": stats.get("aruco_id") if aruco_visible else None,
         "corners": stats.get("aruco_corners") if aruco_visible else None,
     }
-    board = PROFILES_BY_ARUCO[aruco_id] if aruco_id is not None else None
 
     # -- Corners (original image coordinates, as annotated) --
-    n_leds = len(board.always_on_leds[CameraType.RGB]) if board is not None else 4
+    n_leds = len(board.always_on_leds[camera]) if board is not None else 4
     corners = [
         {"visible": pos is not None, "position": pos}
         for pos in corner_positions_in_image(stats, n_leds)
@@ -138,8 +144,19 @@ def run_provenance(data_dir, n_images):
     }
 
 
-def run_benchmark(frames, debug_dir=None):
-    """Run pipeline on all frames, returning results dict keyed by frame key."""
+def run_benchmark(frames, ground_truth=None, debug_dir=None):
+    """Run pipeline on all frames, returning results dict keyed by frame key.
+
+    `ground_truth`, when given, decides each frame's camera mode and board: IR has no
+    marker to auto-resolve either from, so a frame with no annotation falls back to RGB
+    with the board left for the pipeline to detect, exactly as an unannotated run always
+    has. The validator walks retimed clips while annotations are keyed to the recordings
+    they were cut from, so a retimed frame's key is resolved back to its source first.
+    """
+    ground_truth = ground_truth or {}
+    images = ground_truth.get("images") or {}
+    retimed = retimed_videos(ground_truth)
+
     results = {}
     with FrameSource() as source:
         for i, ref in enumerate(tqdm(frames)):
@@ -148,16 +165,23 @@ def run_benchmark(frames, debug_dir=None):
                 print(f"  WARNING: could not read {ref.key}", file=sys.stderr)
                 continue
 
+            entry = images.get(source_key(ref.key, retimed))
+            camera = annotation_camera(entry) if entry is not None else CameraType.RGB
+            aruco_id = entry.get("aruco", {}).get("id") if entry is not None else None
+            profile = PROFILES_BY_ARUCO.get(aruco_id)
+
             stats = {}
             success, timestamp = process_frame(
                 image,
-                CameraType.RGB,
+                camera,
                 i,
+                board=profile,
                 debug_dir=debug_dir,
                 stats=stats,
             )
 
-            result = extract_pipeline_result(stats)
+            result_board = profile or PROFILES_BY_ARUCO.get(stats.get("aruco_id"))
+            result = extract_pipeline_result(stats, camera, result_board)
             timing = extract_pipeline_timing(stats)
 
             results[ref.key] = {
@@ -249,6 +273,13 @@ def main():
         default="benchmark_results.json",
         help="Output JSON file (default: benchmark_results.json)",
     )
+    parser.add_argument(
+        "-g",
+        "--ground-truth",
+        default=None,
+        help="Ground truth JSON, for each frame's camera mode and board "
+        "(default: <data_dir>/ground_truth.json)",
+    )
     parser.add_argument("--debug", default=None, help="Directory for debug images")
     args = parser.parse_args()
 
@@ -261,13 +292,22 @@ def main():
     if args.debug:
         Path(args.debug).mkdir(parents=True, exist_ok=True)
 
+    gt_path = Path(args.ground_truth) if args.ground_truth else data_dir / "ground_truth.json"
+    ground_truth = None
+    if gt_path.is_file():
+        with open(gt_path) as f:
+            ground_truth = json.load(f)
+    elif args.ground_truth:
+        print(f"No ground truth at {gt_path}", file=sys.stderr)
+        sys.exit(1)
+
     n_stills = sum(1 for ref in frames if ref.index is None)
     n_videos = len({ref.path for ref in frames if ref.index is not None})
     print(
         f"Found {len(frames)} frames: {n_stills} images and "
         f"{len(frames) - n_stills} frames from {n_videos} videos"
     )
-    results = run_benchmark(frames, debug_dir=args.debug)
+    results = run_benchmark(frames, ground_truth=ground_truth, debug_dir=args.debug)
 
     n_success = sum(1 for r in results.values() if r["success"])
     print(f"Detection rate: {n_success}/{len(results)} ({n_success / len(results):.1%})")

--- a/sw/rocsync/vision.py
+++ b/sw/rocsync/vision.py
@@ -356,8 +356,8 @@ def rectify_board(
                 # Corners are detected in this grid; the benchmark needs it to get back to image space
                 stats["rough_homography"] = rough_transformation_matrix
             t0 = time.perf_counter()
-            corners = find_corners_dots(rough_pcb, frame_number, board, debug_dir)
-            found = np.isfinite(corners).all(axis=1)
+            rough_corners = find_corners_dots(rough_pcb, frame_number, board, debug_dir)
+            found = np.isfinite(rough_corners).all(axis=1)
             _record_step(
                 stats,
                 "corner_detection",
@@ -365,17 +365,25 @@ def rectify_board(
                 success=bool(found.any()),
                 count=int(found.sum()),
             )
+
+            # Corners are matched in the rough-rectified grid; un-warp them back to image
+            # space so everything this function stores is in one coordinate space.
+            inv_rough = np.linalg.inv(rough_transformation_matrix)
+            image_corners = np.full_like(rough_corners, np.nan)
+            if found.any():
+                image_corners[found] = cv2.perspectiveTransform(
+                    rough_corners[found].reshape(1, -1, 2), inv_rough
+                ).reshape(-1, 2)
             if stats is not None:
-                stats["corner_positions"] = corners.tolist()
+                stats["corner_positions"] = image_corners.tolist()
 
             # The first four always-on LEDs are the perspective-transform anchors; without
             # all four there's nothing to fit the fine homography from. Any extra always-on
             # dots beyond those four were matched purely as a sanity check.
             if not found[:4].all():
                 return True, None, board
-            transformation_matrix = np.dot(
-                cv2.getPerspectiveTransform(corners[:4], board.transform_corners(CameraType.RGB)),
-                rough_transformation_matrix,
+            transformation_matrix = cv2.getPerspectiveTransform(
+                image_corners[:4], board.transform_corners(CameraType.RGB)
             )
             t0 = time.perf_counter()
             pcb = cv2.warpPerspective(mask, transformation_matrix, (board_size, board_size))
@@ -391,20 +399,35 @@ def rectify_board(
             gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
             _, mask = cv2.threshold(gray_image, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
             mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, np.ones((3, 3), np.uint8))
+            t0 = time.perf_counter()
             corners = find_corners_convexhull(mask, frame_number, debug_dir)
+            _record_step(stats, "corner_detection", t0, success=corners is not None)
+            if corners is not None and stats is not None:
+                stats["corner_positions"] = corners.tolist()
             if corners is None:
                 return False, None, board
             transformation_matrix = cv2.getPerspectiveTransform(
                 corners, board.transform_corners(CameraType.INFRARED)
             )
+            t0 = time.perf_counter()
             pcb = cv2.warpPerspective(mask, transformation_matrix, (board_size, board_size))
+            _record_step(stats, "fine_rectification", t0)
 
-            # Find correct rotation
+            # Board orientation is ambiguous from the convex hull alone; find the rotation
+            # that reads a nonzero counter. Rotating pcb without rotating the transform that
+            # produced it would leave `homography` describing the wrong orientation, so fold
+            # each 90° step into the matrix too: it is the same rotation applied to the
+            # *board*-space side of the fit.
+            n = board_size
+            rotate_90 = np.array([[0, -1, n - 1], [1, 0, 0], [0, 0, 1]], dtype=np.float64)
             for _ in range(4):
                 if read_counter(pcb, CameraType.INFRARED, board) == 0:
                     pcb = cv2.rotate(pcb, cv2.ROTATE_90_CLOCKWISE)
+                    transformation_matrix = rotate_90 @ transformation_matrix
             if read_counter(pcb, CameraType.INFRARED, board) == 0:
                 return True, None, board  # Counter was 0, orientation undeterminable
+            if stats is not None:
+                stats["homography"] = transformation_matrix
 
         case _:
             raise ValueError(f"Unsupported camera type: {camera_type!r}")

--- a/sw/tests/test_annotate.py
+++ b/sw/tests/test_annotate.py
@@ -49,7 +49,7 @@ def board_error(H, board, indices):
 def test_too_few_corners_have_no_fit(name):
     """Three points leave a projective map undetermined, so no fit is offered."""
     board = BOARDS[name]
-    assert fit_corner_homography(annotation_corners(board, {0, 1, 2}), board) is None
+    assert fit_corner_homography(annotation_corners(board, {0, 1, 2}), board, CameraType.RGB) is None
 
 
 @pytest.mark.parametrize("name", sorted(BOARDS))
@@ -57,7 +57,7 @@ def test_four_corners_fit_exactly(name):
     """The minimum the tool now accepts, and it reproduces the pose it was built from."""
     board = BOARDS[name]
     indices = [0, 1, 2, 3]
-    H = fit_corner_homography(annotation_corners(board, set(indices)), board)
+    H = fit_corner_homography(annotation_corners(board, set(indices)), board, CameraType.RGB)
     assert H is not None
     assert board_error(H, board, indices) < 1e-3
 
@@ -67,14 +67,14 @@ def test_a_collinear_corner_set_has_no_fit():
     board = BOARDS["v2"]
     indices = {0, 1, 2, 4}
     assert len(indices) == MIN_HOMOGRAPHY_CORNERS
-    assert fit_corner_homography(annotation_corners(board, indices), board) is None
+    assert fit_corner_homography(annotation_corners(board, indices), board, CameraType.RGB) is None
 
 
 def test_all_five_corners_fit_by_least_squares():
     """The over-determined case still lands on the modelled layout."""
     board = BOARDS["v2"]
     indices = [0, 1, 2, 3, 4]
-    H = fit_corner_homography(annotation_corners(board, set(indices)), board)
+    H = fit_corner_homography(annotation_corners(board, set(indices)), board, CameraType.RGB)
     assert H is not None
     assert board_error(H, board, indices) < 1.0
 
@@ -84,7 +84,7 @@ def test_one_hidden_corner_still_fits(hidden):
     """v2 keeps a usable board view through the occlusions that leave a proper quad."""
     board = BOARDS["v2"]
     indices = [i for i in range(5) if i != hidden]
-    H = fit_corner_homography(annotation_corners(board, set(indices)), board)
+    H = fit_corner_homography(annotation_corners(board, set(indices)), board, CameraType.RGB)
     assert H is not None
     assert board_error(H, board, indices) < 1.0
 
@@ -94,4 +94,4 @@ def test_hiding_a_far_corner_leaves_a_collinear_set(hidden):
     """Losing 2 or 3 leaves LEDs 0, 1 and 4 plus one — one line and a point, no fit."""
     board = BOARDS["v2"]
     indices = {i for i in range(5) if i != hidden}
-    assert fit_corner_homography(annotation_corners(board, indices), board) is None
+    assert fit_corner_homography(annotation_corners(board, indices), board, CameraType.RGB) is None

--- a/sw/tests/test_ground_truth.py
+++ b/sw/tests/test_ground_truth.py
@@ -34,12 +34,12 @@ from rocsync.benchmark.annotate import (
 from rocsync.benchmark.common import (
     MIN_REFERENCE_FRAMES,
     ReferenceClock,
+    annotation_camera,
     collect_frames,
     reference_outliers,
     residual_threshold_ms,
 )
 from rocsync.board_profiles import PROFILES_BY_ARUCO
-from rocsync.camera import CameraType
 from rocsync.timeline import frame_pts
 
 GROUND_TRUTH = Path(
@@ -76,7 +76,7 @@ def _nominal_in_image(gt):
         return None
     board = PROFILES_BY_ARUCO[aruco_id].rectify()
     inv_H = np.linalg.inv(np.array(H, dtype=np.float64))
-    pts = np.array([board.always_on_leds[CameraType.RGB]], dtype=np.float64)
+    pts = np.array([board.always_on_leds[annotation_camera(gt)]], dtype=np.float64)
     return cv2.perspectiveTransform(pts, inv_H).reshape(-1, 2)
 
 
@@ -89,7 +89,8 @@ def _determines_its_homography(gt):
         {"visible": bool(c.get("visible")), "position": c.get("position")}
         for c in gt.get("corners", [])
     ]
-    return fit_corner_homography(corners, PROFILES_BY_ARUCO[aruco_id].rectify()) is not None
+    board = PROFILES_BY_ARUCO[aruco_id].rectify()
+    return fit_corner_homography(corners, board, annotation_camera(gt)) is not None
 
 
 def test_annotated_corners_match_the_warped_layout(annotations):


### PR DESCRIPTION
This PR adds support for IR video (e.g. an atracsys_left.mp4) to the benchmark tools #24 . 

Improvements:
* Annotation tool: Added camera mode (=modality) key that let's the user cycle through the camera modes (RGB, IR). Overlaid board layout are updated automatically, similar to the existing revision selection.
* Annotation tool: Moved the annotation status text from the top-right to the status bar, to avoid occluding an always-on LED.
* Annotation tool: All board layouts, represented via their always-on LEDs, are now inititalized at the center of the image instead of the top-left.
* Validation tool: Forward the annotated camera modality to the rocsync pipeline. We assume that the camera modality is user-defined and does not have to be detected automatically.
* Evaluation tool: Take the camera modality into account when computing localization errors (different positioning of RGB vs IR LEDs).

Results are currently not grouped by modality, so the reported benchmark results are not comparable after adding in a new video. Also, the accuracy decreased on average, as the decoding of the IR video frames fails frequently #28 .