### PR TITLE
Fixed benchmark report layout bug. Clarified subsection headers and a…

### DIFF
--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -772,18 +772,21 @@ def highlight(text):
     return f"{GREEN}{text}{RESET}" if _use_color else text
 
 
-def _best_index(values, better):
-    """The one method that beats every other on this row, or None if none stands alone.
+def _best_indices(values, better):
+    """Every method tied for the winning value on this row, or empty if none stands out.
 
-    A tie leaves the row unmarked rather than painting every column: the mark says
-    "pick this one", which a tie cannot. So does a row where only one method has a
-    value — there is nothing it won against.
+    All of them get marked on a tie, since the mark says "this is the best result", not
+    "pick this one arbitrarily". But if every method agrees, that agreement is not a win
+    for any of them, so a row where only one distinct value appears is left unmarked.
     """
     rank = abs if better == LOWER else (lambda v: -v)
-    candidates = sorted((rank(v), i) for i, v in enumerate(values) if v is not None)
-    if better is None or len(candidates) < 2 or candidates[0][0] == candidates[1][0]:
-        return None
-    return candidates[0][1]
+    candidates = [(rank(v), i) for i, v in enumerate(values) if v is not None]
+    if better is None or len(candidates) < 2:
+        return set()
+    best_rank = min(r for r, _ in candidates)
+    if all(r == best_rank for r, _ in candidates):
+        return set()
+    return {i for r, i in candidates if r == best_rank}
 
 
 def format_value(val, width=10):
@@ -809,12 +812,12 @@ def print_row(
     better=None,
     texts=None,
 ):
-    """Print one labelled row of per-method values, the leading method in green."""
-    best = _best_index(values, better)
+    """Print one labelled row of per-method values, every leading method in green."""
+    best = _best_indices(values, better)
     print(f"  {label:>{label_width}}", end="")
     for i, value in enumerate(values):
         text = texts[i].rjust(col_width) if texts else formatter(value, col_width)
-        print(f"  {highlight(text) if i == best else text}", end="")
+        print(f"  {highlight(text) if i in best else text}", end="")
     print()
 
 
@@ -910,11 +913,13 @@ def _print_rectification_block(
     def get(m):
         return all_metrics[m]["rectification"][fit]
 
-    print_header(methods, col_width, label_width, f"{label} — detection")
+    print_header(
+        methods, col_width, label_width, f"{label} — detection (≤{LED_DISC_THRESHOLD_PX} board px)"
+    )
     _print_detection(methods, lambda m: get(m)["detection"], col_width, label_width)
 
     print()
-    print_header(methods, col_width, label_width, f"{label} — LED error")
+    print_header(methods, col_width, label_width, f"{label} — LED error (board px)")
     _print_value_accuracy(
         methods,
         lambda m: get(m)["leds_compared"],
@@ -928,7 +933,6 @@ def _print_rectification_block(
         lambda m: get(m)["error_px"],
         col_width,
         label_width,
-        label_fmt="{stat} (board px)",
     )
 
 
@@ -1012,7 +1016,7 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
     print("  ARUCO DETECTION")
     print(f"{'=' * 100}")
 
-    print_header(methods, col_width, label_width, "Detection")
+    print_header(methods, col_width, label_width, "Detection (visibility)")
     _print_detection(
         methods, lambda m: all_metrics[m]["aruco"]["detection"], col_width, label_width
     )
@@ -1035,7 +1039,7 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
         methods,
         col_width,
         label_width,
-        f"Detection (thres: {CORNER_IMAGE_SPACE_THRESHOLD_PX}px in image space)",
+        f"Detection (≤{CORNER_IMAGE_SPACE_THRESHOLD_PX} img px)",
     )
     _print_detection(
         methods, lambda m: all_metrics[m]["corners"]["detection_image"], col_width, label_width
@@ -1046,14 +1050,14 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
         methods,
         col_width,
         label_width,
-        f"Detection (thres: {LED_DISC_THRESHOLD_PX}px in board space)",
+        f"Detection (≤{LED_DISC_THRESHOLD_PX} board px)",
     )
     _print_detection(
         methods, lambda m: all_metrics[m]["corners"]["detection_board"], col_width, label_width
     )
 
     print()
-    print_header(methods, col_width, label_width, "Pixel error — image space")
+    print_header(methods, col_width, label_width, "Pixel error — img space")
     _print_error_stats(
         methods,
         lambda m: all_metrics[m]["corners"]["error_image_px"],
@@ -1072,21 +1076,21 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
 
     # ── Rectification (final homography) ─────────────────────────────────
     print(f"{'=' * 100}")
-    print("  RECTIFICATION (image → board homography)")
+    print("  RECTIFICATION")
     print(f"{'=' * 100}")
 
-    _print_rectification_block(methods, all_metrics, "fine", "Final fit", col_width, label_width)
-    print()
     _print_rectification_block(
-        methods, all_metrics, "rough", "Coarse (ArUco-only) fit", col_width, label_width
+        methods, all_metrics, "rough", "Coarse fit", col_width, label_width
     )
+    print()
+    _print_rectification_block(methods, all_metrics, "fine", "Final fit", col_width, label_width)
 
     # ── Counter reading ──────────────────────────────────────────────────
     print(f"{'=' * 100}")
     print("  COUNTER READING")
     print(f"{'=' * 100}")
 
-    print_header(methods, col_width, label_width, "Detection")
+    print_header(methods, col_width, label_width, "Detection (visibility)")
     _print_detection(
         methods, lambda m: all_metrics[m]["counter"]["detection"], col_width, label_width
     )
@@ -1107,7 +1111,7 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
     print("  RING READING")
     print(f"{'=' * 100}")
 
-    print_header(methods, col_width, label_width, "Detection")
+    print_header(methods, col_width, label_width, "Detection (visibility)")
     _print_detection(methods, lambda m: all_metrics[m]["ring"]["detection"], col_width, label_width)
 
     print()
@@ -1128,7 +1132,7 @@ def print_report(methods, all_metrics, col_width, label_width=LABEL_WIDTH_DEFAUL
     print("  OVERALL (timestamp)")
     print(f"{'=' * 100}")
 
-    print_header(methods, col_width, label_width, "Detection")
+    print_header(methods, col_width, label_width, "Detection (visibility)")
     _print_detection(
         methods, lambda m: all_metrics[m]["overall"]["detection"], col_width, label_width
     )
@@ -1193,7 +1197,7 @@ def print_timing(methods, timing, col_width, label_width=LABEL_WIDTH_DEFAULT):
 
         for i, step in enumerate([*STEP_ORDER, "total"]):
             if i > 0:
-                print(f"  {step.upper():-^{label_width}}")
+                print(f"    {step.upper():-^{label_width - 2}}")
             for stat in stat_keys:
                 print_row(
                     "  " + stat,


### PR DESCRIPTION
This PR cleans up a small formatting bug in the benchmark report, and clarifies the subsections by adding decision thresholds to the headers.

Fixes #16 

# Benchmark Report

```Ground truth: /home/jonas/datasets/rocsync_benchmark/ground_truth.json (663 frames)
Methods: benchmark_bugfixes, benchmark_ir_support
  benchmark_bugfixes: feature/benchmark_bugfixes@43c5f2d  2026-08-26T08:02:18+00:00  cv2 5.0.0  numpy 2.5.1  658 images, scores 658/663
  benchmark_ir_support: feature/benchmark_ir_support@35be235  2026-08-26T07:59:14+00:00  cv2 5.0.0  numpy 2.5.1  658 images, scores 658/663

WARNING: 5 ground truth frame(s) no column scores. If those inputs are gone, prune them:
  rocsync-annotate <data_dir> --prune
    eFAST/20260717_131635_zed_left.mp4: 5 frame(s)
```
---
  ARUCO DETECTION
---
                                                benchmark_bugfixes    benchmark_ir_support
    --------DETECTION (VISIBILITY)--------  ----------------------  ----------------------
                                        TP                     502                     502
                                        FP                       0                       0
                                        FN                      88                      88
                                        TN                      68                      68
                              TPR (Recall)                   85.1%                   85.1%
                                       FPR                    0.0%                    0.0%
                                 Precision                  100.0%                  100.0%
                                  F1 Score                   91.9%                   91.9%

                                                benchmark_bugfixes    benchmark_ir_support
    ----CORNER ERROR (PX, IMAGE SPACE)----  ----------------------  ----------------------
                                      mean                    1.89                    1.89
                                       std                    1.70                    1.70
                                       min                    0.00                    0.00
                                    median                    1.22                    1.22
                                       max                   16.69                   16.69
                                         n                     502                     502
---
  CORNER LED DETECTION
---
                                                benchmark_bugfixes    benchmark_ir_support
    --------DETECTION (≤3 IMG PX)---------  ----------------------  ----------------------
                                        TP                     828                     845
                                        FP                       0                      22
                                        FN                    1895                    1878
                                        TN                     185                     163
                              TPR (Recall)                   30.4%                   31.0%
                                       FPR                    0.0%                   11.9%
                                 Precision                  100.0%                   97.5%
                                  F1 Score                   46.6%                   47.1%

                                                benchmark_bugfixes    benchmark_ir_support
    -------DETECTION (≤8 BOARD PX)--------  ----------------------  ----------------------
                                        TP                     869                     886
                                        FP                       0                      22
                                        FN                    1854                    1837
                                        TN                     185                     163
                              TPR (Recall)                   31.9%                   32.5%
                                       FPR                    0.0%                   11.9%
                                 Precision                  100.0%                   97.6%
                                  F1 Score                   48.4%                   48.8%

                                                benchmark_bugfixes    benchmark_ir_support
    -------PIXEL ERROR — IMG SPACE--------  ----------------------  ----------------------
                                      mean                    0.55                   95.10
                                       std                    1.05                  257.19
                                       min                    0.00                    0.00
                                    median                    0.07                    0.11
                                       max                    9.21                  990.41
                                         n                     869                    1011

                                                benchmark_bugfixes    benchmark_ir_support
    ------PIXEL ERROR — BOARD SPACE-------  ----------------------  ----------------------
                                      mean                    0.43                   95.35
                                       std                    0.76                  257.89
                                       min                    0.00                    0.00
                                    median                    0.05                    0.07
                                       max                    6.05                  871.37
                                         n                     869                    1011
---
  RECTIFICATION
---
                                                benchmark_bugfixes    benchmark_ir_support
    -COARSE FIT — DETECTION (≤8 BOARD PX)-  ----------------------  ----------------------
                                        TP                     138                     138
                                        FP                       0                       0
                                        FN                     492                     492
                                        TN                      28                      28
                              TPR (Recall)                   21.9%                   21.9%
                                       FPR                    0.0%                    0.0%
                                 Precision                  100.0%                  100.0%
                                  F1 Score                   35.9%                   35.9%

                                                benchmark_bugfixes    benchmark_ir_support
    --COARSE FIT — LED ERROR (BOARD PX)---  ----------------------  ----------------------
                 LEDs within sample radius       27080/29075 (93%)       27080/29075 (93%)
                                      mean                    3.95                    3.95
                                       std                    3.13                    3.13
                                       min                    0.00                    0.00
                                    median                    3.31                    3.31
                                       max                   40.10                   40.10
                                         n                   29075                   29075

                                                benchmark_bugfixes    benchmark_ir_support
    -FINAL FIT — DETECTION (≤8 BOARD PX)--  ----------------------  ----------------------
                                        TP                     122                     146
                                        FP                       0                       0
                                        FN                     508                     484
                                        TN                      28                      28
                              TPR (Recall)                   19.4%                   23.2%
                                       FPR                    0.0%                    0.0%
                                 Precision                  100.0%                  100.0%
                                  F1 Score                   32.4%                   37.6%

                                                benchmark_bugfixes    benchmark_ir_support
    ---FINAL FIT — LED ERROR (BOARD PX)---  ----------------------  ----------------------
                 LEDs within sample radius      15085/15085 (100%)       18199/19460 (94%)
                                      mean                    0.09                   11.96
                                       std                    0.22                   66.13
                                       min                    0.00                    0.00
                                    median                    0.03                    0.04
                                       max                    2.40                  868.99
                                         n                   15085                   19460
---
  COUNTER READING
---
                                                benchmark_bugfixes    benchmark_ir_support
    --------DETECTION (VISIBILITY)--------  ----------------------  ----------------------
                                        TP                     122                     153
                                        FP                       0                       4
                                        FN                     499                     468
                                        TN                      37                      33
                              TPR (Recall)                   19.6%                   24.6%
                                       FPR                    0.0%                   10.8%
                                 Precision                  100.0%                   97.5%
                                  F1 Score                   32.8%                   39.3%

                                                benchmark_bugfixes    benchmark_ir_support
    ------------VALUE ACCURACY------------  ----------------------  ----------------------
                     counter.value correct          122/122 (100%)           142/153 (93%)
---
  RING READING
---
                                                benchmark_bugfixes    benchmark_ir_support
    --------DETECTION (VISIBILITY)--------  ----------------------  ----------------------
                                        TP                     121                     147
                                        FP                       1                       5
                                        FN                     491                     465
                                        TN                      45                      41
                              TPR (Recall)                   19.8%                   24.0%
                                       FPR                    2.2%                   10.9%
                                 Precision                   99.2%                   96.7%
                                  F1 Score                   33.0%                   38.5%

                                                benchmark_bugfixes    benchmark_ir_support
    ------------VALUE ACCURACY------------  ----------------------  ----------------------
                          ring.start exact           117/121 (97%)           139/147 (95%)
                         ring.start ±1 LED          121/121 (100%)           145/147 (99%)
                            ring.end exact           114/121 (94%)           136/147 (93%)
                           ring.end ±1 LED          121/121 (100%)           145/147 (99%)
---
  OVERALL (timestamp)
---
                                                benchmark_bugfixes    benchmark_ir_support
    --------DETECTION (VISIBILITY)--------  ----------------------  ----------------------
                                        TP                     108                     132
                                        FP                       1                       5
                                        FN                     436                     412
                                        TN                     113                     109
                              TPR (Recall)                   19.9%                   24.3%
                                       FPR                    0.9%                    4.4%
                                 Precision                   99.1%                   96.4%
                                  F1 Score                   33.1%                   38.8%

                                                benchmark_bugfixes    benchmark_ir_support
    ----------TIMESTAMP ACCURACY----------  ----------------------  ----------------------
                     timestamp exact match           100/108 (93%)           119/132 (90%)
                 mid-exposure within ±1 ms          108/108 (100%)           127/132 (96%)

                                                benchmark_bugfixes    benchmark_ir_support
    ---------TIMESTAMP ERROR (MS)---------  ----------------------  ----------------------
                        MID-EXPOSURE ERROR
                                      mean                    0.03                13141.74
                                       std                    0.12               130778.92
                                       min                    0.00                    0.00
                                    median                    0.00                    0.00
                                       max                    0.50              1502999.00
                            EXPOSURE ERROR
                                      mean                    0.08                    0.07
                                       std                    0.31                    0.28
                                       min                    0.00                    0.00
                                    median                    0.00                    0.00
                                       max                    2.00                    2.00
---
  CLOCK FIT (aggregated over videos)
---
                                                benchmark_bugfixes    benchmark_ir_support
    -----------MEASURED VIDEOS------------  ----------------------  ----------------------
                             videos scored                     0/5                     1/5
                                  unscored  benchmark_bugfixes: Insufficient number of timestamped frames. (5)
                                  unscored  benchmark_ir_support: Insufficient number of timestamped frames. (4)
          residual_threshold, loosest [ms]                       -                    2.00
        clock_rate error, mean |err| [ppm]                       -                    1.60
       clock_rate error, worst |err| [ppm]                       -                    1.60
         clock_offset_ms error, mean |err|                       -                    0.02
        clock_offset_ms error, worst |err|                       -                    0.02
         first/last_frame error, mean [ms]                       -                    0.22
        first/last_frame error, worst [ms]                       -                    0.22
         rmse_after, mean over videos [ms]                       -                    0.25
        rmse_after, worst over videos [ms]                       -                    0.25
               r2_after, worst over videos                       -                    1.00
         n_considered_frames (fit inliers)                       -                      19
          n_rejected_frames (fit outliers)                       -                       9
      n_dropped_frames (gaps in container)                       -                     210
             fit frames with an annotation                       -                      24
         rejected though decoded correctly                       -                       0
                    kept though misdecoded                       -                       0

                                                benchmark_bugfixes    benchmark_ir_support
    -RESIDUAL VS ANNOTATIONS (MS), POOLED-  ----------------------  ----------------------
                                      mean                       -                   -0.10
                                       std                       -                    0.30
                                       min                       -                   -0.75
                                    median                       -                   -0.15
                                       max                       -                    0.47
                                         n                       0                      36

                                                benchmark_bugfixes    benchmark_ir_support
    ------------RETIMED VIDEOS------------  ----------------------  ----------------------
                             videos scored                     3/3                     3/3
          residual_threshold, loosest [ms]                    2.00                    2.00
        clock_rate error, mean |err| [ppm]                    1.85                    1.85
       clock_rate error, worst |err| [ppm]                    4.06                    4.06
         clock_offset_ms error, mean |err|                    0.01                    0.01
        clock_offset_ms error, worst |err|                    0.03                    0.03
         first/last_frame error, mean [ms]                    0.09                    0.09
        first/last_frame error, worst [ms]                    0.19                    0.19
         rmse_after, mean over videos [ms]                    0.15                    0.15
        rmse_after, worst over videos [ms]                    0.23                    0.23
               r2_after, worst over videos                    1.00                    1.00
         n_considered_frames (fit inliers)                      77                      77
          n_rejected_frames (fit outliers)                       1                       1
      n_dropped_frames (gaps in container)                     221                     221
             fit frames with an annotation                      77                      77
         rejected though decoded correctly                       0                       0
                    kept though misdecoded                       7                       7

                                                benchmark_bugfixes    benchmark_ir_support
    -RESIDUAL VS ANNOTATIONS (MS), POOLED-  ----------------------  ----------------------
                                      mean                    0.06                    0.06
                                       std                    0.05                    0.05
                                       min                   -0.01                   -0.01
                                    median                    0.05                    0.05
                                       max                    0.19                    0.19
                                         n                     193                     193

---
  TIMING — ALL IMAGES (ms)
---
                                                benchmark_bugfixes    benchmark_ir_support
    -----------ARUCO_DETECTION------------  ----------------------  ----------------------
                                      mean                   39.95                   41.57
                                       std                   25.45                   26.18
                                       min                   10.93                   12.26
                                    median                   30.69                   29.94
                                       max                  152.22                  165.59
    -----------CORNER_DETECTION-----------
                                      mean                   23.28                   22.96
                                       std                    9.32                    8.11
                                       min                    7.39                    7.32
                                    median                   21.08                   21.56
                                       max                   77.90                   76.14
    ----------FINE_RECTIFICATION----------
                                      mean                    6.99                    5.39
                                       std                    3.80                    4.44
                                       min                    2.92                    0.42
                                    median                    4.22                    3.28
                                       max                   15.61                   14.91
    -----------COUNTER_READING------------
                                      mean                   19.27                   18.51
                                       std                    3.53                    4.26
                                       min                   14.18                   14.03
                                    median                   19.18                   17.84
                                       max                   33.53                   42.58
    -------------RING_READING-------------
                                      mean                   83.54                   82.78
                                       std                   14.20                   17.68
                                       min                   70.56                   71.16
                                    median                   78.91                   75.98
                                       max                  169.06                  183.19
    ----------------TOTAL-----------------
                                      mean                   71.73                   82.75
                                       std                   68.46                   74.80
                                       min                   10.96                   12.28
                                    median                   34.14                   35.50
                                       max                  312.59                  352.74
---
  TIMING — POSITIVE ANNOTATIONS (per-step) (ms)
---
                                                benchmark_bugfixes    benchmark_ir_support
    -----------ARUCO_DETECTION------------  ----------------------  ----------------------
                                      mean                   42.41                   41.58
                                       std                   25.16                   26.20
                                       min                   12.20                   12.26
                                    median                   31.71                   29.94
                                       max                  152.22                  165.59
    -----------CORNER_DETECTION-----------
                                      mean                   23.28                   23.02
                                       std                    9.32                    8.37
                                       min                    7.39                    7.32
                                    median                   21.08                   21.52
                                       max                   77.90                   76.14
    ----------FINE_RECTIFICATION----------
                                      mean                    6.99                    5.51
                                       std                    3.80                    4.42
                                       min                    2.92                    0.42
                                    median                    4.22                    3.33
                                       max                   15.61                   14.91
    -----------COUNTER_READING------------
                                      mean                   19.27                   18.62
                                       std                    3.53                    4.27
                                       min                   14.18                   14.03
                                    median                   19.18                   17.93
                                       max                   33.53                   42.58
    -------------RING_READING-------------
                                      mean                   83.57                   83.07
                                       std                   14.25                   17.89
                                       min                   70.56                   71.16
                                    median                   78.77                   76.20
                                       max                  169.06                  183.19
    ----------------TOTAL-----------------
                                      mean                   74.75                   85.94
                                       std                   70.55                   77.08
                                       min                   10.96                   12.28
                                    median                   34.38                   35.81
                                       max                  312.59                  352.74
---
  TIMING — NEGATIVE ANNOTATIONS (per-step) (ms)
---
                                                benchmark_bugfixes    benchmark_ir_support
    -----------ARUCO_DETECTION------------  ----------------------  ----------------------
                                      mean                   18.64                   40.84
                                       std                   16.34                   24.74
                                       min                   10.93                   14.88
                                    median                   14.51                   37.61
                                       max                  115.33                   78.98
    -----------CORNER_DETECTION-----------
                                      mean                       -                   22.21
                                       std                       -                    1.64
                                       min                       -                   19.96
                                    median                       -                   22.27
                                       max                       -                   25.71
    ----------FINE_RECTIFICATION----------
                                      mean                       -                    0.50
                                       std                       -                    0.03
                                       min                       -                    0.48
                                    median                       -                    0.48
                                       max                       -                    0.56
    -----------COUNTER_READING------------
                                      mean                       -                   14.54
                                       std                       -                    0.39
                                       min                       -                   14.27
                                    median                       -                   14.35
                                       max                       -                   15.21
    -------------RING_READING-------------
                                      mean                   80.05                   73.89
                                       std                    0.00                    1.31
                                       min                   80.05                   72.43
                                    median                   80.05                   73.73
                                       max                   80.05                   75.49
    ----------------TOTAL-----------------
                                      mean                   57.34                   67.55
                                       std                   55.25                   60.55
                                       min                   11.03                   12.59
                                    median                   32.91                   34.96
                                       max                  259.25                  266.25