### PR TITLE
Benchmark: Fit clock on both the original and retimed videos

### DIFF
--- a/sw/rocsync/benchmark/README.md
+++ b/sw/rocsync/benchmark/README.md
@@ -302,8 +302,10 @@ prediction about its frame *j* resolves back to frame *j + offset* of the record
 
 That is also why **the annotator walks the recordings and never a retimed clip**: the sources are
 untrimmed, so frames outside the current window stay annotatable, which is how a window grows.
-`rocsync-validate` and `rocsync-evaluate` do the opposite — a recording with a retimed clip beside
-it is skipped in favour of it, so the same footage is never benchmarked twice.
+`rocsync-validate` and `rocsync-evaluate` do the opposite for per-frame metrics — a recording with
+a retimed clip beside it is skipped in favour of it, so the same footage is never benchmarked
+twice. Its clock is still fitted, though: the clip's decoded frames stand in for the recording's,
+so the recording gets its own clock fit without being decoded a second time.
 
 ### Re-running
 
@@ -333,9 +335,17 @@ Results JSON contains a `config` section and an `images` section with per-frame 
 Every video additionally gets its clock fitted, by the same code a `rocsync` run uses, and a
 `videos` section records the resulting `VideoStatistics` — clock rate and offset, R²/RMSE
 before and after outlier rejection, frame period, dropouts and exposure. A video whose
-timeline could not be fitted carries an `error` instead of the fit. Each frame of a video
-gains its presentation timestamp as `pts_ms` and, once fitted, a `fit` of
-`{"residual_ms", "inlier"}`, so the per-frame outcome stays next to the frame it belongs to.
+timeline could not be fitted carries an `error` instead of the fit. Each video record also
+carries a `frames` table keyed like the ground truth's `images`, giving each of its frames a
+`pts_ms` and, once fitted, `residual_ms` and `inlier` — a frame's outcome stays with the fit
+that produced it rather than with the frame, since a recording and a retimed clip cut from it
+each fit a different clock over the same frames.
+
+A recording that has a retimed clip beside it is not decoded again: the clip is a stream copy,
+so its decoded frames stand in for the recording's, and its board times are re-fitted against
+the recording's own presentation timestamps to derive the recording's clock. Such a video
+record carries `derived_from` naming the clip and `timeline_windowed: true`, since the fit
+only covers the clip's window rather than the whole file.
 
 Unlike a real run, which analyzes roughly one frame per second, every frame that decoded
 feeds the fit: the benchmark has already paid to decode them all, and using all of them keeps
@@ -375,7 +385,8 @@ Metrics are computed per pipeline step:
   measured and retimed timelines are summarized separately, because a measured one also
   carries the camera's own timestamp error. Fit errors are the mean and the worst over the
   group's videos, frame counters their totals, residuals pooled over every frame the group
-  scored. A recording whose retimed clip the run scored is not reported separately
+  scored. A recording behind a retimed clip is decoded once, through the clip, but reported in
+  the measured group from its own derived fit
 
 Corner positions are compared against the annotated coordinates. Board space is derived by mapping
 both sides through the annotated homography, which normalises the threshold to LED sample radii —
@@ -410,28 +421,37 @@ every clock fit, the reference included. Annotations are unaffected: record what
 and the scoring sorts out what is decodable.
 
 The clock-fit block reads the reference out of the ground truth and never re-fits it. Read a
-sync error against the `reference tolerance` on the same block: a 0.5 ms error against a
-synthesized timeline is a real measurement, while against a measured one it is inside the
-camera's own noise. Its rows:
+fit error against `residual_threshold, loosest [ms]` on the same block: a 0.5 ms error against
+a synthesized timeline is a real measurement, while against a measured one it is inside the
+camera's own noise. Its rows, one block per group (measured videos, retimed videos):
 
 | Row | Meaning |
 | --- | --- |
-| `timeline` | `measured` for a recording, `synthesized` for a [retimed clip](#retimed-videos) |
-| `reference tolerance [ms]` | how far an annotation may sit from the reference, which is what makes those two comparable |
-| `clock rate error [ppm]` | fitted rate minus reference rate; the raw difference is ~1e-5 and unreadable otherwise |
-| `clock offset error [ms]` | fitted board time at `pts == 0` minus the reference's |
-| `sync error, first/last/worst [ms]` | how far the two clocks disagree at either end of the annotated span |
-| `outliers rejected in error` | frames the fit threw out whose decode the annotation confirms |
-| `misdecodes kept as inliers` | frames the fit kept whose decode the annotation contradicts |
-| `residual vs annotations` | fitted board time minus annotated board time, per frame |
+| `residual_threshold, loosest [ms]` | the loosest per-video tolerance in the group, which is what makes fit errors across it comparable |
+| `clock_rate error [ppm]` | fitted rate minus reference rate, mean and worst \|video\| |
+| `clock_offset_ms error` | fitted board time at `pts == 0` minus the reference's, mean and worst \|video\| |
+| `first/last_frame error [ms]` | how far the two clocks disagree at either end of the annotated span |
+| `rmse_after`, `r2_after` | the fit's own diagnostics against its own decoded frames |
+| `n_considered_frames` / `n_rejected_frames` | fit inliers and outliers, summed over the group |
+| `n_dropped_frames` | container gaps the fit found, summed over the group |
+| `fit frames with an annotation` | frames the fit and the ground truth both cover |
+| `rejected though decoded correctly` / `kept though misdecoded` | where the fit's own outlier rejection disagrees with the annotation |
 
-Read `sync error` first. Rate and offset trade off against each other — they cancel at
-`pts == 0` and diverge everywhere else — so either one alone can look bad while the clock is
-fine, or look fine while the clock is not. The sync error is what actually lands on a frame.
+Below the table, `Residual vs annotations` pools the fitted board time minus the annotated one
+over every frame the group scored — the per-frame error a caller of that clock actually sees.
+
+Read `first/last_frame error` first. Rate and offset trade off against each other — they cancel
+at `pts == 0` and diverge everywhere else — so either one alone can look bad while the clock is
+fine, or look fine while the clock is not. The frame error is what actually lands on a frame.
 
 Unlike the position errors above, this block does not favour whichever checkout pre-filled
 the annotations: the reference is fitted over annotated *values*, not copied from a pipeline's
 output. A decoding bias present in both annotations and predictions still cancels.
+
+A recording's derived fit only covers the window its retimed clip spans, while its reference
+clock is fitted over every annotation on the recording. If an annotation sits outside that
+window, its `first/last_frame error` reads as a small extrapolation rather than a measurement
+inside the fit.
 
 ## Comparing branches
 

--- a/sw/rocsync/benchmark/evaluate.py
+++ b/sw/rocsync/benchmark/evaluate.py
@@ -117,12 +117,26 @@ def resolve_retimed_keys(benchmark, retimed):
     A retimed clip carries no annotations of its own, so a prediction about its frame
     j is a prediction about frame j + offset of the recording it was cut from. Doing
     this once at load leaves every per-frame metric comparing keys as it always has.
-    The `videos` section needs no such move: both sides key it by the retimed clip.
+    Each video's own `frames` table is remapped the same way; a table already keyed by
+    annotation keys, like a derived recording's, passes through unchanged.
     """
     if not retimed:
         return benchmark
     images = {source_key(key, retimed): value for key, value in benchmark["images"].items()}
-    return {**benchmark, "images": images}
+    result = {**benchmark, "images": images}
+    if benchmark.get("videos"):
+        result["videos"] = {
+            path: {
+                **record,
+                "frames": {
+                    source_key(key, retimed): frame for key, frame in record["frames"].items()
+                },
+            }
+            if "frames" in record
+            else record
+            for path, record in benchmark["videos"].items()
+        }
+    return result
 
 
 # ── Geometry helpers ─────────────────────────────────────────────────────────
@@ -555,19 +569,10 @@ def compute_clock_metrics(benchmark, gt) -> dict[str, dict]:
             for rel_path, reference in references.items()
         }
 
-    # A recording whose retimed clip this run scored is not separately unscored
-    shadowed = {
-        reference["source"]
-        for path, reference in references.items()
-        if reference.get("source") and path in predictions
-    }
-
     gt_images = gt["images"]
     bm_images = benchmark["images"]
     metrics: dict[str, dict] = {}
     for rel_path, reference in references.items():
-        if rel_path in shadowed:
-            continue
         pred = predictions.get(rel_path)
         if pred is None:
             metrics[rel_path] = described(reference, status="not in this run")
@@ -578,6 +583,7 @@ def compute_clock_metrics(benchmark, gt) -> dict[str, dict]:
 
         ref = ReferenceClock.from_dict(reference)
         rate, offset = pred["clock_rate"], pred["clock_offset_ms"]
+        pred_frames = pred.get("frames") or {}
 
         def predict(pts, rate=rate, offset=offset):
             return rate * pts + offset
@@ -595,23 +601,23 @@ def compute_clock_metrics(benchmark, gt) -> dict[str, dict]:
             if index is None or path != annotated_path:
                 continue
             prediction = bm_images.get(key)
-            if prediction is None:
+            frame = pred_frames.get(key)
+            if prediction is None or frame is None:
                 continue
 
             board = _board_for_gt(annotation)
             gt_ts = reconstruct_timestamp(annotation, board) if board is not None else None
-            pts = prediction.get("pts_ms")
+            pts = frame.get("pts_ms")
             if gt_ts is not None and pts is not None:
                 residuals.append(predict(pts) - gt_ts[0])
 
-            fit = prediction.get("fit")
-            if fit is None or gt_ts is None:
+            if "inlier" not in frame or gt_ts is None:
                 continue
             n_checked_frames += 1
             decoded_correctly = reconstruct_timestamp(prediction, board) == gt_ts
-            if decoded_correctly and not fit["inlier"]:
+            if decoded_correctly and not frame["inlier"]:
                 rejected_but_correct += 1
-            elif not decoded_correctly and fit["inlier"]:
+            elif not decoded_correctly and frame["inlier"]:
                 considered_but_misdecoded += 1
 
         metrics[rel_path] = described(

--- a/sw/rocsync/benchmark/validate.py
+++ b/sw/rocsync/benchmark/validate.py
@@ -193,12 +193,64 @@ def run_benchmark(frames, ground_truth=None, debug_dir=None):
     return results
 
 
-def fit_videos(frames, results):
-    """Fit a clock per video and fold the per-frame outcome back into `results`.
+def _container_fps(path):
+    """Nominal frame rate the container reports."""
+    cap = cv2.VideoCapture(str(path), cv2.CAP_FFMPEG)
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    cap.release()
+    return fps
+
+
+def _fit_record(rel_path, timestamps, frame_times, fps, frame_period_ms, timeline_windowed=False):
+    """Fit one video's clock, returning its summary plus a per-frame table keyed like `images`.
+
+    A frame's pts is its own whether or not the fit succeeds, so `frames` is built first and
+    the fit's own residual/inlier verdict folded in afterward. Kept on the video record rather
+    than in `results`, because a retimed clip and the recording it was cut from can each carry
+    a different fit over the same frame -- one field per frame per fit, not two fields on one.
+    """
+    frames = {
+        frame_key(rel_path, index): {"pts_ms": pts_ms} for index, pts_ms in frame_times.items()
+    }
+    try:
+        statistics, _, considered, rejected, _ = summarize_timeline(
+            timestamps,
+            frame_times,
+            len(frame_times),
+            fps,
+            timeline_windowed=timeline_windowed,
+            frame_period_ms=frame_period_ms,
+        )
+    except ValueError as e:
+        print(f"  WARNING: no clock for {rel_path}: {e}", file=sys.stderr)
+        return {
+            "n_frames": len(frame_times),
+            "n_timestamped_frames": len(timestamps),
+            "error": str(e),
+            "frames": frames,
+        }
+
+    for index, (*_, residual) in {**considered, **rejected}.items():
+        frames[frame_key(rel_path, index)].update(
+            residual_ms=float(residual), inlier=index in considered
+        )
+
+    record = statistics.to_dict()
+    # The per-frame residuals now live in this record's own `frames` table
+    del record["considered_timestamps"], record["rejected_timestamps"]
+    return {**record, "n_timestamped_frames": len(timestamps), "error": None, "frames": frames}
+
+
+def fit_videos(frames, results, data_dir, ground_truth=None):
+    """Fit a clock per video, plus a derived one for each recording behind a retimed clip.
 
     Runs the production summarization over every frame that decoded, rather than the
     one-per-second sample a real run takes: the benchmark has already paid to decode
     them all, and using all of them keeps fit quality separate from sampling policy.
+
+    A retimed clip is a stream copy, so its decoded frame j is the recording's frame
+    j + offset, pixel for pixel. Re-fitting those same decodes against the recording's own
+    timestamps reports the recording's clock too, without decoding it a second time.
     """
     by_path = defaultdict(list)
     for ref in frames:
@@ -206,57 +258,51 @@ def fit_videos(frames, results):
             by_path[ref.path].append(ref)
 
     videos = {}
+    decoded = {}
+    clip_frame_times = {}
     for path in sorted(by_path):
         refs = by_path[path]
         rel_path, _ = parse_frame_key(refs[0].key)
         frame_times = dict(enumerate(frame_pts(path)))
-
-        cap = cv2.VideoCapture(str(path), cv2.CAP_FFMPEG)
-        fps = cap.get(cv2.CAP_PROP_FPS)
-        cap.release()
-
-        # A frame's presentation timestamp is its own, whether or not the fit succeeds
-        for ref in refs:
-            if ref.key in results and ref.index in frame_times:
-                results[ref.key]["pts_ms"] = frame_times[ref.index]
-
         timestamps = {
             ref.index: tuple(results[ref.key]["timestamp"])
             for ref in refs
             if results.get(ref.key, {}).get("timestamp") is not None
         }
+        decoded[rel_path] = timestamps
+        clip_frame_times[rel_path] = frame_times
+        videos[rel_path] = _fit_record(
+            rel_path, timestamps, frame_times, _container_fps(path), source_frame_period_ms(path)
+        )
 
-        try:
-            statistics, _, considered, rejected, _ = summarize_timeline(
-                timestamps,
-                frame_times,
-                len(frame_times),
-                fps,
-                frame_period_ms=source_frame_period_ms(path),
-            )
-        except ValueError as e:
-            videos[rel_path] = {
-                "n_frames": len(frame_times),
-                "n_timestamped_frames": len(timestamps),
-                "error": str(e),
-            }
-            print(f"  WARNING: no clock for {rel_path}: {e}", file=sys.stderr)
+    for clip in retimed_videos(ground_truth or {}).values():
+        if clip.path not in decoded or clip.source in videos:
+            continue  # nothing decoded for the clip, or the recording was benchmarked itself
+        source_path = data_dir / clip.source
+        if not source_path.is_file():
             continue
+        source_pts = dict(enumerate(frame_pts(source_path)))
+        # Every clip frame counts, not just the ones that decoded a timestamp, so a
+        # misdecode does not masquerade as a dropped frame in the recording's own gaps
+        window = {
+            index + clip.frame_offset: source_pts[index + clip.frame_offset]
+            for index in clip_frame_times[clip.path]
+            if index + clip.frame_offset in source_pts
+        }
+        timestamps = {index + clip.frame_offset: ts for index, ts in decoded[clip.path].items()}
+        videos[clip.source] = {
+            **_fit_record(
+                clip.source,
+                timestamps,
+                window,
+                _container_fps(source_path),
+                source_frame_period_ms(source_path),
+                timeline_windowed=True,
+            ),
+            "derived_from": clip.path,
+        }
 
-        for index, (*_, residual) in {**considered, **rejected}.items():
-            key = frame_key(rel_path, index)
-            if key in results:
-                results[key]["fit"] = {
-                    "residual_ms": float(residual),
-                    "inlier": index in considered,
-                }
-
-        record = statistics.to_dict()
-        # The per-frame residuals now live next to the frames they belong to
-        del record["considered_timestamps"], record["rejected_timestamps"]
-        videos[rel_path] = {**record, "n_timestamped_frames": len(timestamps), "error": None}
-
-    return videos
+    return dict(sorted(videos.items()))
 
 
 def main():
@@ -312,13 +358,14 @@ def main():
     n_success = sum(1 for r in results.values() if r["success"])
     print(f"Detection rate: {n_success}/{len(results)} ({n_success / len(results):.1%})")
 
-    videos = fit_videos(frames, results)
+    videos = fit_videos(frames, results, data_dir, ground_truth)
     for rel_path, video in videos.items():
+        derived = f" (derived from {video['derived_from']})" if "derived_from" in video else ""
         if video["error"] is not None:
-            print(f"{rel_path}: no clock ({video['error']})")
+            print(f"{rel_path}{derived}: no clock ({video['error']})")
             continue
         print(
-            f"{rel_path}: {video['clock_rate']:.6f}x, "
+            f"{rel_path}{derived}: {video['clock_rate']:.6f}x, "
             f"offset {video['clock_offset_ms']:.1f} ms, "
             f"RMSE {video['rmse_after']:.2f} ms, "
             f"{video['n_considered_frames']}/{video['n_timestamped_frames']} inliers"

--- a/sw/tests/test_benchmark_timeline.py
+++ b/sw/tests/test_benchmark_timeline.py
@@ -62,15 +62,13 @@ def dataset(n=20, offset_error_ms=0.0, misdecoded=(), rejected=()):
 
     images = {}
     predictions = {}
+    frames = {}
     for i in range(n):
         key = frame_key(VIDEO, i)
         images[key] = as_annotation(starts[i])
         decoded = starts[i] + (37 if i in misdecoded else 0)
-        predictions[key] = {
-            **as_annotation(decoded),
-            "pts_ms": pts[i],
-            "fit": {"residual_ms": 0.0, "inlier": i not in rejected},
-        }
+        predictions[key] = as_annotation(decoded)
+        frames[key] = {"pts_ms": pts[i], "residual_ms": 0.0, "inlier": i not in rejected}
 
     ground_truth = {
         "images": images,
@@ -88,6 +86,7 @@ def dataset(n=20, offset_error_ms=0.0, misdecoded=(), rejected=()):
                 "n_rejected_frames": len(rejected),
                 "n_dropped_frames": 0,
                 "error": None,
+                "frames": frames,
             }
         },
     }
@@ -109,7 +108,16 @@ def retimed_dataset(**kwargs):
             "source_frame_offset": TRIMMED,
         }
     }
-    benchmark["videos"] = {RETIMED: benchmark["videos"][VIDEO]}
+    source_video = benchmark["videos"][VIDEO]
+    benchmark["videos"] = {
+        RETIMED: {
+            **source_video,
+            "frames": {
+                frame_key(RETIMED, index - TRIMMED): source_video["frames"][frame_key(VIDEO, index)]
+                for index in range(TRIMMED, len(source_video["frames"]))
+            },
+        }
+    }
     source_images = benchmark["images"]
     benchmark["images"] = {
         frame_key(RETIMED, index - TRIMMED): source_images[frame_key(VIDEO, index)]


### PR DESCRIPTION
Until now, the benchmark tools preferred to validate the rocsync pipeline on retimed videos, i.e. skipping the original video video when a retimed version exists. The motivation was that the retimed version abstracts from capture noise (in the frame timestamps) and thus focuses the evaluation on the pipeline. 

However, evaluating only on retimed videos may hide differences in robustness against capture noise. Thus, this PR enables the evaluation on both the original videos (with potentially noisy frame timestamps) and retimed videos. The rocsync detection and decoding is done (and evaluated) only once per frame, only the clock fitting is run separately.

The results on original and retimed videos are already reported in separate sections in the benchmark report.