### PR TITLE
Preprocess images with CLAHE for better contrast

### DIFF
--- a/sw/rocsync/vision.py
+++ b/sw/rocsync/vision.py
@@ -15,6 +15,9 @@ MIN_ARUCO_AREA_FRACTION = 0.002  # smallest marker area, as a fraction of the fr
 
 ARUCO_DICTIONARY = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_50)
 
+CLAHE_CLIP_LIMIT = 2.0
+CLAHE_TILE_GRID_SIZE = (8, 8)
+
 # Keys `rocsync.benchmark` expects to find in a stats dict, whether or not the frame decoded.
 _STATS_KEYS = (
     "aruco_id",
@@ -77,6 +80,7 @@ def _make_aruco_detector():
 
 blob_detector = _make_blob_detector()
 aruco_detector = _make_aruco_detector()
+clahe = cv2.createCLAHE(clipLimit=CLAHE_CLIP_LIMIT, tileGridSize=CLAHE_TILE_GRID_SIZE)
 
 
 def draw_polygon(points, image, color):
@@ -265,9 +269,13 @@ def find_corners_dots(mask, frame_number, board, debug_dir=None):
 
 
 def find_corners_aruco(mask, frame_number, debug_dir=None):
-    markers, marker_ids, _ = aruco_detector.detectMarkers(mask)
+    """Locate the board's ArUco marker, equalizing the image first so it survives
+    under- and over-exposure."""
+    gray = cv2.cvtColor(mask, cv2.COLOR_BGR2GRAY) if mask.ndim == 3 else mask
+    normalized = clahe.apply(gray)
+    markers, marker_ids, _ = aruco_detector.detectMarkers(normalized)
     if debug_dir:
-        debug_image = mask.copy()
+        debug_image = cv2.cvtColor(normalized, cv2.COLOR_GRAY2BGR)
         cv2.aruco.drawDetectedMarkers(debug_image, markers, marker_ids)
         cv2.imwrite(f"{debug_dir}/aruco_{frame_number}.png", debug_image)
 


### PR DESCRIPTION
This PR inserts CLAHE preprocessing before the ArUco detection to boost detection rates, especially on underexposed frames #1 #25 .

# Benchmark Report

```
Ground truth: /home/jonas/datasets/rocsync_benchmark/ground_truth.json (663 frames)
Methods: benchmark_latest, clahe
  benchmark_latest: feature/eval_clock_fit_on_original_and_retimed@a700636+dirty  2026-08-26T13:10:57+00:00  cv2 5.0.0  numpy 2.5.1  658 images, scores 658/663
  clahe: feature/clahe@7d6872f+dirty  2026-08-26T13:19:27+00:00  cv2 5.0.0  numpy 2.5.1  658 images, scores 658/663

WARNING: 5 ground truth frame(s) no column scores. If those inputs are gone, prune them:
  rocsync-annotate <data_dir> --prune
    eFAST/20260717_131635_zed_left.mp4: 5 frame(s)
```
---
  ARUCO DETECTION
---
                                              benchmark_latest               clahe
    --------DETECTION (VISIBILITY)--------  ------------------  ------------------
                                        TP                 502                 542
                                        FP                   0                   1
                                        FN                  88                  48
                                        TN                  68                  67
                              TPR (Recall)               85.1%               91.9%
                                       FPR                0.0%                1.5%
                                 Precision              100.0%               99.8%
                                  F1 Score               91.9%               95.7%

                                              benchmark_latest               clahe
    ----CORNER ERROR (PX, IMAGE SPACE)----  ------------------  ------------------
                                      mean                1.89                1.90
                                       std                1.70                1.76
                                       min                0.00                0.35
                                    median                1.22                1.24
                                       max               16.69               17.36
                                         n                 502                 541
---
  CORNER LED DETECTION
---
                                              benchmark_latest               clahe
    --------DETECTION (≤3 IMG PX)---------  ------------------  ------------------
                                        TP                 845                 997
                                        FP                  22                  22
                                        FN                1878                1726
                                        TN                 163                 163
                              TPR (Recall)               31.0%               36.6%
                                       FPR               11.9%               11.9%
                                 Precision               97.5%               97.8%
                                  F1 Score               47.1%               53.3%

                                              benchmark_latest               clahe
    -------DETECTION (≤8 BOARD PX)--------  ------------------  ------------------
                                        TP                 886                1042
                                        FP                  22                  22
                                        FN                1837                1681
                                        TN                 163                 163
                              TPR (Recall)               32.5%               38.3%
                                       FPR               11.9%               11.9%
                                 Precision               97.6%               97.9%
                                  F1 Score               48.8%               55.0%

                                              benchmark_latest               clahe
    -------PIXEL ERROR — IMG SPACE--------  ------------------  ------------------
                                      mean               95.10               82.57
                                       std              257.19              241.40
                                       min                0.00                0.00
                                    median                0.11                0.28
                                       max              990.41              990.41
                                         n                1011                1168

                                              benchmark_latest               clahe
    ------PIXEL ERROR — BOARD SPACE-------  ------------------  ------------------
                                      mean               95.35               82.81
                                       std              257.89              242.05
                                       min                0.00                0.00
                                    median                0.07                0.20
                                       max              871.37              871.37
                                         n                1011                1168
---
  RECTIFICATION
---
                                              benchmark_latest               clahe
    -COARSE FIT — DETECTION (≤8 BOARD PX)-  ------------------  ------------------
                                        TP                 138                 148
                                        FP                   0                   0
                                        FN                 492                 482
                                        TN                  28                  28
                              TPR (Recall)               21.9%               23.5%
                                       FPR                0.0%                0.0%
                                 Precision              100.0%              100.0%
                                  F1 Score               35.9%               38.0%

                                              benchmark_latest               clahe
    --COARSE FIT — LED ERROR (BOARD PX)---  ------------------  ------------------
                 LEDs within sample radius   27080/29075 (93%)   31555/34000 (93%)
                                      mean                3.95                4.12
                                       std                3.13                4.11
                                       min                0.00                0.01
                                    median                3.31                3.30
                                       max               40.10               64.02
                                         n               29075               34000

                                              benchmark_latest               clahe
    -FINAL FIT — DETECTION (≤8 BOARD PX)--  ------------------  ------------------
                                        TP                 146                 182
                                        FP                   0                   0
                                        FN                 484                 448
                                        TN                  28                  28
                              TPR (Recall)               23.2%               28.9%
                                       FPR                0.0%                0.0%
                                 Precision              100.0%              100.0%
                                  F1 Score               37.6%               44.8%

                                              benchmark_latest               clahe
    ---FINAL FIT — LED ERROR (BOARD PX)---  ------------------  ------------------
                 LEDs within sample radius   18199/19460 (94%)   22529/23790 (95%)
                                      mean               11.96                9.97
                                       std               66.13               59.96
                                       min                0.00                0.00
                                    median                0.04                0.10
                                       max              868.99              868.99
                                         n               19460               23790
---
  COUNTER READING
---
                                              benchmark_latest               clahe
    --------DETECTION (VISIBILITY)--------  ------------------  ------------------
                                        TP                 153                 189
                                        FP                   4                   4
                                        FN                 468                 432
                                        TN                  33                  33
                              TPR (Recall)               24.6%               30.4%
                                       FPR               10.8%               10.8%
                                 Precision               97.5%               97.9%
                                  F1 Score               39.3%               46.4%

                                              benchmark_latest               clahe
    ------------VALUE ACCURACY------------  ------------------  ------------------
                     counter.value correct       142/153 (93%)       178/189 (94%)
---
  RING READING
---
                                              benchmark_latest               clahe
    --------DETECTION (VISIBILITY)--------  ------------------  ------------------
                                        TP                 147                 183
                                        FP                   5                   5
                                        FN                 465                 429
                                        TN                  41                  41
                              TPR (Recall)               24.0%               29.9%
                                       FPR               10.9%               10.9%
                                 Precision               96.7%               97.3%
                                  F1 Score               38.5%               45.8%

                                              benchmark_latest               clahe
    ------------VALUE ACCURACY------------  ------------------  ------------------
                          ring.start exact       139/147 (95%)       174/183 (95%)
                         ring.start ±1 LED       145/147 (99%)       181/183 (99%)
                            ring.end exact       136/147 (93%)       171/183 (93%)
                           ring.end ±1 LED       145/147 (99%)       181/183 (99%)
---
  OVERALL (timestamp)
---
                                              benchmark_latest               clahe
    --------DETECTION (VISIBILITY)--------  ------------------  ------------------
                                        TP                 132                 165
                                        FP                   5                   5
                                        FN                 412                 379
                                        TN                 109                 109
                              TPR (Recall)               24.3%               30.3%
                                       FPR                4.4%                4.4%
                                 Precision               96.4%               97.1%
                                  F1 Score               38.8%               46.2%

                                              benchmark_latest               clahe
    ----------TIMESTAMP ACCURACY----------  ------------------  ------------------
                     timestamp exact match       119/132 (90%)       150/165 (91%)
                 mid-exposure within ±1 ms       127/132 (96%)       160/165 (97%)

                                              benchmark_latest               clahe
    ---------TIMESTAMP ERROR (MS)---------  ------------------  ------------------
                        MID-EXPOSURE ERROR
                                      mean            13141.74            10513.40
                                       std           130778.92           117090.28
                                       min                0.00                0.00
                                    median                0.00                0.00
                                       max          1502999.00          1502999.00
                            EXPOSURE ERROR
                                      mean                0.07                0.07
                                       std                0.28                0.27
                                       min                0.00                0.00
                                    median                0.00                0.00
                                       max                2.00                2.00
---
  CLOCK FIT (aggregated over videos)
---
                                              benchmark_latest               clahe
    -----------MEASURED VIDEOS------------  ------------------  ------------------
                             videos scored                 4/8                 4/8
                                  unscored  benchmark_latest: Insufficient number of timestamped frames. (4)
                                  unscored  clahe: Insufficient number of timestamped frames. (4)
          residual_threshold, loosest [ms]               11.14               11.14
        clock_rate error, mean |err| [ppm]                7.07               11.43
       clock_rate error, worst |err| [ppm]               21.65               21.65
         clock_offset_ms error, mean |err|                0.42                0.38
        clock_offset_ms error, worst |err|                1.22                1.22
         first/last_frame error, mean [ms]                0.68                0.85
        first/last_frame error, worst [ms]                1.22                1.22
         rmse_after, mean over videos [ms]                2.23                2.21
        rmse_after, worst over videos [ms]                2.97                2.97
               r2_after, worst over videos                1.00                1.00
         n_considered_frames (fit inliers)                  96                  98
          n_rejected_frames (fit outliers)                  10                  10
      n_dropped_frames (gaps in container)                 431                 431
             fit frames with an annotation                 101                 103
         rejected though decoded correctly                   0                   0
                    kept though misdecoded                   7                   8

                                              benchmark_latest               clahe
    -RESIDUAL VS ANNOTATIONS (MS), POOLED-  ------------------  ------------------
                                      mean               -0.14               -0.23
                                       std                2.39                2.41
                                       min               -6.32               -6.71
                                    median               -0.15               -0.22
                                       max                7.68                7.68
                                         n                 229                 229

                                              benchmark_latest               clahe
    ------------RETIMED VIDEOS------------  ------------------  ------------------
                             videos scored                 3/3                 3/3
          residual_threshold, loosest [ms]                2.00                2.00
        clock_rate error, mean |err| [ppm]                1.85                2.06
       clock_rate error, worst |err| [ppm]                4.06                4.70
         clock_offset_ms error, mean |err|                0.01                0.02
        clock_offset_ms error, worst |err|                0.03                0.03
         first/last_frame error, mean [ms]                0.09                0.10
        first/last_frame error, worst [ms]                0.19                0.21
         rmse_after, mean over videos [ms]                0.15                0.15
        rmse_after, worst over videos [ms]                0.23                0.23
               r2_after, worst over videos                1.00                1.00
         n_considered_frames (fit inliers)                  77                  79
          n_rejected_frames (fit outliers)                   1                   1
      n_dropped_frames (gaps in container)                 221                 221
             fit frames with an annotation                  77                  79
         rejected though decoded correctly                   0                   0
                    kept though misdecoded                   7                   8

                                              benchmark_latest               clahe
    -RESIDUAL VS ANNOTATIONS (MS), POOLED-  ------------------  ------------------
                                      mean                0.06                0.06
                                       std                0.05                0.06
                                       min               -0.01               -0.01
                                    median                0.05                0.05
                                       max                0.19                0.21
                                         n                 193                 193

---
  TIMING — ALL IMAGES (ms)
---
                                              benchmark_latest               clahe
    -----------ARUCO_DETECTION------------  ------------------  ------------------
                                      mean               24.16               28.22
                                       std               11.47               18.67
                                       min               12.20               10.52
                                    median               18.17               19.87
                                       max               90.60              177.47
    -----------CORNER_DETECTION-----------
                                      mean               15.92                9.63
                                       std                5.99                4.33
                                       min                6.61                3.20
                                    median               16.24                9.24
                                       max               38.63               36.99
    ----------FINE_RECTIFICATION----------
                                      mean                3.38                2.59
                                       std                1.99                2.13
                                       min                0.22                0.20
                                    median                3.09                1.65
                                       max                7.95                8.88
    -----------COUNTER_READING------------
                                      mean               13.62                8.54
                                       std                4.11                1.03
                                       min                8.42                7.18
                                    median               14.33                8.58
                                       max               26.15               15.00
    -------------RING_READING-------------
                                      mean               61.46               42.51
                                       std               15.60                1.06
                                       min               41.38               40.97
                                    median               72.08               42.34
                                       max               91.19               49.96
    ----------------TOTAL-----------------
                                      mean               55.50               51.46
                                       std               54.31               39.71
                                       min               12.36               10.86
                                    median               30.02               25.99
                                       max              212.77              258.65
---
  TIMING — POSITIVE ANNOTATIONS (per-step) (ms)
---
                                              benchmark_latest               clahe
    -----------ARUCO_DETECTION------------  ------------------  ------------------
                                      mean               24.11               28.26
                                       std               11.46               18.68
                                       min               12.20               10.52
                                    median               18.14               19.92
                                       max               90.60              177.47
    -----------CORNER_DETECTION-----------
                                      mean               15.51                9.67
                                       std                5.96                4.45
                                       min                6.61                3.20
                                    median               15.20                9.25
                                       max               38.63               36.99
    ----------FINE_RECTIFICATION----------
                                      mean                3.46                2.64
                                       std                1.96                2.12
                                       min                0.22                0.20
                                    median                3.16                1.66
                                       max                7.95                8.88
    -----------COUNTER_READING------------
                                      mean               13.60                8.54
                                       std                4.16                1.04
                                       min                8.42                7.18
                                    median               14.33                8.67
                                       max               26.15               15.00
    -------------RING_READING-------------
                                      mean               61.07               42.51
                                       std               15.69                1.07
                                       min               41.38               40.97
                                    median               72.08               42.35
                                       max               91.19               49.96
    ----------------TOTAL-----------------
                                      mean               56.60               53.99
                                       std               55.32               40.56
                                       min               12.36               10.86
                                    median               27.59               29.46
                                       max              212.77              258.65
---
  TIMING — NEGATIVE ANNOTATIONS (per-step) (ms)
---
                                              benchmark_latest               clahe
    -----------ARUCO_DETECTION------------  ------------------  ------------------
                                      mean               27.41               25.98
                                       std               11.63               17.62
                                       min               15.12               11.70
                                    median               26.77               18.66
                                       max               48.16               59.84
    -----------CORNER_DETECTION-----------
                                      mean               21.90                8.90
                                       std                1.28                0.72
                                       min               19.32                8.00
                                    median               21.98                8.60
                                       max               24.30               10.21
    ----------FINE_RECTIFICATION----------
                                      mean                0.44                0.22
                                       std                0.01                0.01
                                       min                0.42                0.21
                                    median                0.44                0.22
                                       max                0.45                0.24
    -----------COUNTER_READING------------
                                      mean               14.41                8.47
                                       std                0.12                0.07
                                       min               14.27                8.39
                                    median               14.38                8.46
                                       max               14.59                8.55
    -------------RING_READING-------------
                                      mean               73.49               42.27
                                       std                2.96                0.66
                                       min               71.77               41.63
                                    median               72.04               41.83
                                       max               79.39               43.17
    ----------------TOTAL-----------------
                                      mean               50.22               39.38
                                       std               48.86               32.79
                                       min               14.06               11.72
                                    median               33.72               20.78
                                       max              200.62              142.56
